### PR TITLE
FEAT : Boundary type visualization overlay + legend [#42]

### DIFF
--- a/crates/ymir-core/src/tectonics/solver/tectonics.rs
+++ b/crates/ymir-core/src/tectonics/solver/tectonics.rs
@@ -70,6 +70,7 @@ pub struct StepSnapshot<'a> {
     pub s_field: &'a Field2D,
     pub plate_ids: Option<&'a [usize]>,
     pub plates: Option<&'a [Plate]>,
+    pub boundary_types: Option<&'a [BoundaryType]>,
 }
 
 pub fn run_tectonics<F>(
@@ -220,15 +221,35 @@ where
             plate_ctx.traction = rebuild_traction(&plate_ctx.ids, &plate_ctx.plates, n);
         }
 
+        // ── Mass balance tracking ──────────────────────────────────
+        let mass_before: f64 = grid.s.data().iter().sum();
+        let mut mass_after_advection = 0.0_f64;
+        let mut mass_clamp_delta = 0.0_f64;
+        let mut total_div_flux = 0.0_f64;
+        let mut total_source = 0.0_f64;
+
         for _retry in 0..5 {
             compute_divergence_flux(grid, &mut workspace.div_flux);
+
+            mass_after_advection = 0.0;
+            mass_clamp_delta = 0.0;
+            total_div_flux = 0.0;
+            total_source = 0.0;
 
             for j in 0..n {
                 for i in 0..n {
                     let div = workspace.div_flux.get(i, j);
                     let q = if boundaries_active { workspace.source_rate.get(i, j) } else { 0.0 };
-                    let s = grid.s.get(i, j) - dt * div + dt * q;
-                    grid.s.set(i, j, s.clamp(config.s_min, config.s_max));
+                    let s_old = grid.s.get(i, j);
+                    let s_raw = s_old - dt * div + dt * q;
+                    let s_clamped = s_raw.clamp(config.s_min, config.s_max);
+
+                    total_div_flux += dt * div;
+                    total_source += dt * q;
+                    mass_clamp_delta += s_clamped - s_raw;
+                    mass_after_advection += s_clamped;
+
+                    grid.s.set(i, j, s_clamped);
                 }
             }
 
@@ -277,6 +298,9 @@ where
             }
         }
 
+        let mass_after_oceanic_restore: f64 = grid.s.data().iter().sum();
+        let oceanic_restore_delta = mass_after_oceanic_restore - mass_after_advection;
+
         // 3c. Continental minimum thickness protection.
         // Prevents continental crust from thinning to oblivion by modeling
         // buoyancy-driven resistance. Cells below continental_restore_threshold
@@ -298,6 +322,10 @@ where
                 }
             }
         }
+
+        let mass_after_continental_restore: f64 = grid.s.data().iter().sum();
+        let continental_restore_delta = mass_after_continental_restore - mass_after_oceanic_restore;
+        let mass_after = mass_after_continental_restore;
 
         // 4. Update stats
         let mut max_v = 0.0_f64;
@@ -338,6 +366,19 @@ where
         if clamp_ratio > 0.05 {
             warn!(step, clamp_ratio, dt, "excessive clamping — consider reducing CFL or timestep");
         }
+
+        // ── Mass balance diagnostic (always runs) ──────────────────
+        debug!(
+            step,
+            mass_total = %format!("{:.4}", mass_after),
+            mass_delta = %format!("{:.6}", mass_after - mass_before),
+            advection_div = %format!("{:.6}", -total_div_flux),
+            sources_q = %format!("{:.6}", total_source),
+            clamping = %format!("{:.6}", mass_clamp_delta),
+            oceanic_restore = %format!("{:.6}", oceanic_restore_delta),
+            continental_restore = %format!("{:.6}", continental_restore_delta),
+            "mass balance"
+        );
 
         // ── Diagnostic: per-step plate & boundary summary ──────────────
         if config.dynamic_boundaries {
@@ -444,6 +485,7 @@ where
                 None
             },
             plates: if config.dynamic_boundaries { Some(&plate_ctx.plates) } else { None },
+            boundary_types: workspace.boundary_field.as_ref().map(|bf| bf.boundary_type.as_slice()),
         };
         if !progress(step, config.num_timesteps, &workspace.stats, snapshot) {
             return Err(SolverError::Cancelled);

--- a/crates/ymir-viz/src/bridge/events.rs
+++ b/crates/ymir-viz/src/bridge/events.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use ymir_core::erosion::hydraulic::ErosionStats;
 use ymir_core::grid::GridF32;
+use ymir_core::tectonics::boundaries::BoundaryType;
 use ymir_core::tectonics::plates::Plate;
 use ymir_core::tectonics::solver::field::Field2D;
 use ymir_core::tectonics::solver::workspace::StepStats;
@@ -21,11 +22,13 @@ pub enum SolverEvent {
         s_field: Field2D,
         plate_ids: Option<Vec<usize>>,
         plates: Option<Vec<Plate>>,
+        boundary_types: Option<Vec<BoundaryType>>,
     },
     Completed {
         s_field: Field2D,
         plate_ids: Option<Vec<usize>>,
         plates: Option<Vec<Plate>>,
+        boundary_types: Option<Vec<BoundaryType>>,
         elapsed: Duration,
         total_steps: usize,
     },

--- a/crates/ymir-viz/src/bridge/plugin.rs
+++ b/crates/ymir-viz/src/bridge/plugin.rs
@@ -101,7 +101,7 @@ fn poll_solver_events(
             SolverEvent::Progress { step, total_steps, stats } => {
                 bridge.state = SolverState::Running { step, total_steps, stats: Some(stats) };
             }
-            SolverEvent::Snapshot { s_field, plate_ids, plates, .. } => {
+            SolverEvent::Snapshot { s_field, plate_ids, plates, boundary_types, .. } => {
                 let grid_size = s_field.n();
                 terrain_display.update_field(s_field);
                 isostasy_cache.valid = false;
@@ -114,8 +114,13 @@ fn poll_solver_events(
                     dynamic_plates.active_count = pl.iter().filter(|p| p.active).count();
                     dynamic_plates.plates = Some(pl);
                 }
+                if let Some(bt) = boundary_types {
+                    dynamic_plates.boundary_types = Some(bt);
+                }
             }
-            SolverEvent::Completed { s_field, plate_ids, plates, elapsed, .. } => {
+            SolverEvent::Completed {
+                s_field, plate_ids, plates, boundary_types, elapsed, ..
+            } => {
                 let grid_size = s_field.n();
                 terrain_display.update_field(s_field);
                 isostasy_cache.valid = false;
@@ -128,6 +133,9 @@ fn poll_solver_events(
                 if let Some(pl) = plates {
                     dynamic_plates.active_count = pl.iter().filter(|p| p.active).count();
                     dynamic_plates.plates = Some(pl);
+                }
+                if let Some(bt) = boundary_types {
+                    dynamic_plates.boundary_types = Some(bt);
                 }
             }
             SolverEvent::FbmCompleted { heightmap, slope, elapsed } => {

--- a/crates/ymir-viz/src/bridge/thread.rs
+++ b/crates/ymir-viz/src/bridge/thread.rs
@@ -71,6 +71,7 @@ pub fn spawn_solver_thread(
                                         s_field: snap.s_field.clone(),
                                         plate_ids: snap.plate_ids.map(|ids| ids.to_vec()),
                                         plates: snap.plates.map(|p| p.to_vec()),
+                                        boundary_types: snap.boundary_types.map(|bt| bt.to_vec()),
                                     });
                                 }
                                 !cancel_ref.load(Ordering::Relaxed)
@@ -82,6 +83,9 @@ pub fn spawn_solver_thread(
                             if dynamic { Some(plate_ctx.ids.clone()) } else { None };
                         let final_plates =
                             if dynamic { Some(plate_ctx.plates.clone()) } else { None };
+                        let final_boundary_types = workspace.as_ref().and_then(|w| {
+                            w.boundary_field.as_ref().map(|bf| bf.boundary_type.clone())
+                        });
 
                         match result {
                             Ok(()) => {
@@ -89,6 +93,7 @@ pub fn spawn_solver_thread(
                                     s_field: final_s,
                                     plate_ids: final_plate_ids,
                                     plates: final_plates,
+                                    boundary_types: final_boundary_types,
                                     elapsed: start.elapsed(),
                                     total_steps: config.num_timesteps,
                                 });
@@ -100,6 +105,7 @@ pub fn spawn_solver_thread(
                                         s_field: final_s,
                                         plate_ids: final_plate_ids,
                                         plates: final_plates,
+                                        boundary_types: final_boundary_types,
                                         elapsed: start.elapsed(),
                                         total_steps: config.num_timesteps,
                                     });
@@ -137,6 +143,7 @@ pub fn spawn_solver_thread(
                                     s_field: snap.s_field.clone(),
                                     plate_ids: snap.plate_ids.map(|i| i.to_vec()),
                                     plates: snap.plates.map(|p| p.to_vec()),
+                                    boundary_types: snap.boundary_types.map(|bt| bt.to_vec()),
                                 });
                                 let _ = tx.send(SolverEvent::Progress {
                                     step: 0,
@@ -147,10 +154,14 @@ pub fn spawn_solver_thread(
                             },
                         );
 
+                        let final_boundary_types = workspace.as_ref().and_then(|w| {
+                            w.boundary_field.as_ref().map(|bf| bf.boundary_type.clone())
+                        });
                         let _ = events_tx.send(SolverEvent::Completed {
                             s_field: grid.s.clone(),
                             plate_ids: Some(plate_ctx.ids.clone()),
                             plates: Some(plate_ctx.plates.clone()),
+                            boundary_types: final_boundary_types,
                             elapsed: std::time::Duration::ZERO,
                             total_steps: 1,
                         });

--- a/crates/ymir-viz/src/cursor_inspector.rs
+++ b/crates/ymir-viz/src/cursor_inspector.rs
@@ -33,6 +33,7 @@ fn cursor_inspector_overlay(
     erosion_cache: Res<ErosionCache>,
     flow_cache: Res<FlowCache>,
     gen_params: Res<GenerationParamsUi>,
+    dynamic_plates: Res<crate::state::DynamicPlateIds>,
 ) {
     let Ok(ctx) = contexts.ctx_mut() else { return };
 
@@ -45,7 +46,7 @@ fn cursor_inspector_overlay(
                 .inner_margin(6.0)
                 .show(ui, |ui| {
                     if *view_mode.get() == ViewMode::Tectonics {
-                        draw_tectonic_info(ui, &cursor_pos, tectonic.as_deref());
+                        draw_tectonic_info(ui, &cursor_pos, tectonic.as_deref(), &dynamic_plates);
                     } else {
                         draw_pipeline_terrain_info(
                             ui,
@@ -139,7 +140,9 @@ fn draw_tectonic_info(
     ui: &mut bevy_egui::egui::Ui,
     cursor_pos: &CursorWorldPos,
     tectonic: Option<&TectonicState>,
+    dynamic_plates: &crate::state::DynamicPlateIds,
 ) {
+    use ymir_core::tectonics::boundaries::BoundaryType;
     use ymir_core::tectonics::plates::PlateType;
 
     let Some(tectonic) = tectonic else {
@@ -171,6 +174,23 @@ fn draw_tectonic_info(
                 "x: {}  y: {}  plate: {} ({})  t: {:.2}  v: {:.2}",
                 x, y, plate_id, ptype, thickness, speed
             ));
+
+            // Show boundary type if available
+            if let Some(ref bt) = dynamic_plates.boundary_types {
+                let bt_size = dynamic_plates.grid_size;
+                if bt_size == size
+                    && let Some(&btype) = bt.get(y * size + x)
+                {
+                    let bt_name = match btype {
+                        BoundaryType::None => "Interior",
+                        BoundaryType::Subduction => "Subduction",
+                        BoundaryType::OceanicSubduction => "Ocean. Subduction",
+                        BoundaryType::ContinentalCollision => "Collision",
+                        BoundaryType::Rift => "Rift",
+                    };
+                    ui.monospace(format!("boundary: {}", bt_name));
+                }
+            }
         } else {
             ui.monospace("x: ---  plate: ---  thickness: ---");
         }

--- a/crates/ymir-viz/src/main.rs
+++ b/crates/ymir-viz/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
                     ..default()
                 })
                 .set(bevy::log::LogPlugin {
-                    filter: "warn,ymir_core=info,ymir_viz=info".to_string(),
+                    filter: "warn,ymir_core::tectonics=debug".to_string(),
                     level: bevy::log::Level::DEBUG,
                     custom_layer: |_app| {
                         let file = std::fs::OpenOptions::new()

--- a/crates/ymir-viz/src/state.rs
+++ b/crates/ymir-viz/src/state.rs
@@ -54,11 +54,19 @@ pub struct OverlayFlags {
     pub hillshade: bool,
     pub grid: bool,
     pub plates: bool,
+    pub boundary_types: bool,
 }
 
 impl Default for OverlayFlags {
     fn default() -> Self {
-        Self { rivers: false, lakes: false, hillshade: true, grid: false, plates: false }
+        Self {
+            rivers: false,
+            lakes: false,
+            hillshade: true,
+            grid: false,
+            plates: false,
+            boundary_types: false,
+        }
     }
 }
 
@@ -218,7 +226,7 @@ impl Default for SolverConfig {
             dynamic_boundaries: true,
             cratonic: Default::default(),
             yielding: Default::default(),
-            basal_friction: 0.5,
+            basal_friction: 0.05,
         }
     }
 }
@@ -383,6 +391,8 @@ pub struct DynamicPlateIds {
     pub ids: Option<Vec<usize>>,
     /// Current plate seed positions and active flags.
     pub plates: Option<Vec<ymir_core::tectonics::plates::Plate>>,
+    /// Boundary type at each cell (for visualization).
+    pub boundary_types: Option<Vec<ymir_core::tectonics::boundaries::BoundaryType>>,
     /// Number of active plates remaining.
     pub active_count: usize,
     /// Grid size (for indexing into ids).

--- a/crates/ymir-viz/src/tectonic_view.rs
+++ b/crates/ymir-viz/src/tectonic_view.rs
@@ -23,6 +23,7 @@ impl Plugin for TectonicViewPlugin {
                 toggle_tectonic_visibility,
                 draw_velocity_arrows,
                 draw_plate_boundaries,
+                draw_boundary_types,
             ),
         );
     }
@@ -315,6 +316,53 @@ fn draw_plate_boundaries(
             let arrow_end =
                 pos + Vec2::new(plate.velocity.0 * arrow_scale, plate.velocity.1 * arrow_scale);
             gizmos.arrow_2d(pos, arrow_end, color);
+        }
+    }
+}
+
+fn draw_boundary_types(
+    mut gizmos: Gizmos,
+    plate_ids_res: Res<DynamicPlateIds>,
+    view_state: Res<ViewState>,
+) {
+    if !view_state.overlays.boundary_types {
+        return;
+    }
+
+    let Some(ref bt) = plate_ids_res.boundary_types else {
+        return;
+    };
+    let n = plate_ids_res.grid_size;
+    if n == 0 || bt.len() != n * n {
+        return;
+    }
+
+    use ymir_core::tectonics::boundaries::BoundaryType;
+
+    let sprite_size = 600.0_f32;
+    let cell_size = sprite_size / n as f32;
+    let half = sprite_size / 2.0;
+    let half_cell = cell_size * 0.5;
+
+    for j in 0..n {
+        for i in 0..n {
+            let btype = bt[j * n + i];
+            let color = match btype {
+                BoundaryType::None => continue,
+                BoundaryType::Subduction => Color::srgba(1.0, 0.15, 0.15, 0.7),
+                BoundaryType::OceanicSubduction => Color::srgba(0.0, 0.9, 0.9, 0.7),
+                BoundaryType::ContinentalCollision => Color::srgba(0.9, 0.2, 0.7, 0.7),
+                BoundaryType::Rift => Color::srgba(0.2, 0.5, 1.0, 0.7),
+            };
+
+            let x = i as f32 * cell_size - half + half_cell;
+            let y = j as f32 * cell_size - half + half_cell;
+
+            gizmos.rect_2d(
+                Isometry2d::from_translation(Vec2::new(x, y)),
+                Vec2::splat(cell_size * 0.8),
+                color,
+            );
         }
     }
 }

--- a/crates/ymir-viz/src/ui/mod.rs
+++ b/crates/ymir-viz/src/ui/mod.rs
@@ -14,7 +14,14 @@ impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(EguiPlugin::default()).add_systems(
             EguiPrimaryContextPass,
-            (configure_egui_style, ui_top_bar, ui_right_panel, ui_bottom_bar, ui_toasts),
+            (
+                configure_egui_style,
+                ui_top_bar,
+                ui_right_panel,
+                ui_bottom_bar,
+                ui_toasts,
+                draw_boundary_legend,
+            ),
         );
     }
 }
@@ -74,6 +81,7 @@ fn ui_top_bar(
                 ui.checkbox(&mut view_state.overlays.lakes, "Lakes");
                 ui.checkbox(&mut view_state.overlays.grid, "Grid");
                 ui.checkbox(&mut view_state.overlays.plates, "Plates");
+                ui.checkbox(&mut view_state.overlays.boundary_types, "Boundary types");
             });
 
             // ── Right side: Seed + Run / Step / Cancel + Progress ──
@@ -434,6 +442,40 @@ fn ui_toasts(
                     );
                 });
                 ui.add_space(2.0);
+            }
+        });
+}
+
+fn draw_boundary_legend(mut contexts: EguiContexts, view_state: Res<ViewState>) {
+    if !view_state.overlays.boundary_types {
+        return;
+    }
+
+    let Ok(ctx) = contexts.ctx_mut() else { return };
+
+    egui::Window::new("Boundary Types")
+        .anchor(egui::Align2::LEFT_BOTTOM, egui::vec2(65.0, -50.0))
+        .resizable(false)
+        .collapsible(false)
+        .title_bar(false)
+        .frame(
+            egui::Frame::window(&egui::Style::default()).fill(egui::Color32::from_black_alpha(180)),
+        )
+        .show(ctx, |ui| {
+            let entries = [
+                (egui::Color32::from_rgb(255, 38, 38), "Subduction"),
+                (egui::Color32::from_rgb(0, 230, 230), "Oceanic Subduction"),
+                (egui::Color32::from_rgb(230, 51, 179), "Continental Collision"),
+                (egui::Color32::from_rgb(51, 128, 255), "Rift / Spreading"),
+            ];
+
+            for (color, label) in &entries {
+                ui.horizontal(|ui| {
+                    let (rect, _) =
+                        ui.allocate_exact_size(egui::vec2(12.0, 12.0), egui::Sense::hover());
+                    ui.painter().rect_filled(rect, 2.0, *color);
+                    ui.label(*label);
+                });
             }
         });
 }


### PR DESCRIPTION
Thread BoundaryType through StepSnapshot → SolverEvent → DynamicPlateIds so the viz layer can render a color-coded overlay (red subduction, cyan oceanic subduction, magenta collision, blue rift). Add draw_boundary_types gizmo system and a floating legend window that appears when the overlay is enabled. Cursor inspector shows the hovered cell's boundary type. Per-step mass balance debug log (total, delta, advection, sources, clamping, restores) added to track where mass is created or destroyed.