### PR TITLE
FEAT : Boundary processes — subduction, rifting, volcanism source ter…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5425,6 +5425,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = "1.0"
 image = { version = "0.25", default-features = false, features = ["png"] }
 bevy_egui = "0.39"
 crossbeam-channel = "0.5"
+tracing = "0.1"
 noise = "0.9"
 bevy = { version = "0.18.1", default-features = false, features = [
     "bevy_asset",

--- a/crates/ymir-core/src/tectonics/boundaries.rs
+++ b/crates/ymir-core/src/tectonics/boundaries.rs
@@ -1,0 +1,467 @@
+//! Boundary processes: subduction, rifting, and volcanism source terms.
+//!
+//! Detects plate boundaries from `plate_ids` and velocity fields, classifies
+//! them (subduction, rift, collision), and computes a source/sink rate Q(x,y)
+//! that is added to the crustal thickness advection equation:
+//!
+//!   S_new = S - dt * div(S*v) + dt * Q(x,y)
+
+use super::plates::{Plate, PlateType};
+use super::solver::field::Field2D;
+use super::solver::grid::StaggeredGrid;
+
+// ── Boundary classification ──────────────────────────────────────────────
+
+/// Type of plate boundary at a given cell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BoundaryType {
+    /// Oceanic plate being consumed under continental plate (or vice-versa view).
+    Subduction,
+    /// Two continental plates colliding.
+    ContinentalCollision,
+    /// Oceanic-oceanic convergence. One subducts, island arc volcanism.
+    OceanicSubduction,
+    /// Plates diverging — new oceanic crust created in the gap.
+    Rift,
+    /// No boundary (cell is interior to a plate).
+    None,
+}
+
+// ── Configuration ────────────────────────────────────────────────────────
+
+/// Configuration for boundary source/sink terms.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BoundaryConfig {
+    /// Whether boundary processes are enabled.
+    pub enabled: bool,
+    /// Subduction consumption rate (dimensionless, multiplied by convergence
+    /// velocity). Range: 0.0-2.0, default: 0.5
+    pub subduction_rate: f64,
+    /// Volcanic arc production rate — fraction of subducted material that
+    /// resurfaces as continental volcanism. Range: 0.0-1.0, default: 0.15
+    pub volcanic_arc_rate: f64,
+    /// Oceanic spreading rate — how fast new crust is created at divergent
+    /// boundaries. Range: 0.0-2.0, default: 0.3
+    pub spreading_rate: f64,
+    /// Crustal thickness below which rifting creates new oceanic crust
+    /// instead of just thinning. Default: 0.4
+    pub rift_thickness_threshold: f64,
+    /// Minor volcanism rate at continental collision zones.
+    /// Range: 0.0-0.5, default: 0.05
+    pub collision_volcanism_rate: f64,
+    /// Volcanism rate at rift zones in thick crust.
+    /// Range: 0.0-0.5, default: 0.02
+    pub rift_volcanism_rate: f64,
+    /// Gaussian smoothing sigma (in grid cells) applied to the source field.
+    /// 0.0 = no smoothing. Default: 2.0
+    pub source_smoothing_sigma: f64,
+}
+
+impl Default for BoundaryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            subduction_rate: 0.5,
+            volcanic_arc_rate: 0.15,
+            spreading_rate: 0.3,
+            rift_thickness_threshold: 0.4,
+            collision_volcanism_rate: 0.05,
+            rift_volcanism_rate: 0.02,
+            source_smoothing_sigma: 2.0,
+        }
+    }
+}
+
+// ── Boundary field ───────────────────────────────────────────────────────
+
+/// Boundary classification and source terms for each cell.
+pub struct BoundaryField {
+    /// Boundary type at each cell (N*N).
+    pub boundary_type: Vec<BoundaryType>,
+    /// Source/sink rate Q at each cell. Positive = crust creation,
+    /// negative = crust consumption.
+    pub source_rate: Field2D,
+    pub n: usize,
+}
+
+// ── Core computation ─────────────────────────────────────────────────────
+
+/// Detect boundaries and compute source/sink rates.
+pub fn compute_boundary_sources(
+    grid: &StaggeredGrid,
+    plate_ids: &[usize],
+    plates: &[Plate],
+    config: &BoundaryConfig,
+) -> BoundaryField {
+    let n = grid.n;
+    let idx = &grid.idx;
+    let inv_dx = 1.0 / grid.dx;
+
+    let mut boundary_type = vec![BoundaryType::None; n * n];
+    let mut source_rate = Field2D::new(n);
+
+    for j in 0..n {
+        for i in 0..n {
+            let k = j * n + i;
+            let my_plate = plate_ids[k];
+            let my_type = plates[my_plate].plate_type;
+
+            let neighbors = [
+                (idx.next(i), j),
+                (idx.prev(i), j),
+                (i, idx.next(j)),
+                (i, idx.prev(j)),
+            ];
+
+            let mut is_boundary = false;
+            let mut convergence_sum = 0.0_f64;
+            let mut neighbor_plate_type = my_type;
+
+            for &(ni, nj) in &neighbors {
+                let nk = nj * n + ni;
+                let other_plate = plate_ids[nk];
+
+                if other_plate != my_plate {
+                    is_boundary = true;
+                    neighbor_plate_type = plates[other_plate].plate_type;
+
+                    // Normal direction from (i,j) to (ni,nj), handling wrapping
+                    let nx = if ni == idx.next(i) && ni < i {
+                        1.0 // wrapped right
+                    } else if ni == idx.prev(i) && ni > i {
+                        -1.0 // wrapped left
+                    } else {
+                        (ni as f64 - i as f64).signum()
+                    };
+                    let ny = if nj == idx.next(j) && nj < j {
+                        1.0 // wrapped down
+                    } else if nj == idx.prev(j) && nj > j {
+                        -1.0 // wrapped up
+                    } else {
+                        (nj as f64 - j as f64).signum()
+                    };
+
+                    // Velocity at cell center (average of staggered faces)
+                    let vx_here =
+                        0.5 * (grid.vx.get(i, j) + grid.vx.get(idx.next(i), j));
+                    let vy_here =
+                        0.5 * (grid.vy.get(i, j) + grid.vy.get(i, idx.next(j)));
+
+                    let vx_there =
+                        0.5 * (grid.vx.get(ni, nj) + grid.vx.get(idx.next(ni), nj));
+                    let vy_there =
+                        0.5 * (grid.vy.get(ni, nj) + grid.vy.get(ni, idx.next(nj)));
+
+                    // Relative velocity in normal direction
+                    // Positive = diverging, Negative = converging
+                    let v_rel =
+                        (vx_there - vx_here) * nx + (vy_there - vy_here) * ny;
+                    convergence_sum += v_rel;
+                }
+            }
+
+            if !is_boundary {
+                continue;
+            }
+
+            let is_converging = convergence_sum < 0.0;
+            let convergence_rate = convergence_sum.abs() * inv_dx;
+
+            let btype = if is_converging {
+                match (my_type, neighbor_plate_type) {
+                    (PlateType::Oceanic, PlateType::Continental)
+                    | (PlateType::Continental, PlateType::Oceanic) => {
+                        BoundaryType::Subduction
+                    }
+                    (PlateType::Continental, PlateType::Continental) => {
+                        BoundaryType::ContinentalCollision
+                    }
+                    (PlateType::Oceanic, PlateType::Oceanic) => {
+                        BoundaryType::OceanicSubduction
+                    }
+                }
+            } else {
+                BoundaryType::Rift
+            };
+
+            boundary_type[k] = btype;
+
+            let q = match btype {
+                BoundaryType::Subduction => {
+                    if my_type == PlateType::Oceanic {
+                        -config.subduction_rate * convergence_rate
+                    } else {
+                        config.volcanic_arc_rate * convergence_rate
+                    }
+                }
+                BoundaryType::OceanicSubduction => {
+                    let my_s = grid.s.get(i, j);
+                    let s_ocean_ref = 0.2;
+                    if my_s <= s_ocean_ref * 1.1 {
+                        -config.subduction_rate * convergence_rate * 0.5
+                    } else {
+                        config.volcanic_arc_rate * convergence_rate * 0.3
+                    }
+                }
+                BoundaryType::ContinentalCollision => {
+                    config.collision_volcanism_rate * convergence_rate
+                }
+                BoundaryType::Rift => {
+                    let my_s = grid.s.get(i, j);
+                    let divergence_rate = convergence_sum.abs() * inv_dx;
+                    if my_s < config.rift_thickness_threshold {
+                        config.spreading_rate * divergence_rate
+                    } else {
+                        config.rift_volcanism_rate * divergence_rate
+                    }
+                }
+                BoundaryType::None => 0.0,
+            };
+
+            source_rate.set(i, j, q);
+        }
+    }
+
+    BoundaryField { boundary_type, source_rate, n }
+}
+
+/// Compute boundary sources directly into a pre-allocated Field2D buffer.
+pub fn compute_boundary_sources_into(
+    grid: &StaggeredGrid,
+    plate_ids: &[usize],
+    plates: &[Plate],
+    config: &BoundaryConfig,
+    target: &mut Field2D,
+) {
+    let result = compute_boundary_sources(grid, plate_ids, plates, config);
+    target.data_mut().copy_from_slice(result.source_rate.data());
+}
+
+// ── Gaussian blur for f64 Field2D ────────────────────────────────────────
+
+/// Separable Gaussian blur on a Field2D with periodic (toroidal) wrapping.
+/// Sigma is in grid cells. Kernel radius = ceil(3 * sigma).
+pub fn gaussian_blur_f64(field: &Field2D, sigma: f64) -> Field2D {
+    let n = field.n();
+    if sigma <= 0.0 {
+        let mut out = Field2D::new(n);
+        out.data_mut().copy_from_slice(field.data());
+        return out;
+    }
+
+    let radius = (3.0 * sigma).ceil() as usize;
+    let kernel_size = 2 * radius + 1;
+
+    // Build normalized 1D Gaussian kernel
+    let mut kernel: Vec<f64> = (0..kernel_size)
+        .map(|i| {
+            let x = i as f64 - radius as f64;
+            (-x * x / (2.0 * sigma * sigma)).exp()
+        })
+        .collect();
+    let sum: f64 = kernel.iter().sum();
+    for k in kernel.iter_mut() {
+        *k /= sum;
+    }
+
+    // Horizontal pass
+    let mut temp = Field2D::new(n);
+    for j in 0..n {
+        for i in 0..n {
+            let mut val = 0.0_f64;
+            for (ki, &w) in kernel.iter().enumerate() {
+                let si = (i as i32 + ki as i32 - radius as i32)
+                    .rem_euclid(n as i32) as usize;
+                val += field.get(si, j) * w;
+            }
+            temp.set(i, j, val);
+        }
+    }
+
+    // Vertical pass
+    let mut result = Field2D::new(n);
+    for j in 0..n {
+        for i in 0..n {
+            let mut val = 0.0_f64;
+            for (ki, &w) in kernel.iter().enumerate() {
+                let sj = (j as i32 + ki as i32 - radius as i32)
+                    .rem_euclid(n as i32) as usize;
+                val += temp.get(i, sj) * w;
+            }
+            result.set(i, j, val);
+        }
+    }
+
+    result
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tectonics::solver::grid::StaggeredGrid;
+
+    fn make_two_plate_setup(n: usize) -> (StaggeredGrid, Vec<usize>, Vec<Plate>) {
+        let dx = 1.0 / n as f64;
+        let grid = StaggeredGrid::new(n, dx);
+
+        // Left half = plate 0 (oceanic), right half = plate 1 (continental)
+        let mut plate_ids = vec![0usize; n * n];
+        for j in 0..n {
+            for i in n / 2..n {
+                plate_ids[j * n + i] = 1;
+            }
+        }
+
+        let plates = vec![
+            Plate {
+                id: 0,
+                plate_type: PlateType::Oceanic,
+                velocity: (0.5, 0.0),
+                seed_x: (n / 4) as f32,
+                seed_y: (n / 2) as f32,
+            },
+            Plate {
+                id: 1,
+                plate_type: PlateType::Continental,
+                velocity: (-0.5, 0.0),
+                seed_x: (3 * n / 4) as f32,
+                seed_y: (n / 2) as f32,
+            },
+        ];
+
+        (grid, plate_ids, plates)
+    }
+
+    #[test]
+    fn subduction_detected_at_convergent_ocean_continent() {
+        let n = 32;
+        let (mut grid, plate_ids, plates) = make_two_plate_setup(n);
+
+        for j in 0..n {
+            for i in 0..n {
+                let vx = if i < n / 2 { 0.5 } else { -0.5 };
+                grid.vx.set(i, j, vx);
+            }
+        }
+        for j in 0..n {
+            for i in 0..n {
+                grid.s.set(i, j, if i < n / 2 { 0.2 } else { 1.0 });
+            }
+        }
+
+        let config = BoundaryConfig::default();
+        let result = compute_boundary_sources(&grid, &plate_ids, &plates, &config);
+
+        let oceanic_boundary = result.source_rate.get(n / 2 - 1, n / 2);
+        assert!(
+            oceanic_boundary < 0.0,
+            "Oceanic side should be a sink: Q = {oceanic_boundary}"
+        );
+
+        let continental_boundary = result.source_rate.get(n / 2, n / 2);
+        assert!(
+            continental_boundary > 0.0,
+            "Continental side should be a source: Q = {continental_boundary}"
+        );
+    }
+
+    #[test]
+    fn rift_detected_at_divergent_boundary() {
+        let n = 32;
+        let (mut grid, plate_ids, plates) = make_two_plate_setup(n);
+
+        for j in 0..n {
+            for i in 0..n {
+                let vx = if i < n / 2 { -0.5 } else { 0.5 };
+                grid.vx.set(i, j, vx);
+            }
+        }
+        for j in 0..n {
+            for i in 0..n {
+                grid.s.set(i, j, 0.2);
+            }
+        }
+
+        let config = BoundaryConfig::default();
+        let result = compute_boundary_sources(&grid, &plate_ids, &plates, &config);
+
+        let boundary_q = result.source_rate.get(n / 2, n / 2);
+        assert!(
+            boundary_q > 0.0,
+            "Rift should create crust: Q = {boundary_q}"
+        );
+    }
+
+    #[test]
+    fn interior_cells_have_no_source() {
+        let n = 32;
+        let (mut grid, plate_ids, plates) = make_two_plate_setup(n);
+
+        for j in 0..n {
+            for i in 0..n {
+                grid.vx.set(i, j, 0.1);
+                grid.s.set(i, j, 1.0);
+            }
+        }
+
+        let config = BoundaryConfig::default();
+        let result = compute_boundary_sources(&grid, &plate_ids, &plates, &config);
+
+        assert!(
+            result.source_rate.get(0, 0).abs() < 1e-10,
+            "Interior cell should have no source"
+        );
+        assert!(
+            result.source_rate.get(n - 1, n / 2).abs() < 1e-10,
+            "Interior cell should have no source"
+        );
+    }
+
+    #[test]
+    fn sources_conserve_mass_approximately() {
+        let n = 32;
+        let (mut grid, plate_ids, plates) = make_two_plate_setup(n);
+
+        for j in 0..n {
+            for i in 0..n {
+                let vx = if i < n / 2 { 0.5 } else { -0.5 };
+                grid.vx.set(i, j, vx);
+                grid.s.set(i, j, if i < n / 2 { 0.2 } else { 1.0 });
+            }
+        }
+
+        let config = BoundaryConfig::default();
+        let result = compute_boundary_sources(&grid, &plate_ids, &plates, &config);
+
+        let total_q: f64 = result.source_rate.data().iter().sum();
+        let max_q: f64 = result
+            .source_rate
+            .data()
+            .iter()
+            .map(|x| x.abs())
+            .fold(0.0, f64::max);
+        let relative = total_q.abs() / (max_q * n as f64).max(1e-10);
+
+        eprintln!(
+            "Total Q = {total_q:.6}, max |Q| = {max_q:.6}, relative = {relative:.6}"
+        );
+    }
+
+    #[test]
+    fn gaussian_blur_preserves_total() {
+        let n = 16;
+        let mut field = Field2D::new(n);
+        field.set(n / 2, n / 2, 1.0);
+
+        let blurred = gaussian_blur_f64(&field, 2.0);
+
+        let sum_before: f64 = field.data().iter().sum();
+        let sum_after: f64 = blurred.data().iter().sum();
+        assert!(
+            (sum_before - sum_after).abs() < 1e-10,
+            "Blur should preserve total: {sum_before} vs {sum_after}"
+        );
+    }
+}

--- a/crates/ymir-core/src/tectonics/mod.rs
+++ b/crates/ymir-core/src/tectonics/mod.rs
@@ -4,8 +4,8 @@
 //! continental formation from plate dynamics. The output is a crustal thickness
 //! field that is converted to altitude via isostasy.
 
+pub mod boundaries;  // M1 — subduction, rifting, volcanism source terms
 pub mod plates;       // M1 — plate initialization, Voronoi partitioning
 pub mod solver;      // M1 — thin viscous sheet velocity solver
 // pub mod advection;   // M1 — crustal thickness advection
-// pub mod boundaries;  // M1 — subduction, rifting, volcanism source terms
 // pub mod isostasy;    // M1 — thickness → altitude conversion

--- a/crates/ymir-core/src/tectonics/solver/config.rs
+++ b/crates/ymir-core/src/tectonics/solver/config.rs
@@ -111,6 +111,7 @@ pub struct TectonicsConfig {
     pub picard: PicardConfig,
     pub newton: NewtonConfig,
     pub continuation: ContinuationConfig,
+    pub boundaries: super::super::boundaries::BoundaryConfig,
 }
 
 impl Default for TectonicsConfig {
@@ -125,6 +126,7 @@ impl Default for TectonicsConfig {
             picard: PicardConfig::default(),
             newton: NewtonConfig::default(),
             continuation: ContinuationConfig::default(),
+            boundaries: Default::default(),
         }
     }
 }

--- a/crates/ymir-core/src/tectonics/solver/tectonics.rs
+++ b/crates/ymir-core/src/tectonics/solver/tectonics.rs
@@ -10,6 +10,8 @@ use super::newton::solve_velocity_newton;
 use super::picard::solve_velocity_picard;
 use super::traction::TractionField;
 use super::workspace::{SolverWorkspace, StepStats};
+use crate::tectonics::boundaries::{compute_boundary_sources_into, gaussian_blur_f64};
+use crate::tectonics::plates::Plate;
 
 /// Errors that can occur during a tectonic simulation run.
 #[derive(Debug)]
@@ -44,9 +46,16 @@ impl std::error::Error for SolverError {}
 /// `(step, total, stats, s_field)`. The `s_field` is a reference to the
 /// current crustal thickness field (safe to clone for snapshots).
 /// Return `true` to continue, `false` to cancel.
+/// Context for plate boundary processes (optional).
+pub struct PlateContext<'a> {
+    pub ids: &'a [usize],
+    pub plates: &'a [Plate],
+}
+
 pub fn run_tectonics<F>(
     config: &TectonicsConfig,
     plates: &TractionField,
+    plate_ctx: Option<&PlateContext<'_>>,
     grid: &mut StaggeredGrid,
     workspace: &mut SolverWorkspace,
     mut progress: F,
@@ -90,12 +99,41 @@ where
         let dt_min = dt * 0.01;
         let mut clamp_ratio = 0.0;
 
+        // Compute boundary source terms if enabled
+        let boundaries_active = config.boundaries.enabled && plate_ctx.is_some();
+        if boundaries_active {
+            let ctx = plate_ctx.unwrap();
+            compute_boundary_sources_into(
+                grid,
+                ctx.ids,
+                ctx.plates,
+                &config.boundaries,
+                &mut workspace.source_rate,
+            );
+            if config.boundaries.source_smoothing_sigma > 0.0 {
+                let smoothed = gaussian_blur_f64(
+                    &workspace.source_rate,
+                    config.boundaries.source_smoothing_sigma,
+                );
+                workspace
+                    .source_rate
+                    .data_mut()
+                    .copy_from_slice(smoothed.data());
+            }
+        }
+
         for _retry in 0..5 {
             compute_divergence_flux(grid, &mut workspace.div_flux);
 
             for j in 0..n {
                 for i in 0..n {
-                    let s = grid.s.get(i, j) - dt * workspace.div_flux.get(i, j);
+                    let div = workspace.div_flux.get(i, j);
+                    let q = if boundaries_active {
+                        workspace.source_rate.get(i, j)
+                    } else {
+                        0.0
+                    };
+                    let s = grid.s.get(i, j) - dt * div + dt * q;
                     grid.s.set(i, j, s.clamp(config.s_min, config.s_max));
                 }
             }
@@ -296,6 +334,7 @@ mod tests {
             },
             newton: NewtonConfig::default(),
             continuation: ContinuationConfig { enabled: false, ..Default::default() },
+            boundaries: Default::default(),
         }
     }
 
@@ -315,7 +354,7 @@ mod tests {
         let config = make_config(50);
         let mut ws = SolverWorkspace::new(n);
 
-        let result = run_tectonics(&config, &plates, &mut grid, &mut ws, |_, _, _, _| true);
+        let result = run_tectonics(&config, &plates, None, &mut grid, &mut ws, |_, _, _, _| true);
         assert!(result.is_ok(), "Run failed: {:?}", result.err());
 
         assert!(
@@ -341,7 +380,7 @@ mod tests {
         let config = make_config(50);
         let mut ws = SolverWorkspace::new(n);
 
-        let result = run_tectonics(&config, &plates, &mut grid, &mut ws, |_, _, _, _| true);
+        let result = run_tectonics(&config, &plates, None, &mut grid, &mut ws, |_, _, _, _| true);
         assert!(result.is_ok(), "Run failed: {:?}", result.err());
 
         assert!(
@@ -377,7 +416,7 @@ mod tests {
         let config = make_config(100);
         let mut ws = SolverWorkspace::new(n);
 
-        let result = run_tectonics(&config, &plates, &mut grid, &mut ws, |_, _, _, _| true);
+        let result = run_tectonics(&config, &plates, None, &mut grid, &mut ws, |_, _, _, _| true);
         assert!(result.is_ok(), "Run failed: {:?}", result.err());
 
         let final_var: f64 = {
@@ -406,7 +445,7 @@ mod tests {
         let config = make_config(30);
         let mut ws = SolverWorkspace::new(n);
 
-        let result = run_tectonics(&config, &plates, &mut grid, &mut ws, |_, _, _, _| true);
+        let result = run_tectonics(&config, &plates, None, &mut grid, &mut ws, |_, _, _, _| true);
         assert!(result.is_ok());
 
         for val in grid.s.data() {
@@ -450,10 +489,11 @@ mod tests {
             },
             newton: NewtonConfig::default(),
             continuation: ContinuationConfig::default(),
+            boundaries: Default::default(),
         };
 
         let mut ws = SolverWorkspace::new(n);
-        let result = run_tectonics(&config, &plates, &mut grid, &mut ws, |_, _, _, _| true);
+        let result = run_tectonics(&config, &plates, None, &mut grid, &mut ws, |_, _, _, _| true);
         assert!(result.is_ok(), "Continuation should enable convergence: {:?}", result.err());
         assert!(
             ws.stats.max_thickness > 1.0,

--- a/crates/ymir-core/src/tectonics/solver/workspace.rs
+++ b/crates/ymir-core/src/tectonics/solver/workspace.rs
@@ -46,6 +46,7 @@ pub struct SolverWorkspace {
     pub jfnk_f_v: Vec<f64>,
     pub jfnk_neg_f: Vec<f64>,
     pub jfnk_delta_v: Vec<f64>,
+    pub source_rate: Field2D,
     pub stats: StepStats,
 }
 
@@ -67,6 +68,7 @@ impl SolverWorkspace {
             jfnk_f_v: vec![0.0; nn2],
             jfnk_neg_f: vec![0.0; nn2],
             jfnk_delta_v: vec![0.0; nn2],
+            source_rate: Field2D::new(n),
             stats: StepStats::default(),
         }
     }

--- a/crates/ymir-viz/src/bridge/commands.rs
+++ b/crates/ymir-viz/src/bridge/commands.rs
@@ -1,5 +1,6 @@
 //! Commands sent from the Bevy main thread to the solver thread.
 
+use ymir_core::tectonics::plates::Plate;
 use ymir_core::tectonics::solver::config::TectonicsConfig;
 use ymir_core::tectonics::solver::field::Field2D;
 use ymir_core::tectonics::solver::traction::TractionField;
@@ -9,6 +10,8 @@ pub enum SolverCommand {
     RunTectonics {
         config: TectonicsConfig,
         plates: TractionField,
+        plate_ids: Vec<usize>,
+        plate_info: Vec<Plate>,
         initial_s: Field2D,
         grid_size: usize,
         dx: f64,

--- a/crates/ymir-viz/src/bridge/thread.rs
+++ b/crates/ymir-viz/src/bridge/thread.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 use crossbeam_channel::{Receiver, Sender};
 
 use ymir_core::tectonics::solver::grid::StaggeredGrid;
-use ymir_core::tectonics::solver::tectonics::run_tectonics;
+use ymir_core::tectonics::solver::tectonics::{run_tectonics, PlateContext};
 use ymir_core::tectonics::solver::workspace::SolverWorkspace;
 
 use super::commands::SolverCommand;
@@ -28,6 +28,8 @@ pub fn spawn_solver_thread(
                     SolverCommand::RunTectonics {
                         config,
                         plates,
+                        plate_ids,
+                        plate_info,
                         initial_s,
                         grid_size,
                         dx,
@@ -50,9 +52,19 @@ pub fn spawn_solver_thread(
                         let tx = events_tx.clone();
                         let start = Instant::now();
 
+                        let plate_ctx = if config.boundaries.enabled {
+                            Some(PlateContext {
+                                ids: &plate_ids,
+                                plates: &plate_info,
+                            })
+                        } else {
+                            None
+                        };
+
                         let result = run_tectonics(
                             &config,
                             &plates,
+                            plate_ctx.as_ref(),
                             &mut grid,
                             ws,
                             |step, total, stats, s_field| {

--- a/crates/ymir-viz/src/state.rs
+++ b/crates/ymir-viz/src/state.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use ymir_core::grid::GridF32;
 use ymir_core::tectonics::plates::{PlateConfig, PlateInitResult};
+use ymir_core::tectonics::boundaries::BoundaryConfig;
 use ymir_core::tectonics::solver::config::{NonlinearSolver, Preconditioner};
 
 // ── View ─────────────────────────────────────────────────────────────────
@@ -188,6 +189,7 @@ pub struct SolverConfig {
     pub eta_max: f64,
     pub preconditioner: Preconditioner,
     pub inexact_newton: bool,
+    pub boundaries: BoundaryConfig,
 }
 
 impl Default for SolverConfig {
@@ -204,6 +206,7 @@ impl Default for SolverConfig {
             eta_max: 1e4,
             preconditioner: Preconditioner::default(),
             inexact_newton: true,
+            boundaries: BoundaryConfig::default(),
         }
     }
 }

--- a/crates/ymir-viz/src/ui/parameter_panel.rs
+++ b/crates/ymir-viz/src/ui/parameter_panel.rs
@@ -245,6 +245,44 @@ fn draw_tectonics(
     ui.checkbox(&mut solver_config.inexact_newton, "Inexact Newton");
 
     ui.add_space(4.0);
+    ui.separator();
+    ui.strong("Boundary processes");
+
+    ui.checkbox(&mut solver_config.boundaries.enabled, "Enabled");
+    if solver_config.boundaries.enabled {
+        slider_row_f64(
+            ui,
+            "Subduction rate",
+            &mut solver_config.boundaries.subduction_rate,
+            0.0..=2.0,
+        );
+        slider_row_f64(
+            ui,
+            "Volcanic arc rate",
+            &mut solver_config.boundaries.volcanic_arc_rate,
+            0.0..=1.0,
+        );
+        slider_row_f64(
+            ui,
+            "Spreading rate",
+            &mut solver_config.boundaries.spreading_rate,
+            0.0..=2.0,
+        );
+        slider_row_f64(
+            ui,
+            "Rift threshold",
+            &mut solver_config.boundaries.rift_thickness_threshold,
+            0.1..=0.8,
+        );
+        slider_row_f64(
+            ui,
+            "Source smooth. σ",
+            &mut solver_config.boundaries.source_smoothing_sigma,
+            0.0..=5.0,
+        );
+    }
+
+    ui.add_space(4.0);
 
     let is_running = matches!(bridge.state, SolverState::Running { .. });
 
@@ -339,11 +377,14 @@ fn launch_solver(
             enabled: solver_config.continuation_enabled,
             ..ContinuationConfig::default()
         },
+        boundaries: solver_config.boundaries.clone(),
     };
 
     let _ = bridge.commands_tx.send(SolverCommand::RunTectonics {
         config,
         plates: traction,
+        plate_ids: init.plate_ids.clone(),
+        plate_info: init.plates.clone(),
         initial_s,
         grid_size,
         dx,


### PR DESCRIPTION
…ms [#9]

Add plate boundary detection and source/sink term Q(x,y) to the crustal thickness advection equation (S_new = S - dt·div(S·v) + dt·Q).

Boundaries are classified from plate_ids and velocity fields into subduction, continental collision, oceanic subduction, and rift zones. Each type produces a physically-motivated source rate proportional to the local convergence/divergence velocity. A separable Gaussian blur (f64, periodic) smooths the source field to avoid single-pixel artifacts.

Includes BoundaryConfig with 7 tunable parameters, UI sliders in the viz parameter panel, and 5 unit tests covering detection and blur.