### PR TITLE
FEAT : Continental minimum thickness protection [#35]

### DIFF
--- a/crates/ymir-core/src/tectonics/boundaries.rs
+++ b/crates/ymir-core/src/tectonics/boundaries.rs
@@ -74,6 +74,18 @@ pub struct BoundaryConfig {
     /// 0.0 = no restoring, 1.0 = excess removed in one step.
     /// Range: 0.0-1.0, default: 0.3
     pub oceanic_restore_rate: f64,
+    /// Minimum stable thickness for continental crust. Continental cells
+    /// thinner than this are gently restored upward, modeling buoyancy.
+    /// Default: 0.5 (thinned but still buoyant continental crust).
+    pub continental_min_thickness: f64,
+    /// Thickness below which continental restoring gives up — the crust
+    /// has been fully rifted and effectively becomes oceanic.
+    /// Default: 0.15 (below oceanic reference, enabling Wilson cycles).
+    pub continental_restore_threshold: f64,
+    /// Rate at which thinned continental crust is restored per timestep.
+    /// 0.0 = no restoring, 1.0 = restored in one step.
+    /// Default: 0.03 (gentle, allows temporary thinning during rifting).
+    pub continental_restore_rate: f64,
     /// Enable dynamic slab pull. Default: true.
     pub slab_pull_enabled: bool,
     /// Slab pull traction increase per unit of subducted mass.
@@ -103,6 +115,9 @@ impl Default for BoundaryConfig {
             oceanic_reference_thickness: 0.25,
             oceanic_restore_threshold: 0.4,
             oceanic_restore_rate: 0.05,
+            continental_min_thickness: 0.5,
+            continental_restore_threshold: 0.15,
+            continental_restore_rate: 0.03,
             slab_pull_enabled: true,
             slab_pull_factor: 0.05,
             max_plate_velocity: 5.0,

--- a/crates/ymir-core/src/tectonics/solver/tectonics.rs
+++ b/crates/ymir-core/src/tectonics/solver/tectonics.rs
@@ -243,6 +243,28 @@ where
             }
         }
 
+        // 3c. Continental minimum thickness protection.
+        // Prevents continental crust from thinning to oblivion by modeling
+        // buoyancy-driven resistance. Cells below continental_restore_threshold
+        // are considered fully rifted (new ocean floor) and not restored.
+        if config.boundaries.enabled && config.boundaries.continental_restore_rate > 0.0 {
+            let rate = config.boundaries.continental_restore_rate;
+            let s_min = config.boundaries.continental_min_thickness;
+            let s_thr = config.boundaries.continental_restore_threshold;
+            for j in 0..n {
+                for i in 0..n {
+                    let pid = plate_ctx.ids[j * n + i];
+                    if plate_ctx.plates[pid].plate_type == PlateType::Continental {
+                        let s_current = grid.s.get(i, j);
+                        if s_current < s_min && s_current > s_thr {
+                            let s_new = s_current + dt * rate * (s_min - s_current);
+                            grid.s.set(i, j, s_new);
+                        }
+                    }
+                }
+            }
+        }
+
         // 4. Update stats
         let mut max_v = 0.0_f64;
         let mut max_s = f64::NEG_INFINITY;

--- a/crates/ymir-viz/src/ui/parameter_panel.rs
+++ b/crates/ymir-viz/src/ui/parameter_panel.rs
@@ -379,6 +379,27 @@ fn draw_tectonics(
         );
 
         ui.separator();
+        ui.strong("Continental restore");
+        slider_row_f64(
+            ui,
+            "Cont. min S",
+            &mut solver_config.boundaries.continental_min_thickness,
+            0.3..=0.8,
+        );
+        slider_row_f64(
+            ui,
+            "Cont. restore Thr",
+            &mut solver_config.boundaries.continental_restore_threshold,
+            0.05..=0.3,
+        );
+        slider_row_f64(
+            ui,
+            "Cont. restore",
+            &mut solver_config.boundaries.continental_restore_rate,
+            0.0..=0.1,
+        );
+
+        ui.separator();
         ui.strong("Density & slab pull");
 
         slider_row_f64(


### PR DESCRIPTION
Add buoyancy-driven restoring force for continental crust, symmetric to the existing oceanic restore. Continental cells thinner than continental_min_thickness are gently restored upward unless they fall below continental_restore_threshold (fully rifted). Three new BoundaryConfig fields: continental_min_thickness (0.5), continental_restore_threshold (0.15), continental_restore_rate (0.03). UI sliders added under "Continental restore" in boundary processes.