### PR TITLE
Issue #125 — C1 Phase 1.3 equilibrium height + harness refactor

### DIFF
--- a/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/mod.rs
+++ b/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/mod.rs
@@ -1,0 +1,78 @@
+//! Equilibrium height closure — gravitational collapse cap on `S̃`
+//! (C1 Phase 1.3, Issue #125).
+//!
+//! ## Physics in one paragraph
+//!
+//! Per Molnar & Lyon-Caen 1988, *J. Geophys. Res.* 93(B5), 4885-4923
+//! and England & Houseman 1989, *J. Geophys. Res.* 94(B12), 17561-
+//! 17579: a thickened continental lithosphere stores gravitational
+//! potential energy proportional to the thickness excess above some
+//! equilibrium value `h_eq`. Above that threshold, the gravitational
+//! body force becomes large enough to drive ductile extension /
+//! gravitational collapse, capping the elevated wedge at the
+//! equilibrium height. The closure approximates this as a linear
+//! one-sided relaxation:
+//!
+//! ```text
+//!     ∂S̃/∂t = − k_collapse · max(0, S̃ − h_eq)
+//! ```
+//!
+//! The `max(0, ·)` makes the closure **asymmetric**: cells above
+//! `h_eq` collapse toward it, cells below are untouched (no thin-
+//! lithosphere "lift"). The asymmetry is what makes this term a
+//! pure sink — never a source.
+//!
+//! ## Differences from Davis-Suppe
+//!
+//! - **Applied globally.** No plate-type or boundary skip — every
+//!   cell is subject to the same gravitational stability criterion,
+//!   regardless of upper/lower-plate identity or boundary
+//!   classification. This is the architectural difference that lets
+//!   the closure cap Phase 1.2's boundary pile-up
+//!   (`global_max ≈ 2297` in the advection-dominated 300-step run).
+//! - **First global sink in C1.** Davis-Suppe is source-only;
+//!   equilibrium height is the first closure that subtracts mass.
+//!   Phase 1.4's stream-power erosion will be the second.
+//! - **Bounded contribution.** For `k_collapse · dt ≤ 1` the per-
+//!   step decrement is a convex combination of `S̃_old` and `h_eq`
+//!   → no undershoot. The [`source_term`] module ships a defensive
+//!   clamp that protects against pathological time steps; see
+//!   [`source_term::apply_equilibrium_height_step`] for the in-
+//!   function comment explaining when the clamp triggers.
+//!
+//! ## Interaction with Phase 1.2 Davis-Suppe imprint
+//!
+//! With the default `h_eq = 2.0` (below `DavisSuppeParams::h_max
+//! = 2.5`), the Phase 1.2 statistics partition naturally:
+//!
+//! | Phase 1.2 quantity      | value  | relation to `h_eq = 2.0`     |
+//! |-------------------------|--------|------------------------------|
+//! | `mean(S̃)`              | 1.574  | below — untouched            |
+//! | `wedge_p95`             | 0.376  | below — untouched            |
+//! | `mean(d∈0..5)` (near)   | 0.904  | below — untouched            |
+//! | `wedge_p99`             | 5.83   | above — collapsed to `h_eq`  |
+//! | `global_max` (boundary) | 2297   | above — collapsed to `h_eq`  |
+//!
+//! The bulk wedge body (where the Davis-Suppe fill-ratio profile
+//! sits) is preserved; only the sparse boundary pile-up tail is
+//! capped. Stage E3 integration tests will verify both invariants
+//! simultaneously.
+//!
+//! ## Module layout
+//!
+//! - [`params`] — [`params::EquilibriumHeightParams`] tunables
+//!   (`h_eq = 2.0`, `k_collapse = 1.0`, `enabled = true`).
+//! - [`source_term`] — [`source_term::apply_equilibrium_height_step`],
+//!   the per-step in-place collapse plus 5 unit tests.
+//!
+//! ## References
+//!
+//! - Molnar, P. & Lyon-Caen, H. (1988). Some simple physical aspects
+//!   of the support, structure, and evolution of mountain belts.
+//!   *Geological Society of America Special Papers*, 218, 179-208.
+//! - England, P. & Houseman, G. (1989). Extension during continental
+//!   convergence, with application to the Tibetan Plateau.
+//!   *J. Geophys. Res.*, 94(B12), 17561-17579.
+
+pub mod params;
+pub mod source_term;

--- a/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/mod.rs
+++ b/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/mod.rs
@@ -3,24 +3,63 @@
 //!
 //! ## Physics in one paragraph
 //!
-//! Per Molnar & Lyon-Caen 1988, *J. Geophys. Res.* 93(B5), 4885-4923
-//! and England & Houseman 1989, *J. Geophys. Res.* 94(B12), 17561-
-//! 17579: a thickened continental lithosphere stores gravitational
-//! potential energy proportional to the thickness excess above some
-//! equilibrium value `h_eq`. Above that threshold, the gravitational
-//! body force becomes large enough to drive ductile extension /
-//! gravitational collapse, capping the elevated wedge at the
-//! equilibrium height. The closure approximates this as a linear
-//! one-sided relaxation:
+//! Per Molnar & Lyon-Caen 1988, *Geological Society of America
+//! Special Papers* 218, 179-208 and England & Houseman 1989,
+//! *J. Geophys. Res.* 94(B12), 17561-17579: a thickened
+//! continental lithosphere stores gravitational potential energy
+//! quadratically in the thickness excess above some equilibrium
+//! value `h_eq`. Above that threshold, the gravitational body
+//! force drives ductile extension / gravitational collapse,
+//! capping the elevated wedge. The closure approximates this as
+//! a quadratic one-sided relaxation:
 //!
 //! ```text
-//!     ∂S̃/∂t = − k_collapse · max(0, S̃ − h_eq)
+//!     ∂S̃/∂t = − k_collapse · max(0, S̃ − h_eq)²
 //! ```
 //!
 //! The `max(0, ·)` makes the closure **asymmetric**: cells above
 //! `h_eq` collapse toward it, cells below are untouched (no thin-
 //! lithosphere "lift"). The asymmetry is what makes this term a
-//! pure sink — never a source.
+//! pure sink — never a source. The squared excess implements a
+//! soft threshold (see § Formula derivation).
+//!
+//! ## Formula derivation
+//!
+//! Per Molnar & Lyon-Caen 1988, GSA Spec. Paper 218, eq. (2):
+//!
+//! ```text
+//!     ΔPE_A = ½ρ_c·g·h² + ρ_c·g·h·H_0 + ½·Δρ·g·ΔH²
+//! ```
+//!
+//! The gravitational potential energy excess is **quadratic** in
+//! the excess thickness `ΔH`. Our sink term derives from this:
+//!
+//! ```text
+//!     ∂S̃/∂t |_equilibrium = − k_collapse · max(0, S̃ − h_eq)²
+//! ```
+//!
+//! Quadratic dependence implements threshold behavior:
+//!
+//! - **Small excess** → weak collapse (preserves the Davis-Suppe
+//!   wedge body where excess above `h_eq` is < 1 or so).
+//! - **Large excess** → strong collapse (caps boundary outliers,
+//!   advection pile-up cells where excess can reach `≈ 2 × 10³`
+//!   in the Phase 1.2 regime). One step is enough — the safety
+//!   clamp in [`source_term`] catches the overshoot and holds the
+//!   cell at `h_eq`.
+//!
+//! ## Parameter `h_eq = 2.0` (phenomenological)
+//!
+//! Corresponds to the observed Tibet crustal-thickness ratio
+//! (~70 km plateau crust vs ~35 km normal continental crust →
+//! ratio ≈ 2). This is **not** a rigorous "equilibrium height"
+//! derivation; Molnar & Lyon-Caen 1988 itself defines a critical
+//! thickness `S_c ≈ 50-60 km` (ratio 1.43-1.71) above which
+//! convective removal of the mantle lithosphere is the active
+//! mechanism — a more complex two-layer instability than this
+//! single-field linear sink. We adopt `h_eq = 2.0` as a tunable
+//! target consistent with observed plateau elevation limits, not
+//! as a derived equilibrium value.
 //!
 //! ## Differences from Davis-Suppe
 //!
@@ -33,12 +72,13 @@
 //! - **First global sink in C1.** Davis-Suppe is source-only;
 //!   equilibrium height is the first closure that subtracts mass.
 //!   Phase 1.4's stream-power erosion will be the second.
-//! - **Bounded contribution.** For `k_collapse · dt ≤ 1` the per-
-//!   step decrement is a convex combination of `S̃_old` and `h_eq`
-//!   → no undershoot. The [`source_term`] module ships a defensive
-//!   clamp that protects against pathological time steps; see
-//!   [`source_term::apply_equilibrium_height_step`] for the in-
-//!   function comment explaining when the clamp triggers.
+//! - **Bounded by clamp, not by linearity.** With the quadratic
+//!   form, the per-step decrement `k_collapse · excess² · dt` can
+//!   exceed `excess` for large `excess`; the safety clamp in
+//!   [`source_term`] holds the cell at `h_eq` in that case. This
+//!   is the intended threshold behavior — see
+//!   [`source_term::apply_equilibrium_height_step`] for the
+//!   in-function comment.
 //!
 //! ## Interaction with Phase 1.2 Davis-Suppe imprint
 //!
@@ -50,8 +90,8 @@
 //! | `mean(S̃)`              | 1.574  | below — untouched            |
 //! | `wedge_p95`             | 0.376  | below — untouched            |
 //! | `mean(d∈0..5)` (near)   | 0.904  | below — untouched            |
-//! | `wedge_p99`             | 5.83   | above — collapsed to `h_eq`  |
-//! | `global_max` (boundary) | 2297   | above — collapsed to `h_eq`  |
+//! | `wedge_p99`             | 5.83   | above — clamped to `h_eq`    |
+//! | `global_max` (boundary) | 2297   | above — clamped to `h_eq`    |
 //!
 //! The bulk wedge body (where the Davis-Suppe fill-ratio profile
 //! sits) is preserved; only the sparse boundary pile-up tail is
@@ -61,7 +101,7 @@
 //! ## Module layout
 //!
 //! - [`params`] — [`params::EquilibriumHeightParams`] tunables
-//!   (`h_eq = 2.0`, `k_collapse = 1.0`, `enabled = true`).
+//!   (`h_eq = 2.0`, `k_collapse = 2.0`, `enabled = true`).
 //! - [`source_term`] — [`source_term::apply_equilibrium_height_step`],
 //!   the per-step in-place collapse plus 5 unit tests.
 //!

--- a/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/params.rs
+++ b/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/params.rs
@@ -1,49 +1,56 @@
 //! Tunables for the equilibrium height closure.
 //!
-//! See [`super`] for the physics motivation and the regime in
-//! which the defaults below are well-conditioned.
+//! See [`super`] for the physics motivation, the quadratic
+//! formula derivation, and the threshold behavior that the
+//! defaults below are calibrated for.
 
 /// Equilibrium height closure tunables.
 ///
-/// Defaults selected to interact cleanly with the Phase 1.2 Davis-
-/// Suppe demo at 64²:
+/// Defaults selected for the Phase 1.2 / 1.3 64²×300-step demo:
 ///
 /// - `h_eq = 2.0` sits **below** the Davis-Suppe plateau
-///   `h_max = 2.5`, so the Phase 1.2 boundary pile-up
-///   (`global_max ≈ 2297` from advection-into-boundary cells) and
-///   the sparse near-boundary saturation tail (`wedge_p99 ≈ 5.83`)
-///   are capped at `h_eq` after a few relaxation time scales. The
-///   Phase 1.2 wedge bulk (`wedge_p95 ≈ 0.376`, `mean ≈ 1.574`)
-///   is below `h_eq` and stays untouched, so the Davis-Suppe
-///   fill-ratio imprint (`fill_near ≈ 0.778`, `fill_far ≈ 0.079`)
-///   is preserved.
+///   `h_max = 2.5` and matches the observed Tibet crustal-
+///   thickness ratio (~70 km plateau vs ~35 km normal crust).
+///   See [`super`] § "Parameter `h_eq = 2.0` (phenomenological)"
+///   for why this is a tunable target, not a derived equilibrium
+///   value.
 ///
-/// - `k_collapse = 1.0` with the Phase 1.1 timestep
-///   `dt ≈ 0.69` gives `k_collapse · dt ≈ 0.69` — under 1, so the
-///   linear-Euler scheme stays in the safe convex-combination
-///   regime (no undershoot of `h_eq`). The [`super::source_term`]
-///   module ships a defensive clamp that catches pathological
-///   timesteps where `k_collapse · dt > 1`.
+/// - `k_collapse = 2.0` is calibrated for the quadratic formula
+///   derived from Molnar & Lyon-Caen 1988 eq. (2). The squared
+///   excess produces a threshold behavior:
+///
+///   - **Small excess** (wedge body cells, < 1 above `h_eq`):
+///     per-step decrement `k · excess² · dt` stays small —
+///     wedge cells relax gradually toward `h_eq` without erasing
+///     the Davis-Suppe fill-ratio imprint.
+///   - **Large excess** (boundary outliers, `excess > 100` in
+///     the Phase 1.2 advection-dominated regime): per-step
+///     decrement overshoots `h_eq`; the safety clamp in
+///     [`super::source_term::apply_equilibrium_height_step`]
+///     holds the cell at `h_eq` — effectively a one-step cap on
+///     outliers.
 ///
 /// `enabled` follows the same W4 watchpoint convention as
 /// [`crate::tectonics_c1::closures::davis_suppe::source_term::DavisSuppeParams`]:
-/// when `false`, the closure is a no-op and the run reproduces the
-/// caller's previous behaviour bit-identically.
+/// when `false`, the closure is a no-op and the run reproduces
+/// the caller's previous behaviour bit-identically.
 #[derive(Clone, Copy, Debug)]
 pub struct EquilibriumHeightParams {
     /// Master enable/disable. When `false`,
     /// [`super::source_term::apply_equilibrium_height_step`] is a
     /// no-op (W4 closure-isolation discipline).
     pub enabled: bool,
-    /// Equilibrium thickness toward which thickened cells collapse.
-    /// Set below `DavisSuppeParams::h_max` so the orogenic wedge
-    /// plateau is the active cap on the simulated state.
+    /// Equilibrium thickness toward which thickened cells
+    /// collapse. Set below `DavisSuppeParams::h_max` so the
+    /// orogenic wedge plateau is the active cap on the simulated
+    /// state.
     pub h_eq: f64,
-    /// Relaxation rate of the one-sided collapse term, in
-    /// `1 / time` units consistent with the time-loop `dt`. Keep
-    /// `k_collapse · dt < 1` to stay in the well-conditioned
-    /// forward-Euler regime; the source-term module clamps to
-    /// `h_eq` if this is violated by a pathological caller.
+    /// Relaxation rate for the **quadratic** collapse term
+    /// `k_collapse · max(0, S̃ − h_eq)²`. Units `1 / (length ·
+    /// time)` consistent with the time-loop `dt`. Calibrated
+    /// against Molnar-Lyon-Caen 1988 ΔPE_A; the safety clamp in
+    /// [`super::source_term`] catches the large-excess outliers
+    /// where one step would overshoot `h_eq`.
     pub k_collapse: f64,
 }
 
@@ -52,7 +59,7 @@ impl Default for EquilibriumHeightParams {
         Self {
             enabled: true,
             h_eq: 2.0,
-            k_collapse: 1.0,
+            k_collapse: 2.0,
         }
     }
 }

--- a/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/params.rs
+++ b/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/params.rs
@@ -1,0 +1,58 @@
+//! Tunables for the equilibrium height closure.
+//!
+//! See [`super`] for the physics motivation and the regime in
+//! which the defaults below are well-conditioned.
+
+/// Equilibrium height closure tunables.
+///
+/// Defaults selected to interact cleanly with the Phase 1.2 Davis-
+/// Suppe demo at 64²:
+///
+/// - `h_eq = 2.0` sits **below** the Davis-Suppe plateau
+///   `h_max = 2.5`, so the Phase 1.2 boundary pile-up
+///   (`global_max ≈ 2297` from advection-into-boundary cells) and
+///   the sparse near-boundary saturation tail (`wedge_p99 ≈ 5.83`)
+///   are capped at `h_eq` after a few relaxation time scales. The
+///   Phase 1.2 wedge bulk (`wedge_p95 ≈ 0.376`, `mean ≈ 1.574`)
+///   is below `h_eq` and stays untouched, so the Davis-Suppe
+///   fill-ratio imprint (`fill_near ≈ 0.778`, `fill_far ≈ 0.079`)
+///   is preserved.
+///
+/// - `k_collapse = 1.0` with the Phase 1.1 timestep
+///   `dt ≈ 0.69` gives `k_collapse · dt ≈ 0.69` — under 1, so the
+///   linear-Euler scheme stays in the safe convex-combination
+///   regime (no undershoot of `h_eq`). The [`super::source_term`]
+///   module ships a defensive clamp that catches pathological
+///   timesteps where `k_collapse · dt > 1`.
+///
+/// `enabled` follows the same W4 watchpoint convention as
+/// [`crate::tectonics_c1::closures::davis_suppe::source_term::DavisSuppeParams`]:
+/// when `false`, the closure is a no-op and the run reproduces the
+/// caller's previous behaviour bit-identically.
+#[derive(Clone, Copy, Debug)]
+pub struct EquilibriumHeightParams {
+    /// Master enable/disable. When `false`,
+    /// [`super::source_term::apply_equilibrium_height_step`] is a
+    /// no-op (W4 closure-isolation discipline).
+    pub enabled: bool,
+    /// Equilibrium thickness toward which thickened cells collapse.
+    /// Set below `DavisSuppeParams::h_max` so the orogenic wedge
+    /// plateau is the active cap on the simulated state.
+    pub h_eq: f64,
+    /// Relaxation rate of the one-sided collapse term, in
+    /// `1 / time` units consistent with the time-loop `dt`. Keep
+    /// `k_collapse · dt < 1` to stay in the well-conditioned
+    /// forward-Euler regime; the source-term module clamps to
+    /// `h_eq` if this is violated by a pathological caller.
+    pub k_collapse: f64,
+}
+
+impl Default for EquilibriumHeightParams {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            h_eq: 2.0,
+            k_collapse: 1.0,
+        }
+    }
+}

--- a/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/source_term.rs
+++ b/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/source_term.rs
@@ -1,0 +1,209 @@
+//! Per-time-step application of the equilibrium height closure.
+//!
+//! See the parent module ([`super`]) for the physics derivation,
+//! the global-cell application rationale, and the interaction
+//! with Phase 1.2's Davis-Suppe imprint.
+
+use crate::tectonics_v2::field::Field2D;
+
+use super::params::EquilibriumHeightParams;
+
+/// Apply one forward-Euler step of the equilibrium-height closure
+/// to the `S̃` field, **in place**.
+///
+/// For each cell `c`:
+///
+/// ```text
+///     S̃_new(c) = S̃(c) − k_collapse · max(0, S̃(c) − h_eq) · dt
+/// ```
+///
+/// with a defensive clamp at `h_eq` (see the in-function comment
+/// for why this is non-physical safety, not part of the model).
+///
+/// Unlike
+/// [`super::super::davis_suppe::source_term::apply_davis_suppe_step`],
+/// this closure does **not** skip any cell category: boundary
+/// cells, cratonic cells, oceanic cells, wedge-body cells — all
+/// equally subject to the same gravitational stability criterion.
+/// That global application is what makes equilibrium height the
+/// first effective sink in C1 (Phase 1.2 Davis-Suppe is source-
+/// only, applied selectively on upper-plate wedge bodies).
+///
+/// Inputs:
+/// - `s`: mutable `S̃` field, updated in place
+/// - `params`: closure tunables (see
+///   [`EquilibriumHeightParams`])
+/// - `dt`: time step in the same units as `1 / k_collapse`
+pub fn apply_equilibrium_height_step(
+    s: &mut Field2D,
+    params: &EquilibriumHeightParams,
+    dt: f64,
+) {
+    if !params.enabled {
+        return;
+    }
+    let nx = s.nx();
+    let ny = s.ny();
+    let h_eq = params.h_eq;
+    let k_collapse = params.k_collapse;
+    for j in 0..ny {
+        for i in 0..nx {
+            let s_now = s.get(i, j);
+            let excess = s_now - h_eq;
+            if excess <= 0.0 {
+                continue;
+            }
+            let mut s_new = s_now - k_collapse * excess * dt;
+            // Safety clamp: prevent undershoot of h_eq if k_collapse · dt > 1
+            // This is defensive (not physically meaningful) — in normal
+            // operation k_collapse · dt << 1.
+            if s_new < h_eq {
+                s_new = h_eq;
+            }
+            s.set(i, j, s_new);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fill a fresh `nx × ny` field with a uniform `value`.
+    fn fill_with(nx: usize, ny: usize, value: f64) -> Field2D {
+        let mut s = Field2D::new(nx, ny);
+        for j in 0..ny {
+            for i in 0..nx {
+                s.set(i, j, value);
+            }
+        }
+        s
+    }
+
+    #[test]
+    fn no_op_below_h_eq() {
+        // S̃ uniformly under h_eq → asymmetric closure must not act.
+        let params = EquilibriumHeightParams::default();
+        let initial = 1.0;
+        assert!(
+            initial < params.h_eq,
+            "test premise: initial S̃ must be below h_eq"
+        );
+        let mut s = fill_with(4, 4, initial);
+        let before = s.data().to_vec();
+        apply_equilibrium_height_step(&mut s, &params, 1.0);
+        let after = s.data();
+        for k in 0..after.len() {
+            assert_eq!(
+                before[k], after[k],
+                "S̃ below h_eq must not change; mismatch at flat index {k}"
+            );
+        }
+    }
+
+    #[test]
+    fn collapse_above_h_eq() {
+        // S̃ = 3.0, h_eq = 2.0, k_collapse = 1.0, dt = 0.1
+        //   excess    = 1.0
+        //   decrement = 1.0 · 1.0 · 0.1 = 0.1
+        //   S̃_new    = 3.0 - 0.1 = 2.9
+        // k_collapse · dt = 0.1 « 1 → clamp inactive, exact formula.
+        let params = EquilibriumHeightParams::default();
+        let initial = 3.0;
+        let dt = 0.1;
+        let mut s = fill_with(4, 4, initial);
+        apply_equilibrium_height_step(&mut s, &params, dt);
+        let expected = initial - params.k_collapse * (initial - params.h_eq) * dt;
+        for j in 0..s.ny() {
+            for i in 0..s.nx() {
+                let got = s.get(i, j);
+                assert!(
+                    (got - expected).abs() < 1e-12,
+                    "expected S̃ = {expected}, got {got} at ({i},{j})"
+                );
+                assert!(got < initial, "collapse must reduce S̃");
+                assert!(
+                    got > params.h_eq,
+                    "single subcritical step from S̃=3 must not reach h_eq; got {got}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn smooth_at_h_eq_boundary() {
+        // S̃ exactly at h_eq: excess = 0 → no change. Locks the
+        // closure against numerical "kicks" through the threshold
+        // when the system sits at equilibrium.
+        let params = EquilibriumHeightParams::default();
+        let mut s = fill_with(4, 4, params.h_eq);
+        let before = s.data().to_vec();
+        apply_equilibrium_height_step(&mut s, &params, 1.0);
+        let after = s.data();
+        for k in 0..after.len() {
+            assert_eq!(
+                before[k], after[k],
+                "S̃ at h_eq must not change; mismatch at flat index {k}"
+            );
+        }
+    }
+
+    #[test]
+    fn disabled_no_op() {
+        // enabled = false → bit-identical pre/post regardless of
+        // input values (including cells well above h_eq). Mirrors
+        // the W4 closure-isolation discipline used by Davis-Suppe.
+        let params = EquilibriumHeightParams {
+            enabled: false,
+            ..EquilibriumHeightParams::default()
+        };
+        let mut s = fill_with(4, 4, 5.0); // uniformly above h_eq
+        // Sprinkle non-uniform values so a forgotten branch can't
+        // pass by accident on a uniform field.
+        s.set(0, 0, 100.0);
+        s.set(1, 2, -3.0);
+        s.set(3, 3, params.h_eq);
+        let before = s.data().to_vec();
+        apply_equilibrium_height_step(&mut s, &params, 1.0);
+        let after = s.data();
+        for k in 0..after.len() {
+            assert_eq!(
+                before[k], after[k],
+                "disabled closure must not touch any cell; mismatch at flat index {k}"
+            );
+        }
+    }
+
+    #[test]
+    fn never_undershoots_h_eq() {
+        // Pathological k_collapse · dt = 100 — without the safety
+        // clamp this would predict S̃_new = 3 - 100 · (3-2) = -97.
+        // The clamp must hold S̃_new at h_eq = 2.
+        //
+        // This test locks the *defensive* clamp; in normal use
+        // k_collapse · dt « 1 and the clamp never triggers.
+        let params = EquilibriumHeightParams {
+            k_collapse: 100.0,
+            ..EquilibriumHeightParams::default()
+        };
+        let initial = 3.0;
+        let dt = 1.0;
+        let predicted_unclamped = initial - params.k_collapse * (initial - params.h_eq) * dt;
+        assert!(
+            predicted_unclamped < params.h_eq,
+            "test premise: unclamped prediction must undershoot h_eq (got {predicted_unclamped})"
+        );
+        let mut s = fill_with(4, 4, initial);
+        apply_equilibrium_height_step(&mut s, &params, dt);
+        for j in 0..s.ny() {
+            for i in 0..s.nx() {
+                let got = s.get(i, j);
+                assert_eq!(
+                    got, params.h_eq,
+                    "safety clamp must hold S̃ at h_eq; got {got}, expected {} at ({i},{j})",
+                    params.h_eq
+                );
+            }
+        }
+    }
+}

--- a/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/source_term.rs
+++ b/crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/source_term.rs
@@ -1,8 +1,9 @@
 //! Per-time-step application of the equilibrium height closure.
 //!
-//! See the parent module ([`super`]) for the physics derivation,
-//! the global-cell application rationale, and the interaction
-//! with Phase 1.2's Davis-Suppe imprint.
+//! See the parent module ([`super`]) for the physics derivation
+//! (quadratic per Molnar & Lyon-Caen 1988 eq. 2), the global-cell
+//! application rationale, and the interaction with Phase 1.2's
+//! Davis-Suppe imprint.
 
 use crate::tectonics_v2::field::Field2D;
 
@@ -14,11 +15,13 @@ use super::params::EquilibriumHeightParams;
 /// For each cell `c`:
 ///
 /// ```text
-///     S̃_new(c) = S̃(c) − k_collapse · max(0, S̃(c) − h_eq) · dt
+///     S̃_new(c) = S̃(c) − k_collapse · max(0, S̃(c) − h_eq)² · dt
 /// ```
 ///
 /// with a defensive clamp at `h_eq` (see the in-function comment
-/// for why this is non-physical safety, not part of the model).
+/// for why this triggers as part of the *intended* threshold
+/// behavior for large-excess cells, and is non-physical safety
+/// for the small-excess regime).
 ///
 /// Unlike
 /// [`super::super::davis_suppe::source_term::apply_davis_suppe_step`],
@@ -33,7 +36,8 @@ use super::params::EquilibriumHeightParams;
 /// - `s`: mutable `S̃` field, updated in place
 /// - `params`: closure tunables (see
 ///   [`EquilibriumHeightParams`])
-/// - `dt`: time step in the same units as `1 / k_collapse`
+/// - `dt`: time step in the same units as `1 / (k_collapse ·
+///   length)`
 pub fn apply_equilibrium_height_step(
     s: &mut Field2D,
     params: &EquilibriumHeightParams,
@@ -53,10 +57,15 @@ pub fn apply_equilibrium_height_step(
             if excess <= 0.0 {
                 continue;
             }
-            let mut s_new = s_now - k_collapse * excess * dt;
-            // Safety clamp: prevent undershoot of h_eq if k_collapse · dt > 1
-            // This is defensive (not physically meaningful) — in normal
-            // operation k_collapse · dt << 1.
+            let mut s_new = s_now - k_collapse * excess.powi(2) * dt;
+            // Safety clamp: prevent undershoot of h_eq.
+            // For the quadratic formula this is the intended
+            // threshold behavior on large-excess cells (k · excess²
+            // · dt > excess when k · excess · dt > 1), where one
+            // step caps the cell at h_eq.
+            // For small-excess wedge cells (k · excess · dt « 1)
+            // the clamp never triggers and the formula evolves
+            // smoothly.
             if s_new < h_eq {
                 s_new = h_eq;
             }
@@ -103,17 +112,19 @@ mod tests {
 
     #[test]
     fn collapse_above_h_eq() {
-        // S̃ = 3.0, h_eq = 2.0, k_collapse = 1.0, dt = 0.1
-        //   excess    = 1.0
-        //   decrement = 1.0 · 1.0 · 0.1 = 0.1
-        //   S̃_new    = 3.0 - 0.1 = 2.9
-        // k_collapse · dt = 0.1 « 1 → clamp inactive, exact formula.
+        // Quadratic formula sanity check with the post-E1.bis
+        // defaults (k_collapse = 2.0):
+        //   excess     = 1.0
+        //   decrement  = 2.0 · 1.0² · 0.1 = 0.2
+        //   S̃_new     = 3.0 - 0.2 = 2.8
+        // k · excess · dt = 0.2 « 1 → clamp inactive, exact
+        // quadratic formula.
         let params = EquilibriumHeightParams::default();
         let initial = 3.0;
         let dt = 0.1;
         let mut s = fill_with(4, 4, initial);
         apply_equilibrium_height_step(&mut s, &params, dt);
-        let expected = initial - params.k_collapse * (initial - params.h_eq) * dt;
+        let expected = initial - params.k_collapse * (initial - params.h_eq).powi(2) * dt;
         for j in 0..s.ny() {
             for i in 0..s.nx() {
                 let got = s.get(i, j);
@@ -177,18 +188,23 @@ mod tests {
     #[test]
     fn never_undershoots_h_eq() {
         // Pathological k_collapse · dt = 100 — without the safety
-        // clamp this would predict S̃_new = 3 - 100 · (3-2) = -97.
+        // clamp the quadratic formula would predict
+        //   S̃_new = 3 − 100 · (3 − 2)² · 1 = 3 − 100 = −97.
         // The clamp must hold S̃_new at h_eq = 2.
         //
-        // This test locks the *defensive* clamp; in normal use
-        // k_collapse · dt « 1 and the clamp never triggers.
+        // This test locks the *defensive / threshold* clamp; in
+        // normal use on small-excess wedge cells `k · excess · dt
+        // « 1` and the clamp never triggers. On large-excess
+        // boundary outliers the clamp triggering is the intended
+        // one-step cap (see module docstring).
         let params = EquilibriumHeightParams {
             k_collapse: 100.0,
             ..EquilibriumHeightParams::default()
         };
         let initial = 3.0;
         let dt = 1.0;
-        let predicted_unclamped = initial - params.k_collapse * (initial - params.h_eq) * dt;
+        let predicted_unclamped =
+            initial - params.k_collapse * (initial - params.h_eq).powi(2) * dt;
         assert!(
             predicted_unclamped < params.h_eq,
             "test premise: unclamped prediction must undershoot h_eq (got {predicted_unclamped})"

--- a/crates/ymir-core/src/tectonics_c1/closures/mod.rs
+++ b/crates/ymir-core/src/tectonics_c1/closures/mod.rs
@@ -24,3 +24,4 @@
 //!   re-implemented)
 
 pub mod davis_suppe;
+pub mod equilibrium_height;

--- a/crates/ymir-core/src/tectonics_c1/time_loop.rs
+++ b/crates/ymir-core/src/tectonics_c1/time_loop.rs
@@ -11,16 +11,22 @@
 //! not bit-identical). The clean closure-OFF baseline is to call
 //! [`run_advection_only`] directly.
 //!
-//! ## Phase 1.2 contract — [`run_with_closures`]
+//! ## Phase 1.2 / 1.3 contract — [`run_with_closures`]
 //!
-//! Adds the Davis-Suppe orogenic source term after each advection
+//! Adds per-step closure source / sink terms after each advection
 //! step. Per-step structure:
 //!
 //! 1. CFL Δt.
 //! 2. Advect `S̃` and `age` (same as Phase 1.1).
-//! 3. Apply Davis-Suppe source term on upper-plate interior cells
-//!    via [`super::closures::davis_suppe::source_term::apply_davis_suppe_step`].
-//! 4. Diagnostic callback.
+//! 3. Apply Davis-Suppe orogenic source term on upper-plate
+//!    interior cells via
+//!    [`super::closures::davis_suppe::source_term::apply_davis_suppe_step`]
+//!    (Phase 1.2).
+//! 4. Apply equilibrium-height gravitational sink globally via
+//!    [`super::closures::equilibrium_height::source_term::apply_equilibrium_height_step`]
+//!    (Phase 1.3). Strict ordering: AFTER Davis-Suppe — reversing
+//!    would oscillate around `h_eq` instead of converging.
+//! 5. Diagnostic callback.
 //!
 //! ## Static-classification optimisation
 //!
@@ -43,6 +49,8 @@ use crate::tectonics_v2::field::{Field2D, PeriodicIndex};
 
 use super::boundary_classification::classify_boundaries;
 use super::closures::davis_suppe::source_term::{apply_davis_suppe_step, DavisSuppeParams};
+use super::closures::equilibrium_height::params::EquilibriumHeightParams;
+use super::closures::equilibrium_height::source_term::apply_equilibrium_height_step;
 use super::distance_field::wedge_distance_intra_plate;
 use super::kinematics::PlateKinematics;
 use super::state::C1State;
@@ -139,21 +147,45 @@ fn fill_velocity_field(
 /// Bundle of all C1 closures and their parameters.
 ///
 /// Each closure is independently togglable via its own `enabled`
-/// flag. The bundle grows alongside the C1 milestone:
+/// flag (W4 isolation discipline). The bundle grows alongside the
+/// C1 milestone:
 ///
-/// - Phase 1.2 (Issue #123) — `davis_suppe` (this issue).
-/// - Phase 1.3 — `equilibrium_height` (Molnar-Lyon-Caen). TBA.
+/// - Phase 1.2 (Issue #123) — `davis_suppe` (orogenic source).
+/// - Phase 1.3 (Issue #125) — `equilibrium_height` (gravitational
+///   collapse sink, Molnar-Lyon-Caen).
 /// - Phase 1.4 — `macro_erosion` (Whipple-Tucker) and isostasy
 ///   hook. TBA.
 /// - Phase 2 — `parsons_sclater` (oceanic bathymetry). TBA.
+///
+/// ## Default-behaviour caveat
+///
+/// `C1Closures::default()` enables **both** Davis-Suppe and
+/// equilibrium-height. Tests written for a Phase-1.2-only regime
+/// (where the unbounded boundary pile-up `global_max ≈ 2297` is a
+/// load-bearing observable) must explicitly disable
+/// `equilibrium_height`:
+///
+/// ```ignore
+/// let closures = C1Closures {
+///     davis_suppe: DavisSuppeParams::default(),
+///     equilibrium_height: EquilibriumHeightParams {
+///         enabled: false,
+///         ..EquilibriumHeightParams::default()
+///     },
+/// };
+/// ```
 #[derive(Clone, Copy, Debug)]
 pub struct C1Closures {
     pub davis_suppe: DavisSuppeParams,
+    pub equilibrium_height: EquilibriumHeightParams,
 }
 
 impl Default for C1Closures {
     fn default() -> Self {
-        Self { davis_suppe: DavisSuppeParams::default() }
+        Self {
+            davis_suppe: DavisSuppeParams::default(),
+            equilibrium_height: EquilibriumHeightParams::default(),
+        }
     }
 }
 
@@ -219,7 +251,7 @@ pub fn run_with_closures<F>(
         std::mem::swap(&mut state.s, &mut s_next);
         std::mem::swap(&mut state.age, &mut age_next);
 
-        // 2. Davis-Suppe orogenic source term.
+        // 2. Davis-Suppe orogenic source term (Phase 1.2).
         apply_davis_suppe_step(
             &mut state.s,
             &state.plate_id,
@@ -230,7 +262,16 @@ pub fn run_with_closures<F>(
             dt,
         );
 
-        // 3. (Future closures land here.)
+        // 3. Equilibrium height sink (Phase 1.3).
+        // Order critical: AFTER Davis-Suppe.
+        // Reverse order causes oscillation:
+        //   - Equilibrium caps at h_eq
+        //   - Davis-Suppe re-injects mass above h_eq
+        //   - Next step: excess from re-injection
+        //   - Etc., oscillation around h_eq instead of stable equilibrium.
+        apply_equilibrium_height_step(&mut state.s, &closures.equilibrium_height, dt);
+
+        // 4. (Future closures land here — Phase 1.4 erosion.)
 
         on_step(step, state);
     }

--- a/crates/ymir-core/src/tectonics_v2/workflow/macro_redistribution.rs
+++ b/crates/ymir-core/src/tectonics_v2/workflow/macro_redistribution.rs
@@ -80,7 +80,7 @@ pub struct RedistributionStats {
 ///
 /// See module docstring for the algorithm. Returns
 /// [`RedistributionStats`] for the orchestrator's per-cycle metrics
-/// (R3 wires this into [`super::CycleOutput`]).
+/// (R3 wires this into [`super::CycleOutputV2`]).
 ///
 /// Only `alpha`, `isostatic_rebound_ratio`, and `max_drainage_distance`
 /// from `params` are consumed — `n_cycles` and `k_cycle` are

--- a/crates/ymir-core/src/tectonics_v2/workflow/mod.rs
+++ b/crates/ymir-core/src/tectonics_v2/workflow/mod.rs
@@ -34,6 +34,7 @@
 
 pub mod drainage;
 pub mod macro_redistribution;
+pub mod phase_a_common;
 
 // Issue #117 HC4 / Phase 1.3 H2 — Phase A's v2 path
 // (`run_phase_a_cycle_v2`) couples to the retired harness; gated

--- a/crates/ymir-core/src/tectonics_v2/workflow/mod.rs
+++ b/crates/ymir-core/src/tectonics_v2/workflow/mod.rs
@@ -21,7 +21,7 @@
 //! [`WorkflowConfig::Disabled`] passthrough. The Disabled variant is
 //! the default, structurally short-circuits every workflow branch,
 //! and is the **bit-identical contract** for Steps 0–13.5 regression:
-//! calling [`phase_a::run_phase_a_cycle`] with `Disabled` is exactly
+//! calling [`phase_a::run_phase_a_cycle_v2`] with `Disabled` is exactly
 //! [`crate::tectonics_v2::diagnostics::harness::run_baseline`] under
 //! the hood, no extra allocation, no extra RNG consumption, no path
 //! deviation — see `tests/v2_workflow_disabled_regression.rs`.
@@ -35,14 +35,15 @@
 pub mod drainage;
 pub mod macro_redistribution;
 
-// Issue #117 HC4 — Phase A currently couples to the retired harness
-// (`run_baseline_with_progress`); gated until Phase 1.3 H2 ships the
-// C1 path. Phase B is paradigm-agnostic at runtime (consumes
-// `Field2D + sea_level + iso_config`, no `BaselineResult`); the
-// Phase 1.3 H1 audit confirmed it is safe to un-gate.
-// See `docs/migrations/harness_paradigm_agnostic.md` § 2.2.
+// Issue #117 HC4 / Phase 1.3 H2 — Phase A's v2 path
+// (`run_phase_a_cycle_v2`) couples to the retired harness; gated
+// under `v2_legacy`. The C1 path (`run_phase_a_cycle_c1`, Commit 4
+// of H2) is default-features-on. Phase B is paradigm-agnostic at
+// runtime (consumes `Field2D + sea_level + iso_config`, no
+// `BaselineResult`); H1 audit § 2.2 confirmed it is safe to un-gate.
+// See `docs/migrations/harness_paradigm_agnostic.md`.
 #[cfg(feature = "v2_legacy")]
-pub mod phase_a;
+pub mod phase_a_v2;
 pub mod phase_b;
 
 use serde::{Deserialize, Serialize};
@@ -53,9 +54,9 @@ use crate::terrain::upscale::FbmUpscaleConfig;
 pub use macro_redistribution::RedistributionStats;
 
 #[cfg(feature = "v2_legacy")]
-pub use phase_a::{
-    final_state_to_continuation, run_phase_a_cycle, run_phase_a_cycle_with_progress,
-    run_phase_a_loop,
+pub use phase_a_v2::{
+    final_state_to_continuation_v2, run_phase_a_cycle_v2, run_phase_a_cycle_with_progress_v2,
+    run_phase_a_loop_v2,
 };
 pub use phase_b::run_phase_b;
 
@@ -69,7 +70,7 @@ pub use phase_b::run_phase_b;
 ///
 /// Default: `Disabled` — preserves Step 11 standalone behaviour
 /// bit-for-bit. The Step 12 acceptance #15 regression test verifies
-/// this by calling [`run_phase_a_cycle`] with `Disabled` and comparing
+/// this by calling [`run_phase_a_cycle_v2`] with `Disabled` and comparing
 /// final-state byte-by-byte against a direct `run_baseline` call.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub enum WorkflowConfig {
@@ -223,7 +224,7 @@ impl Default for PhaseBParams {
 /// shared pass as `workflow::phase_a_common`).
 ///
 /// Carrying them in a dedicated struct (rather than as flat fields
-/// on the paradigm-specific `CycleOutput*` envelopes) keeps the
+/// on the paradigm-specific `CycleOutputV2*` envelopes) keeps the
 /// two paths from drifting silently. See
 /// `docs/migrations/harness_paradigm_agnostic.md` § R3.
 #[derive(Clone, Copy, Debug, Default)]
@@ -267,28 +268,28 @@ pub struct CycleOutputCommon {
 /// All Disabled-cycle scalars in `common` are zeroed/`None` — the
 /// regression test `v2_workflow_disabled_regression` pins this
 /// contract.
-// Issue #117 / Phase 1.3 H2 — `CycleOutput` carries `BaselineResult`
+// Issue #117 / Phase 1.3 H2 — `CycleOutputV2` carries `BaselineResult`
 // which is v2-specific. Gated under `v2_legacy`; the paradigm-
 // agnostic scalars have moved to [`CycleOutputCommon`] which is not
 // gated.
 #[cfg(feature = "v2_legacy")]
 #[derive(Debug)]
-pub struct CycleOutput {
+pub struct CycleOutputV2 {
     pub baseline: crate::tectonics_v2::diagnostics::harness::BaselineResult,
     pub common: CycleOutputCommon,
 }
 
-/// Output of the full Phase A loop (one [`CycleOutput`] per cycle).
+/// Output of the full Phase A loop (one [`CycleOutputV2`] per cycle).
 ///
 /// When `WorkflowConfig::Disabled`, the vec contains exactly one
 /// entry — the direct `run_baseline` passthrough — so the regression
 /// contract holds: `output.cycles[0].baseline ≡ run_baseline(cfg)`.
-// Issue #117 — `PhaseAOutput` transitively gates because it carries
-// `Vec<CycleOutput>` (which references retired harness types).
+// Issue #117 — `PhaseAOutputV2` transitively gates because it carries
+// `Vec<CycleOutputV2>` (which references retired harness types).
 #[cfg(feature = "v2_legacy")]
 #[derive(Debug)]
-pub struct PhaseAOutput {
-    pub cycles: Vec<CycleOutput>,
+pub struct PhaseAOutputV2 {
+    pub cycles: Vec<CycleOutputV2>,
 }
 
 /// Output of Phase B HD finalization.

--- a/crates/ymir-core/src/tectonics_v2/workflow/mod.rs
+++ b/crates/ymir-core/src/tectonics_v2/workflow/mod.rs
@@ -38,13 +38,14 @@ pub mod phase_a_common;
 
 // Issue #117 HC4 / Phase 1.3 H2 — Phase A's v2 path
 // (`run_phase_a_cycle_v2`) couples to the retired harness; gated
-// under `v2_legacy`. The C1 path (`run_phase_a_cycle_c1`, Commit 4
-// of H2) is default-features-on. Phase B is paradigm-agnostic at
-// runtime (consumes `Field2D + sea_level + iso_config`, no
+// under `v2_legacy`. The C1 path (`run_phase_a_cycle_c1`) is
+// default-features-on. Phase B is paradigm-agnostic at runtime
+// (consumes `Field2D + sea_level + iso_config`, no
 // `BaselineResult`); H1 audit § 2.2 confirmed it is safe to un-gate.
 // See `docs/migrations/harness_paradigm_agnostic.md`.
 #[cfg(feature = "v2_legacy")]
 pub mod phase_a_v2;
+pub mod phase_a_c1;
 pub mod phase_b;
 
 use serde::{Deserialize, Serialize};
@@ -59,6 +60,7 @@ pub use phase_a_v2::{
     final_state_to_continuation_v2, run_phase_a_cycle_v2, run_phase_a_cycle_with_progress_v2,
     run_phase_a_loop_v2,
 };
+pub use phase_a_c1::{run_phase_a_cycle_c1, PhaseACycleInputC1, PhaseACycleOutputC1};
 pub use phase_b::run_phase_b;
 
 /// Top-level workflow on/off switch.

--- a/crates/ymir-core/src/tectonics_v2/workflow/mod.rs
+++ b/crates/ymir-core/src/tectonics_v2/workflow/mod.rs
@@ -35,13 +35,14 @@
 pub mod drainage;
 pub mod macro_redistribution;
 
-// Issue #117 — Phase A + Phase B currently call into the retired
-// harness (`run_baseline_with_progress`). Per audit HC4, gate the
-// orchestrator entry points until C1's paradigm-agnostic per-cycle
-// tectonic runner reintroduces them in Phase 1.3 (§7 C1.md).
+// Issue #117 HC4 — Phase A currently couples to the retired harness
+// (`run_baseline_with_progress`); gated until Phase 1.3 H2 ships the
+// C1 path. Phase B is paradigm-agnostic at runtime (consumes
+// `Field2D + sea_level + iso_config`, no `BaselineResult`); the
+// Phase 1.3 H1 audit confirmed it is safe to un-gate.
+// See `docs/migrations/harness_paradigm_agnostic.md` § 2.2.
 #[cfg(feature = "v2_legacy")]
 pub mod phase_a;
-#[cfg(feature = "v2_legacy")]
 pub mod phase_b;
 
 use serde::{Deserialize, Serialize};
@@ -56,7 +57,6 @@ pub use phase_a::{
     final_state_to_continuation, run_phase_a_cycle, run_phase_a_cycle_with_progress,
     run_phase_a_loop,
 };
-#[cfg(feature = "v2_legacy")]
 pub use phase_b::run_phase_b;
 
 /// Top-level workflow on/off switch.
@@ -212,24 +212,22 @@ impl Default for PhaseBParams {
     }
 }
 
-/// Output of a single Phase A cycle.
+/// Paradigm-agnostic per-cycle Phase A diagnostics.
 ///
-/// `baseline` carries the full
-/// [`crate::tectonics_v2::diagnostics::harness::BaselineResult`] from
-/// the cycle's tectonic run (final state, metrics, config dump). Under
-/// `WorkflowConfig::Enabled`, the `final_state` is post-erosion +
-/// post-reclassification + post-craton-recompute (i.e. the state the
-/// next cycle's continuation should warm-start from).
+/// These five scalars describe the cycle's macro-redistribution +
+/// reclassification + craton-recompute pass and are **paradigm-
+/// independent**: both the v2 path and the C1 path populate them
+/// from the same downstream code in
+/// [`crate::tectonics_v2::workflow::macro_redistribution`] and the
+/// shared post-tectonic-step pass (Phase 1.3 H2 introduces this
+/// shared pass as `workflow::phase_a_common`).
 ///
-/// All Disabled-cycle scalars are zeroed/`None` — the regression test
-/// `v2_workflow_disabled_regression` pins this contract.
-// Issue #117 — `CycleOutput` carries `BaselineResult` which retires with
-// the harness. Gated until C1's per-cycle tectonic runner provides a
-// paradigm-agnostic replacement.
-#[cfg(feature = "v2_legacy")]
-#[derive(Debug)]
-pub struct CycleOutput {
-    pub baseline: crate::tectonics_v2::diagnostics::harness::BaselineResult,
+/// Carrying them in a dedicated struct (rather than as flat fields
+/// on the paradigm-specific `CycleOutput*` envelopes) keeps the
+/// two paths from drifting silently. See
+/// `docs/migrations/harness_paradigm_agnostic.md` § R3.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CycleOutputCommon {
     /// Gross integrated `Σ Δh` over continental cells (low-res erosion
     /// pass output). Net mass change is `-(1 - β) · volume_removed`.
     pub erosion_volume_removed: f64,
@@ -248,9 +246,36 @@ pub struct CycleOutput {
     pub mass_drift: f64,
     /// Fraction of cells whose `cratonic_factor` changed by more than
     /// `1e-9` between pre-cycle and post-cycle recompute. `None` when
-    /// no `CratonicConfig::Enabled` was active. The Phase 4
+    /// no `CratonicConfig::Enabled` was active (or the paradigm has
+    /// no equivalent — C1 currently does not). The Phase 4
     /// multi-cycle metrics dashboard accumulates these per cycle.
     pub craton_recomputation_change: Option<f64>,
+}
+
+/// Output of a single Phase A cycle on the **v2 path**.
+///
+/// `baseline` carries the full
+/// [`crate::tectonics_v2::diagnostics::harness::BaselineResult`] from
+/// the cycle's tectonic run (final state, metrics, config dump). Under
+/// `WorkflowConfig::Enabled`, the `final_state` is post-erosion +
+/// post-reclassification + post-craton-recompute (i.e. the state the
+/// next cycle's continuation should warm-start from).
+///
+/// `common` carries the paradigm-agnostic per-cycle diagnostics shared
+/// with the C1 path; see [`CycleOutputCommon`].
+///
+/// All Disabled-cycle scalars in `common` are zeroed/`None` — the
+/// regression test `v2_workflow_disabled_regression` pins this
+/// contract.
+// Issue #117 / Phase 1.3 H2 — `CycleOutput` carries `BaselineResult`
+// which is v2-specific. Gated under `v2_legacy`; the paradigm-
+// agnostic scalars have moved to [`CycleOutputCommon`] which is not
+// gated.
+#[cfg(feature = "v2_legacy")]
+#[derive(Debug)]
+pub struct CycleOutput {
+    pub baseline: crate::tectonics_v2::diagnostics::harness::BaselineResult,
+    pub common: CycleOutputCommon,
 }
 
 /// Output of the full Phase A loop (one [`CycleOutput`] per cycle).

--- a/crates/ymir-core/src/tectonics_v2/workflow/phase_a.rs
+++ b/crates/ymir-core/src/tectonics_v2/workflow/phase_a.rs
@@ -39,7 +39,7 @@
 //! `v2_workflow_disabled_regression::workflow_disabled_run_phase_a_cycle_is_bit_identical_to_run_baseline`
 //! pins this contract byte-for-byte.
 
-use super::{macro_redistribution, CycleOutput, PhaseAOutput, WorkflowConfig};
+use super::{macro_redistribution, CycleOutput, CycleOutputCommon, PhaseAOutput, WorkflowConfig};
 use crate::tectonics::isostasy::IsostasyConfig;
 use crate::tectonics_v2::boundaries::{PlateType, PlateTypeField};
 use crate::tectonics_v2::cratonic::factor::build_cratonic_factor_field;
@@ -97,11 +97,7 @@ where
             let baseline = run_baseline_with_progress(cfg, on_progress);
             CycleOutput {
                 baseline,
-                erosion_volume_removed: 0.0,
-                erosion_peak_delta_h: 0.0,
-                sea_level_normalized: 0.0,
-                mass_drift: 0.0,
-                craton_recomputation_change: None,
+                common: CycleOutputCommon::default(),
             }
         }
         WorkflowConfig::Enabled(params) => {
@@ -251,11 +247,13 @@ where
 
             CycleOutput {
                 baseline,
-                erosion_volume_removed: stats.total_eroded,
-                erosion_peak_delta_h: stats.peak_delta_h,
-                sea_level_normalized: sea_level_ref,
-                mass_drift: mass_after - mass_before,
-                craton_recomputation_change: craton_change,
+                common: CycleOutputCommon {
+                    erosion_volume_removed: stats.total_eroded,
+                    erosion_peak_delta_h: stats.peak_delta_h,
+                    sea_level_normalized: sea_level_ref,
+                    mass_drift: mass_after - mass_before,
+                    craton_recomputation_change: craton_change,
+                },
             }
         }
     }

--- a/crates/ymir-core/src/tectonics_v2/workflow/phase_a_c1.rs
+++ b/crates/ymir-core/src/tectonics_v2/workflow/phase_a_c1.rs
@@ -1,0 +1,245 @@
+//! Phase A — low-res loop orchestration, **C1 path**.
+//!
+//! Per Phase 1.3 H2 (Issue #125), this module is the C1-paradigm
+//! Phase A entry point — **default-features-on, no `v2_legacy`
+//! gate**. The structurally-identical v2-paradigm path lives at
+//! [`super::phase_a_v2`] (gated under `v2_legacy`).
+//!
+//! ## Asymmetric API by design
+//!
+//! Per the H1 audit's R1 mitigation, the C1 path API is **not**
+//! force-symmetric with v2. The two paradigms have structurally
+//! different state and progress shapes:
+//!
+//! | Aspect              | v2 path                          | C1 path (this module)              |
+//! |---------------------|----------------------------------|------------------------------------|
+//! | Tectonic input      | `&BaselineConfig` (23-field)     | `&mut C1State` + `&PlateKinematics` + `&C1Closures` + `&C1TimeLoopConfig` |
+//! | Per-step progress   | `FnMut(&StepProgress<'_>) -> bool` (Stokes residuals, nonlinear iter count, …) | not exposed — see "deferred" note below |
+//! | Result envelope     | `CycleOutputV2 { baseline: BaselineResult, common: CycleOutputCommon }` | `PhaseACycleOutputC1 { common, new_cratonic_factor }` — no `baseline` |
+//! | State threading     | `final_state_to_continuation_v2` (returns `ContinuationState` for cycle N+1 warm-start) | implicit: caller owns `&mut C1State` across cycles |
+//!
+//! The shared post-tectonic-step pass
+//! ([`super::phase_a_common::apply_post_tectonic`]) handles the
+//! paradigm-agnostic part (sea-level → macro-redistribution →
+//! reclassification → cratonic recompute) and is called identically
+//! by both paths.
+//!
+//! ## On_progress variant deferred to Phase 4
+//!
+//! The v2 path ships both `run_phase_a_cycle_v2` and
+//! `run_phase_a_cycle_with_progress_v2` so the viz bridge thread
+//! can stream `V2Event::Progress` events to the metrics dashboard.
+//! The C1 path ships only the no-progress variant for Phase 1.3 —
+//! the C1 viz bridge will be added in a later phase (Phase 4 UI
+//! integration per the milestone roadmap), and at that point a
+//! `run_phase_a_cycle_with_progress_c1` callback signature can be
+//! designed in concert with the bridge consumers. The C1
+//! `time_loop::run_with_closures` already takes a per-step
+//! callback (`FnMut(usize, &C1State)`), so the lift is trivial
+//! once the consumer side is ready.
+
+use crate::tectonics::isostasy::IsostasyConfig;
+use crate::tectonics_v2::cratonic::CratonicConfigEnabled;
+use crate::tectonics_v2::field::Field2D;
+
+use crate::tectonics_c1::kinematics::PlateKinematics;
+use crate::tectonics_c1::state::C1State;
+use crate::tectonics_c1::time_loop::{run_with_closures, C1Closures, C1TimeLoopConfig};
+
+use super::phase_a_common::{apply_post_tectonic, extract_per_plate_type, PostTectonicInput};
+use super::{CycleOutputCommon, WorkflowConfig};
+
+/// Inputs to [`run_phase_a_cycle_c1`].
+///
+/// `state` is mutated in place by the tectonic step (advection
+/// of `S̃` and `age`, plus per-cell closures from `closures`).
+/// When `wf == Enabled(_)`, the shared post-tectonic pass mutates
+/// `state.s` again (macro-redistribution) and `state.plate_type`
+/// (reclassification).
+///
+/// `cratonic_config` is optional: C1 Phase 1.3 has no cratonic-
+/// factor field on `C1State` (only a `BoolField cratonic_mask`),
+/// so the recomputed factor returned in
+/// [`PhaseACycleOutputC1::new_cratonic_factor`] would be discarded
+/// by the caller. Set to `None` to skip the recompute step
+/// entirely; Phase 1.4+ may add a `Field2D` cratonic factor to
+/// `C1State` and consume the output.
+pub struct PhaseACycleInputC1<'a> {
+    pub state: &'a mut C1State,
+    pub kinematics: &'a PlateKinematics,
+    pub closures: &'a C1Closures,
+    pub time_loop_config: &'a C1TimeLoopConfig,
+    pub iso_config: &'a IsostasyConfig,
+    pub cratonic_config: Option<&'a CratonicConfigEnabled>,
+}
+
+/// Output of [`run_phase_a_cycle_c1`].
+///
+/// Asymmetric vs v2's `CycleOutputV2`: no `baseline` field because
+/// C1 mutates `&mut C1State` in place — the caller already holds
+/// the post-cycle state.
+pub struct PhaseACycleOutputC1 {
+    pub common: CycleOutputCommon,
+    /// Recomputed cratonic factor, or `None` when
+    /// `input.cratonic_config` was `None` (or `wf == Disabled`).
+    /// Discarded by C1 Phase 1.3 callers (no consuming field on
+    /// `C1State`); reserved for Phase 1.4+.
+    pub new_cratonic_factor: Option<Field2D>,
+}
+
+/// Run a single Phase A cycle on the C1 path.
+///
+/// `Disabled` → run the C1 tectonic sub-cycle (advection + the
+/// per-cell closures in `closures`) and return an empty
+/// `CycleOutputCommon` — no macro-redistribution, no
+/// reclassification, no cratonic recompute. This is the parallel
+/// of v2's `WorkflowConfig::Disabled` bit-identical-to-run-baseline
+/// contract: `run_phase_a_cycle_c1(input, Disabled)` ≡ direct
+/// `run_with_closures(state, ..., |_, _| {})`. See H3 Commit 5 for
+/// the regression test.
+///
+/// `Enabled(params)` → 2-step pipeline:
+///   1. Tectonic — `run_with_closures` (C1 advection + closures).
+///   2. Shared post-tectonic pass — delegates to
+///      [`apply_post_tectonic`] for sea-level, macro-redistribution,
+///      reclassification, and cratonic recompute. The freshly-
+///      recomputed cratonic factor (if any) is returned in
+///      [`PhaseACycleOutputC1::new_cratonic_factor`] for the
+///      caller to install or discard.
+pub fn run_phase_a_cycle_c1(
+    input: PhaseACycleInputC1<'_>,
+    wf: &WorkflowConfig,
+) -> PhaseACycleOutputC1 {
+    let PhaseACycleInputC1 {
+        state,
+        kinematics,
+        closures,
+        time_loop_config,
+        iso_config,
+        cratonic_config,
+    } = input;
+
+    // Step 1 — Tectonic (C1 forward-Euler advection + closures).
+    // C1 has no continuation/warm-start concept (the closures are
+    // per-cell additive and the kinematics are static); the loop
+    // mutates `state` in place.
+    run_with_closures(state, kinematics, time_loop_config, closures, |_, _| {});
+
+    match wf {
+        WorkflowConfig::Disabled => PhaseACycleOutputC1 {
+            common: CycleOutputCommon::default(),
+            new_cratonic_factor: None,
+        },
+        WorkflowConfig::Enabled(params) => {
+            // Capture the pre-reclassification per-plate type for
+            // the D4 "was continental at init" gate. Must happen
+            // BEFORE `apply_post_tectonic` mutates `plate_type`.
+            let original_per_plate_type =
+                extract_per_plate_type(&state.plate_id, &state.plate_type);
+
+            // Step 2 — Shared post-tectonic pass. The struct
+            // literal holds three disjoint borrows of `state` (mut
+            // `s`, shared `plate_id`, mut `plate_type`), which the
+            // borrow checker accepts under the splitting-borrow
+            // rule.
+            let post = apply_post_tectonic(PostTectonicInput {
+                s_field: &mut state.s,
+                plate_id: Some(&state.plate_id),
+                plate_type: Some(&mut state.plate_type),
+                previous_cratonic_factor: None,
+                initial_per_plate_type: Some(&original_per_plate_type),
+                params: &params.phase_a,
+                iso_cfg: iso_config,
+                cratonic_cfg: cratonic_config,
+            });
+
+            PhaseACycleOutputC1 {
+                common: post.common,
+                new_cratonic_factor: post.new_cratonic_factor,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::tectonics_c1::init::init_c1_state_phase_1_1;
+    use crate::tectonics_v2::workflow::WorkflowParams;
+
+    /// Smoke test: a 300-step C1 cycle through the full
+    /// Phase A pipeline (`Enabled`) completes without producing
+    /// NaN/Inf, lands within macro_redistribution's mass-
+    /// conservation budget, and populates the
+    /// `CycleOutputCommon` scalars.
+    ///
+    /// This is a sanity check, **not** a Phase 1.3 acceptance
+    /// test — those live in Stage E3.
+    #[test]
+    fn c1_phase_a_cycle_completes_300_steps() {
+        let grid = 64;
+        let mut state = init_c1_state_phase_1_1(grid, 42);
+        let kinematics = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let time_loop_config = C1TimeLoopConfig {
+            n_steps: 300,
+            dx: 1.0 / grid as f64,
+            dy: 1.0 / grid as f64,
+        };
+        let iso_config = IsostasyConfig::default();
+        let wf = WorkflowConfig::Enabled(WorkflowParams::default());
+
+        let output = run_phase_a_cycle_c1(
+            PhaseACycleInputC1 {
+                state: &mut state,
+                kinematics: &kinematics,
+                closures: &closures,
+                time_loop_config: &time_loop_config,
+                iso_config: &iso_config,
+                cratonic_config: None,
+            },
+            &wf,
+        );
+
+        // Sanity 1 — no NaN / Inf in `S̃`.
+        for &v in state.s.data() {
+            assert!(
+                v.is_finite(),
+                "non-finite S̃ in state after 300 steps + post-pass"
+            );
+        }
+
+        // Sanity 2 — sea-level was computed by the Enabled
+        // post-pass (Disabled would have left this at 0.0).
+        assert!(
+            output.common.sea_level_normalized > 0.0,
+            "sea_level_normalized should be set by Enabled post-pass; got {}",
+            output.common.sea_level_normalized
+        );
+
+        // Sanity 3 — macro_redistribution is mass-conserving by
+        // construction (Step 12 R3 drainage + isostatic rebound).
+        // The `mass_drift` field measures the pre-vs-post-macro
+        // delta inside `apply_post_tectonic` and should be at
+        // machine-precision floor relative to the integrated
+        // mass.
+        let total_mass: f64 = state.s.data().iter().sum();
+        let drift_budget = total_mass.abs() * 1e-9;
+        assert!(
+            output.common.mass_drift.abs() < drift_budget,
+            "macro_redistribution mass drift {} exceeds {:.3e} budget (1e-9 × |mass| = {:.3e}); macro_redistribution must conserve mass",
+            output.common.mass_drift, drift_budget, drift_budget
+        );
+
+        // Sanity 4 — cratonic_config was None → no recompute.
+        assert!(
+            output.new_cratonic_factor.is_none(),
+            "C1 Phase 1.3 default-config call must produce no cratonic factor"
+        );
+        assert!(
+            output.common.craton_recomputation_change.is_none(),
+            "C1 Phase 1.3 default-config call must produce no craton change"
+        );
+    }
+}

--- a/crates/ymir-core/src/tectonics_v2/workflow/phase_a_common.rs
+++ b/crates/ymir-core/src/tectonics_v2/workflow/phase_a_common.rs
@@ -1,0 +1,360 @@
+//! Shared paradigm-agnostic post-tectonic-step pass for Phase A.
+//!
+//! Both the v2 path ([`super::phase_a_v2`]) and the C1 path
+//! ([`super::phase_a_c1`], Commit 4 of Issue #125 H2) need the same
+//! per-cycle pipeline AFTER the tectonic step has updated the
+//! `S̃` field:
+//!
+//! 1. **Sea-level threshold** — compute the adaptive `sea_level_ref`
+//!    in `S̃` space from the current min/max of `S̃` and
+//!    `IsostasyConfig::sea_level_fraction` (the Phase 3.5 fix —
+//!    the original heightmap-space sea_level produced wrong
+//!    thresholds for the reclassification rule).
+//! 2. **Macro mass redistribution** — Step 12 R3 erosion + drainage
+//!    + isostatic rebound, mass-conserving. Mutates `S̃` in place;
+//!    surfaces `erosion_volume_removed` + `erosion_peak_delta_h`
+//!    in [`CycleOutputCommon`].
+//! 3. **Reclassification** — per-cell `plate_type[i,j]` =
+//!    `Continental` iff `S̃[i,j] > sea_level_ref`, else `Oceanic`.
+//!    The Voronoi tessellation (`plate_id`) is static for the run;
+//!    only the per-cell type changes.
+//! 4. **Cratonic factor recompute** — D4 retention rule: a plate
+//!    keeps its continental status iff (a) it was continental at
+//!    init, AND (b) the post-erosion continental cell fraction
+//!    inside the plate is `≥ craton_retention_threshold`. Rebuilds
+//!    the `cratonic_factor: Field2D` via the Step 9 BFS smoothstep
+//!    algorithm.
+//!
+//! All four steps use **paradigm-agnostic types**: `Field2D`,
+//! `PlateIdField`, `PlateTypeField`, `PlateType`, `PhaseAParams`,
+//! `IsostasyConfig`, `CratonicConfigEnabled`. The
+//! `tectonics_v2::cratonic` namespace is data-only and is **not**
+//! gated under `v2_legacy` (it has no Stokes / mantle / slab
+//! dependency); see `docs/migrations/v2_to_c1_attic.md` § §4.8.
+//!
+//! ## Why this is a shared pass, not a trait
+//!
+//! Per the Phase 1.3 H1 audit `docs/migrations/
+//! harness_paradigm_agnostic.md` (Option B chosen), the v2 and C1
+//! tectonic *runners* have structurally different signatures (v2
+//! takes 23-field `BaselineConfig` + returns `BaselineResult`; C1
+//! mutates `&mut C1State` in place). But once the tectonic step
+//! has updated the `S̃` field, **the post-step pipeline is
+//! identical** — it operates on `S̃`, `plate_id`, `plate_type`,
+//! and the per-plate continental classification. Extracting that
+//! pipeline as a function takes care of W2 / W3 / R3 from the
+//! audit doc: single implementation, two callers, no silent
+//! divergence of the shared diagnostics
+//! ([`CycleOutputCommon::mass_drift`],
+//! [`CycleOutputCommon::erosion_volume_removed`], etc.).
+//!
+//! ## What stays paradigm-specific
+//!
+//! - v2's velocity-reset post-macro-redistribution (the
+//!   counter-intuitive D1-ter `v = 0` empirical finding) stays in
+//!   `phase_a_v2.rs` — C1 has no Stokes velocity field.
+//! - v2's `BaselineResult::final_state` install of the new
+//!   `cratonic_factor` stays in `phase_a_v2.rs`. The factor itself
+//!   is paradigm-agnostic (`Field2D`), but where to store it is
+//!   not (`baseline.final_state.cratonic_factor` for v2; C1 has
+//!   no `cratonic_factor` field today — its `C1State.cratonic_mask`
+//!   is a `BoolField`, a different data shape).
+//!
+//! Both paradigm-specific bits are surfaced via
+//! [`PostTectonicOutput`]: the new `cratonic_factor: Option<Field2D>`
+//! is returned, and the caller installs it (or ignores it) per its
+//! state shape. C1 in Phase 1.3 has no cratonic-factor evolution,
+//! so it discards. Phase 1.4+ may add one.
+
+use crate::tectonics::isostasy::IsostasyConfig;
+use crate::tectonics_v2::boundaries::{PlateType, PlateTypeField};
+use crate::tectonics_v2::cratonic::factor::build_cratonic_factor_field;
+use crate::tectonics_v2::cratonic::CratonicConfigEnabled;
+use crate::tectonics_v2::field::Field2D;
+use crate::tectonics_v2::voronoi::{PlateIdField, VoronoiPlates};
+
+use super::{macro_redistribution, CycleOutputCommon, PhaseAParams};
+
+/// Inputs to [`apply_post_tectonic`].
+///
+/// All types are paradigm-agnostic (used identically by the v2 and
+/// C1 Phase A paths). The caller is responsible for capturing
+/// `initial_per_plate_type` from the pre-reclassification
+/// `plate_type` field via [`extract_per_plate_type`] **before**
+/// invoking this function.
+pub struct PostTectonicInput<'a> {
+    /// `S̃` field, mutated in place by the macro-redistribution
+    /// step.
+    pub s_field: &'a mut Field2D,
+    /// Voronoi plate-id field. Static for the run. `None` →
+    /// reclassification and craton recompute skipped (no plate
+    /// concept at this call site).
+    pub plate_id: Option<&'a PlateIdField>,
+    /// Per-cell plate-type field, mutated in place by the
+    /// reclassification step. `None` → step skipped.
+    pub plate_type: Option<&'a mut PlateTypeField>,
+    /// Previous-cycle cratonic factor field (for the
+    /// `craton_recomputation_change` diagnostic). `None` → no
+    /// change measurement, only forward computation.
+    pub previous_cratonic_factor: Option<&'a Field2D>,
+    /// Per-plate type at run init (D4 "was continental at init"
+    /// gate). Caller-captured via [`extract_per_plate_type`].
+    /// `None` → craton recompute skipped.
+    pub initial_per_plate_type: Option<&'a [PlateType]>,
+    /// Phase A loop parameters (alpha, isostatic_rebound_ratio,
+    /// max_drainage_distance) consumed by
+    /// [`super::macro_redistribution::apply`].
+    pub params: &'a PhaseAParams,
+    /// Isostasy configuration. The function reads only
+    /// `sea_level_fraction` from this — the Phase 3.5 S̃-space
+    /// sea-level formula.
+    pub iso_cfg: &'a IsostasyConfig,
+    /// Cratonic configuration. `None` → craton recompute skipped.
+    /// The `tectonics_v2::cratonic` namespace is data-only and
+    /// not v2_legacy-gated (no Stokes coupling), so this is
+    /// available to both paradigms.
+    pub cratonic_cfg: Option<&'a CratonicConfigEnabled>,
+}
+
+/// Output of [`apply_post_tectonic`].
+///
+/// `common` is the paradigm-agnostic per-cycle diagnostics bundle.
+/// `new_cratonic_factor` is the freshly-recomputed factor field; the
+/// caller installs it where appropriate for its state shape
+/// (v2: `baseline.final_state.cratonic_factor`; C1: discards in
+/// Phase 1.3, may consume later).
+pub struct PostTectonicOutput {
+    pub common: CycleOutputCommon,
+    pub new_cratonic_factor: Option<Field2D>,
+}
+
+/// Run the shared post-tectonic pass: sea-level → macro-redistribution
+/// → reclassification → cratonic recompute. See module docstring
+/// for the rationale and the v2/C1 boundary.
+pub fn apply_post_tectonic(mut input: PostTectonicInput<'_>) -> PostTectonicOutput {
+    // Step 1 — adaptive sea-level threshold in S̃ space.
+    //
+    // Phase 3.5 fix (see `phase_a_v2.rs` history for the pre-3.5
+    // bug): compute the threshold *in S̃ units* via the isostasy
+    // formula `h_sea = h_min + sea_level_fraction · h_range`,
+    // applied to `S̃` directly:
+    //
+    //     s_sea = s_min + sea_level_fraction · (s_max - s_min)
+    //
+    // At init (S̃ ∈ [≈0.2, ≈1.2]) this resolves to ≈ 0.6 — close to
+    // the natural 0.5 midpoint between oceanic and continental, and
+    // adaptive to the S̃ distribution as cycles erode.
+    let sea_level_ref = compute_sea_level_ref(input.s_field, input.iso_cfg);
+
+    // Step 2 — macro mass redistribution. Step 12 R3 replaced the
+    // legacy `low_res_erosion::apply` with this drainage + isostatic-
+    // rebound formulation; mass drift is now ~ IEEE-754 floor by
+    // construction.
+    let mass_before: f64 = input.s_field.data().iter().sum();
+    let stats = macro_redistribution::apply(input.s_field, input.params, sea_level_ref);
+    let mass_after: f64 = input.s_field.data().iter().sum();
+
+    // Step 3 — reclassify per-cell `plate_type` from the new
+    // `s_field` against `sea_level_ref`.
+    if let Some(plate_type) = input.plate_type.as_deref_mut() {
+        reclassify_inplace(plate_type, input.s_field, sea_level_ref);
+    }
+
+    // Step 4 — recompute cratonic factor when the cfg + plate_id +
+    // initial_per_plate_type are all present.
+    let mut new_cratonic_factor: Option<Field2D> = None;
+    let mut craton_change: Option<f64> = None;
+    if let (Some(crcfg), Some(plate_id), Some(orig)) = (
+        input.cratonic_cfg,
+        input.plate_id,
+        input.initial_per_plate_type,
+    ) {
+        let factor = recompute_cratonic_factor_for_cycle(
+            plate_id,
+            orig,
+            input.s_field,
+            sea_level_ref,
+            crcfg,
+        );
+        if let Some(old_factor) = input.previous_cratonic_factor {
+            craton_change = Some(measure_craton_change(old_factor, &factor));
+        }
+        new_cratonic_factor = Some(factor);
+    }
+
+    PostTectonicOutput {
+        common: CycleOutputCommon {
+            erosion_volume_removed: stats.total_eroded,
+            erosion_peak_delta_h: stats.peak_delta_h,
+            sea_level_normalized: sea_level_ref,
+            mass_drift: mass_after - mass_before,
+            craton_recomputation_change: craton_change,
+        },
+        new_cratonic_factor,
+    }
+}
+
+/// Recover `per_plate_type[p]` from the per-cell `plate_type` field.
+///
+/// At `run_baseline` start (v2) or `init_c1_state_phase_1_1` (C1)
+/// the per-cell field is a deterministic broadcast of `per_plate_
+/// type` (every cell of plate `p` has type `per_plate_type[p]`).
+/// Sampling the first occurrence of each `plate_id` is therefore a
+/// faithful recovery — the function returns `Vec<PlateType>` of
+/// length `max(plate_id) + 1`.
+///
+/// Callers should invoke this **before** [`apply_post_tectonic`] so
+/// the captured per-plate type reflects the *pre-reclassification*
+/// state, which is what the D4 "was continental at init" gate
+/// needs.
+pub fn extract_per_plate_type(
+    plate_id: &PlateIdField,
+    plate_type: &PlateTypeField,
+) -> Vec<PlateType> {
+    let nx = plate_id.nx();
+    let ny = plate_id.ny();
+    let max_id = plate_id.data().iter().copied().max().unwrap_or(0) as usize;
+    let num_plates = max_id + 1;
+    let mut per = vec![PlateType::Oceanic; num_plates];
+    let mut seen = vec![false; num_plates];
+    for j in 0..ny {
+        for i in 0..nx {
+            let pid = plate_id.get(i, j) as usize;
+            if !seen[pid] {
+                per[pid] = plate_type.get(i, j);
+                seen[pid] = true;
+            }
+        }
+    }
+    per
+}
+
+/// Phase 3.5 sea-level formula in `S̃` space.
+fn compute_sea_level_ref(s: &Field2D, iso_cfg: &IsostasyConfig) -> f64 {
+    let s_data = s.data();
+    let (s_min, s_max) = s_data.iter().copied().fold(
+        (f64::INFINITY, f64::NEG_INFINITY),
+        |(lo, hi), v| (lo.min(v), hi.max(v)),
+    );
+    let s_range = (s_max - s_min).max(1e-10);
+    s_min + (iso_cfg.sea_level_fraction as f64) * s_range
+}
+
+/// Reclassify per-cell `plate_type` from the post-erosion `S̃`
+/// field against `sea_level_ref`.
+fn reclassify_inplace(plate_type: &mut PlateTypeField, s: &Field2D, sea_level_ref: f64) {
+    for j in 0..plate_type.ny() {
+        for i in 0..plate_type.nx() {
+            let new_type = if s.get(i, j) > sea_level_ref {
+                PlateType::Continental
+            } else {
+                PlateType::Oceanic
+            };
+            plate_type.set(i, j, new_type);
+        }
+    }
+}
+
+/// Step 12 D4 cratonic recompute: synthesise an updated
+/// [`VoronoiPlates`] in which each plate's `per_plate_type` reflects
+/// the post-erosion D4 retention rule, then call
+/// [`build_cratonic_factor_field`].
+///
+/// **D4 retention rule** (per `step12_issue.md`, Phase 3.5
+/// disambiguation):
+///
+/// ```text
+/// continental_fraction[p] = cells in plate p with S̃ > sea_level
+///                         / total cells in plate p   (within-plate)
+/// retained[p] = was_continental_at_init[p]
+///             && continental_fraction[p] >= craton_retention_threshold
+/// ```
+///
+/// The threshold is [`CratonicConfigEnabled::craton_retention_threshold`]
+/// (Semantics 2, within-plate), **not** `plate_area_min` (Semantics 1,
+/// fraction-of-domain). The two are independently configurable since
+/// Step 12 Phase 3.5; the Phase 3 implementation overloaded
+/// `plate_area_min` and could not isolate the D4 flip from the init
+/// exclusion. See `step12_issue.md` D4 + the Phase 3.5 commit message
+/// for the disambiguation rationale.
+fn recompute_cratonic_factor_for_cycle(
+    plate_id: &PlateIdField,
+    initial_per_plate_type: &[PlateType],
+    s: &Field2D,
+    sea_level_reference: f64,
+    cfg: &CratonicConfigEnabled,
+) -> Field2D {
+    let nx = plate_id.nx();
+    let ny = plate_id.ny();
+    let num_plates = initial_per_plate_type.len();
+
+    // Per-plate continental cell count under the new sea_level.
+    let mut cont_count = vec![0u32; num_plates];
+    let mut total_count = vec![0u32; num_plates];
+    for j in 0..ny {
+        for i in 0..nx {
+            let pid = plate_id.get(i, j) as usize;
+            total_count[pid] += 1;
+            if s.get(i, j) > sea_level_reference {
+                cont_count[pid] += 1;
+            }
+        }
+    }
+
+    // Apply D4 retention rule to derive the new per_plate_type.
+    let mut updated_per_plate_type: Vec<PlateType> = Vec::with_capacity(num_plates);
+    for p in 0..num_plates {
+        let frac = if total_count[p] > 0 {
+            cont_count[p] as f64 / total_count[p] as f64
+        } else {
+            0.0
+        };
+        let was_continental = matches!(initial_per_plate_type[p], PlateType::Continental);
+        let new_type = if was_continental && frac >= cfg.craton_retention_threshold {
+            PlateType::Continental
+        } else {
+            PlateType::Oceanic
+        };
+        updated_per_plate_type.push(new_type);
+    }
+
+    // Mirror `per_plate_type` into a per-cell PlateTypeField so the
+    // synthesised `VoronoiPlates` is internally consistent.
+    let mut updated_plate_type = PlateTypeField::filled(nx, ny, PlateType::Oceanic);
+    for j in 0..ny {
+        for i in 0..nx {
+            let pid = plate_id.get(i, j) as usize;
+            updated_plate_type.set(i, j, updated_per_plate_type[pid]);
+        }
+    }
+
+    let plates = VoronoiPlates {
+        num_plates,
+        plate_id: plate_id.clone(),
+        plate_type: updated_plate_type,
+        per_plate_type: updated_per_plate_type,
+        // `seed_coords` is unused by `build_cratonic_factor_field` —
+        // empty Vec is safe.
+        seed_coords: Vec::new(),
+    };
+    build_cratonic_factor_field(&plates, cfg)
+}
+
+/// Fraction of cells whose `cratonic_factor` changed by more than
+/// `1e-9` between two snapshots. The threshold is well above the
+/// rounding error of the smoothstep (a smooth function of distances)
+/// while small enough to catch any genuine BFS reshuffle from the
+/// D4 retention rule kicking in or out for a plate.
+fn measure_craton_change(old: &Field2D, new: &Field2D) -> f64 {
+    let n = old.data().len();
+    if n == 0 {
+        return 0.0;
+    }
+    let mut changed = 0_usize;
+    for k in 0..n {
+        if (old.data()[k] - new.data()[k]).abs() > 1e-9 {
+            changed += 1;
+        }
+    }
+    changed as f64 / n as f64
+}

--- a/crates/ymir-core/src/tectonics_v2/workflow/phase_a_v2.rs
+++ b/crates/ymir-core/src/tectonics_v2/workflow/phase_a_v2.rs
@@ -1,6 +1,6 @@
 //! Phase A — low-res loop orchestration.
 //!
-//! `run_phase_a_cycle` chains the 5-step single-cycle pipeline:
+//! `run_phase_a_cycle_v2` chains the 5-step single-cycle pipeline:
 //!
 //! 1. **Tectonic** — `run_baseline(cfg)`; the cfg may carry a
 //!    [`ContinuationState`] for cycle-to-cycle warm-start (D3).
@@ -39,7 +39,7 @@
 //! `v2_workflow_disabled_regression::workflow_disabled_run_phase_a_cycle_is_bit_identical_to_run_baseline`
 //! pins this contract byte-for-byte.
 
-use super::{macro_redistribution, CycleOutput, CycleOutputCommon, PhaseAOutput, WorkflowConfig};
+use super::{macro_redistribution, CycleOutputV2, CycleOutputCommon, PhaseAOutputV2, WorkflowConfig};
 use crate::tectonics::isostasy::IsostasyConfig;
 use crate::tectonics_v2::boundaries::{PlateType, PlateTypeField};
 use crate::tectonics_v2::cratonic::factor::build_cratonic_factor_field;
@@ -51,24 +51,24 @@ use crate::tectonics_v2::field::Field2D;
 use crate::tectonics_v2::voronoi::{PlateIdField, VoronoiPlates};
 
 /// Run a single Phase A cycle. Thin wrapper over
-/// [`run_phase_a_cycle_with_progress`] with a no-op callback that
+/// [`run_phase_a_cycle_with_progress_v2`] with a no-op callback that
 /// never aborts, preserving the bit-identical regression contract
 /// (acceptance #15) byte-for-byte: `run_baseline_with_progress(cfg,
 /// |_| true)` is itself a wrapper over `run_baseline` from Step 8.6
 /// follow-up, so the call chain reduces to the same primitive.
 ///
 /// `Disabled` → direct `run_baseline(cfg)` passthrough wrapped in a
-/// [`CycleOutput`] with all extra scalars at zero/`None`.
+/// [`CycleOutputV2`] with all extra scalars at zero/`None`.
 ///
 /// `Enabled(params)` → 5-step pipeline (tectonic → isostasy → erosion →
 /// reclassify → recompute craton). Returns the post-cycle state
 /// suitable for cycle-to-cycle continuation via
-/// [`final_state_to_continuation`].
-pub fn run_phase_a_cycle(cfg: &BaselineConfig, wf: &WorkflowConfig) -> CycleOutput {
-    run_phase_a_cycle_with_progress(cfg, wf, |_| true)
+/// [`final_state_to_continuation_v2`].
+pub fn run_phase_a_cycle_v2(cfg: &BaselineConfig, wf: &WorkflowConfig) -> CycleOutputV2 {
+    run_phase_a_cycle_with_progress_v2(cfg, wf, |_| true)
 }
 
-/// Streaming variant of [`run_phase_a_cycle`]. The callback fires
+/// Streaming variant of [`run_phase_a_cycle_v2`]. The callback fires
 /// once per completed harness step inside the cycle's tectonic
 /// sub-phase (steps 1 of the 5-step pipeline); returning `false`
 /// requests a graceful abort of the harness step loop. Same
@@ -78,24 +78,24 @@ pub fn run_phase_a_cycle(cfg: &BaselineConfig, wf: &WorkflowConfig) -> CycleOutp
 /// Added in Step 12 follow-up so the v2 bridge can stream per-step
 /// `V2Event::Progress` to the metrics dashboard during Phase A
 /// (the dashboard previously froze between `WorkflowCycleCompleted`
-/// events because `run_phase_a_cycle` invoked `run_baseline` —
+/// events because `run_phase_a_cycle_v2` invoked `run_baseline` —
 /// the `|_| true` callback wrapper — with no streaming hook). The
 /// post-tectonic substeps (isostasy, erosion, reclassify, craton
 /// recompute) are not currently streamed; they're sub-second on
 /// 64² mantle-on, so a single "cycle progress" tick is the
 /// pragmatic granularity.
-pub fn run_phase_a_cycle_with_progress<F>(
+pub fn run_phase_a_cycle_with_progress_v2<F>(
     cfg: &BaselineConfig,
     wf: &WorkflowConfig,
     on_progress: F,
-) -> CycleOutput
+) -> CycleOutputV2
 where
     F: FnMut(&StepProgress<'_>) -> bool,
 {
     match wf {
         WorkflowConfig::Disabled => {
             let baseline = run_baseline_with_progress(cfg, on_progress);
-            CycleOutput {
+            CycleOutputV2 {
                 baseline,
                 common: CycleOutputCommon::default(),
             }
@@ -245,7 +245,7 @@ where
                 }
             }
 
-            CycleOutput {
+            CycleOutputV2 {
                 baseline,
                 common: CycleOutputCommon {
                     erosion_volume_removed: stats.total_eroded,
@@ -269,7 +269,7 @@ where
 ///
 /// `Enabled(params)` → loop `params.phase_a.n_cycles` cycles. After
 /// each cycle (except the last) the loop sets
-/// `cfg.continuation = Some(final_state_to_continuation(...))` so the
+/// `cfg.continuation = Some(final_state_to_continuation_v2(...))` so the
 /// next cycle's `run_baseline` warm-starts from the prior cycle's
 /// post-erosion state. The S̃ field, velocity, age and cratonic
 /// factor all thread through (D3 contract pinned by
@@ -279,27 +279,27 @@ where
 /// The convention is to set `cfg.steps = params.phase_a.k_cycle`
 /// before calling, but the loop does not enforce this — the two are
 /// independently configurable.
-pub fn run_phase_a_loop(cfg: &mut BaselineConfig, wf: &WorkflowConfig) -> PhaseAOutput {
+pub fn run_phase_a_loop_v2(cfg: &mut BaselineConfig, wf: &WorkflowConfig) -> PhaseAOutputV2 {
     match wf {
         WorkflowConfig::Disabled => {
-            let cycle = run_phase_a_cycle(cfg, wf);
-            PhaseAOutput { cycles: vec![cycle] }
+            let cycle = run_phase_a_cycle_v2(cfg, wf);
+            PhaseAOutputV2 { cycles: vec![cycle] }
         }
         WorkflowConfig::Enabled(params) => {
             let n_cycles = params.phase_a.n_cycles.max(1);
-            let mut cycles: Vec<CycleOutput> = Vec::with_capacity(n_cycles);
+            let mut cycles: Vec<CycleOutputV2> = Vec::with_capacity(n_cycles);
             for cycle_idx in 0..n_cycles {
-                let cycle = run_phase_a_cycle(cfg, wf);
+                let cycle = run_phase_a_cycle_v2(cfg, wf);
                 // Set up the next cycle's warm-start *before* moving
                 // `cycle` into the output vec. Skip the last cycle:
                 // there is no next cycle to warm-start.
                 if cycle_idx + 1 < n_cycles {
                     cfg.continuation =
-                        Some(final_state_to_continuation(&cycle.baseline.final_state));
+                        Some(final_state_to_continuation_v2(&cycle.baseline.final_state));
                 }
                 cycles.push(cycle);
             }
-            PhaseAOutput { cycles }
+            PhaseAOutputV2 { cycles }
         }
     }
 }
@@ -316,7 +316,7 @@ pub fn run_phase_a_loop(cfg: &mut BaselineConfig, wf: &WorkflowConfig) -> PhaseA
 /// D3 contract: cycle `N+1` step 1 should produce a peak|v| within
 /// 10 % of cycle `N` step `k_cycle` — pinned by the
 /// `v2_workflow_continuation_no_transient` test.
-pub fn final_state_to_continuation(fs: &FinalState) -> ContinuationState {
+pub fn final_state_to_continuation_v2(fs: &FinalState) -> ContinuationState {
     ContinuationState {
         s: fs.s_field.clone(),
         vx: fs.vx.clone(),

--- a/crates/ymir-core/src/tectonics_v2/workflow/phase_a_v2.rs
+++ b/crates/ymir-core/src/tectonics_v2/workflow/phase_a_v2.rs
@@ -1,56 +1,43 @@
-//! Phase A — low-res loop orchestration.
+//! Phase A — low-res loop orchestration, **v2 path**.
+//!
+//! Per Phase 1.3 H2 (Issue #125), this module is the v2-paradigm
+//! Phase A entry point — gated under `v2_legacy`. The structurally-
+//! identical C1 paradigm path lives at [`super::phase_a_c1`]
+//! (default-features-on, Commit 4).
 //!
 //! `run_phase_a_cycle_v2` chains the 5-step single-cycle pipeline:
 //!
 //! 1. **Tectonic** — `run_baseline(cfg)`; the cfg may carry a
 //!    [`ContinuationState`] for cycle-to-cycle warm-start (D3).
-//! 2. **Isostasy** — `compute_isostasy(s_field)` to extract
-//!    `sea_level_normalized` (Option 2 of Phase 0 finding E:
-//!    adaptive threshold drives erosion + reclassification).
-//! 3. **Macro mass redistribution** — `macro_redistribution::apply`
-//!    in-place on `final_state.s_field` with the cycle's `α /
-//!    isostatic_rebound_ratio / max_drainage_distance`. Step 12 R3
-//!    replaced the legacy `low_res_erosion` (per-cycle diffusive
-//!    erosion + local `β`-deposition) with a long-distance drainage
-//!    + isostatic-rebound formulation — see
-//!    [`super::macro_redistribution`] module docstring for the full
-//!    arithmetic and conservation contract.
-//! 4. **Reclassify** — per-cell `plate_type[i, j]` = `Continental`
-//!    iff `s_field[i, j] > sea_level_normalized`; otherwise
-//!    `Oceanic`.
-//! 5. **Recompute cratonic factor** — clone the (static) `plate_id`
-//!    field; rebuild `per_plate_type[p]` from the post-erosion
-//!    continental fraction (D4: a plate retains its continental
-//!    eligibility iff `frac >= plate_area_min`); call
-//!    [`crate::tectonics_v2::cratonic::factor::build_cratonic_factor_field`]
-//!    with this synthesised `VoronoiPlates` (Step 9 BFS, Manhattan
-//!    4-conn, smoothstep — *not* `voronoi/distance.rs` which is
-//!    Chebyshev 8-conn). The new factor field replaces
-//!    `final_state.cratonic_factor`.
+//!    **v2-specific** (Stokes + nonlinear continuation).
+//! 2. **Post-tectonic pass (shared)** — delegates to
+//!    [`super::phase_a_common::apply_post_tectonic`]: sea-level →
+//!    macro-redistribution → reclassification → cratonic
+//!    recompute. Paradigm-agnostic; the C1 path calls the same
+//!    function in Commit 4.
+//! 3. **Velocity reset** — sets `vx = vy = 0` after macro-
+//!    redistribution. **v2-specific** (D1-ter empirical finding,
+//!    see in-function comment for the rationale).
+//! 4. **Cratonic factor install** — assigns the freshly-recomputed
+//!    factor to `baseline.final_state.cratonic_factor`. **v2-
+//!    specific** (data shape: v2 stores `Field2D`, C1 has only
+//!    `BoolField cratonic_mask`).
 //!
-//! Order is **strict**: erosion before reclassify, reclassify before
-//! craton recompute. Otherwise the craton would reflect the pre-erosion
-//! `S̃` and the cycle's effect would be invisible to Phase 4's
-//! `craton_recomputation_change` metric.
-//!
-//! `WorkflowConfig::Disabled` short-circuits this entire pipeline:
-//! the cycle is exactly `run_baseline(cfg)` with all extra scalars at
-//! zero/`None`. The regression
+//! `WorkflowConfig::Disabled` short-circuits the entire pipeline:
+//! the cycle is exactly `run_baseline(cfg)` with all extra scalars
+//! at zero/`None`. The regression
 //! `v2_workflow_disabled_regression::workflow_disabled_run_phase_a_cycle_is_bit_identical_to_run_baseline`
 //! pins this contract byte-for-byte.
 
-use super::{macro_redistribution, CycleOutputV2, CycleOutputCommon, PhaseAOutputV2, WorkflowConfig};
+use super::phase_a_common::{apply_post_tectonic, extract_per_plate_type, PostTectonicInput};
+use super::{CycleOutputCommon, CycleOutputV2, PhaseAOutputV2, WorkflowConfig};
 use crate::tectonics::isostasy::IsostasyConfig;
-use crate::tectonics_v2::boundaries::{PlateType, PlateTypeField};
-use crate::tectonics_v2::cratonic::factor::build_cratonic_factor_field;
-use crate::tectonics_v2::cratonic::{CratonicConfig, CratonicConfigEnabled};
+use crate::tectonics_v2::cratonic::CratonicConfig;
 use crate::tectonics_v2::diagnostics::harness::{
     run_baseline_with_progress, BaselineConfig, ContinuationState, FinalState, StepProgress,
 };
-use crate::tectonics_v2::field::Field2D;
-use crate::tectonics_v2::voronoi::{PlateIdField, VoronoiPlates};
 
-/// Run a single Phase A cycle. Thin wrapper over
+/// Run a single Phase A cycle on the v2 path. Thin wrapper over
 /// [`run_phase_a_cycle_with_progress_v2`] with a no-op callback that
 /// never aborts, preserving the bit-identical regression contract
 /// (acceptance #15) byte-for-byte: `run_baseline_with_progress(cfg,
@@ -60,17 +47,17 @@ use crate::tectonics_v2::voronoi::{PlateIdField, VoronoiPlates};
 /// `Disabled` → direct `run_baseline(cfg)` passthrough wrapped in a
 /// [`CycleOutputV2`] with all extra scalars at zero/`None`.
 ///
-/// `Enabled(params)` → 5-step pipeline (tectonic → isostasy → erosion →
-/// reclassify → recompute craton). Returns the post-cycle state
-/// suitable for cycle-to-cycle continuation via
-/// [`final_state_to_continuation_v2`].
+/// `Enabled(params)` → 4-step pipeline (tectonic → shared post-
+/// tectonic pass → velocity reset → cratonic factor install).
+/// Returns the post-cycle state suitable for cycle-to-cycle
+/// continuation via [`final_state_to_continuation_v2`].
 pub fn run_phase_a_cycle_v2(cfg: &BaselineConfig, wf: &WorkflowConfig) -> CycleOutputV2 {
     run_phase_a_cycle_with_progress_v2(cfg, wf, |_| true)
 }
 
 /// Streaming variant of [`run_phase_a_cycle_v2`]. The callback fires
 /// once per completed harness step inside the cycle's tectonic
-/// sub-phase (steps 1 of the 5-step pipeline); returning `false`
+/// sub-phase (step 1 of the 4-step pipeline); returning `false`
 /// requests a graceful abort of the harness step loop. Same
 /// callback shape as
 /// [`crate::tectonics_v2::diagnostics::harness::run_baseline_with_progress`].
@@ -101,47 +88,13 @@ where
             }
         }
         WorkflowConfig::Enabled(params) => {
-            // Step 1: Tectonic.
+            // Step 1 — Tectonic (v2-specific).
             let mut baseline = run_baseline_with_progress(cfg, on_progress);
 
-            // Step 2: Adaptive sea-level threshold in S̃ space.
-            //
-            // Phase 3 originally piped
-            // `compute_isostasy(s).sea_level_normalized` (a `f32` in
-            // heightmap `[0, 1]` space), which on the default
-            // IsostasyConfig (max_depth=500 m, max_elevation=4000 m)
-            // resolves to `0.111` — well below S̃'s natural oceanic
-            // floor of ≈ 0.2. As a result the continental/oceanic
-            // mask was satisfied by *every* cell, the recompute D4
-            // rule never fired, and the v2_workflow_cratonic_recompute_*
-            // tests passed for the wrong reason.
-            //
-            // Phase 3.5 fix: compute the threshold *in S̃ units* via
-            // the isostasy formula `h_sea = h_min + sea_level_fraction
-            // · h_range`, applied to S̃ directly:
-            //
-            //     s_sea = s_min + sea_level_fraction · (s_max - s_min)
-            //
-            // At init (S̃ ∈ [≈0.2, ≈1.2]) this resolves to ≈ 0.6 —
-            // close to the natural 0.5 midpoint between oceanic and
-            // continental, and adaptive to the S̃ distribution as
-            // cycles erode. Source: same formula as
-            // `compute_isostasy::h_sea`, just in S̃ units rather
-            // than buoyancy-scaled altitude.
-            let iso_cfg = IsostasyConfig::default();
-            let sea_level_ref = {
-                let s_data = baseline.final_state.s_field.data();
-                let (s_min, s_max) = s_data.iter().copied().fold(
-                    (f64::INFINITY, f64::NEG_INFINITY),
-                    |(lo, hi), v| (lo.min(v), hi.max(v)),
-                );
-                let s_range = (s_max - s_min).max(1e-10);
-                s_min + (iso_cfg.sea_level_fraction as f64) * s_range
-            };
-
-            // Step 3: Capture original `per_plate_type` BEFORE
-            // reclassification — needed for the craton recompute's
-            // "plate was originally continental" gate (D4).
+            // Capture the pre-reclassification per-plate type for
+            // the D4 "was continental at init" gate. Must happen
+            // BEFORE the shared post-tectonic pass mutates
+            // `plate_type` via reclassification.
             let original_per_plate_type = baseline
                 .final_state
                 .plate_type
@@ -149,52 +102,70 @@ where
                 .zip(baseline.final_state.plate_id.as_ref())
                 .map(|(pt, pid)| extract_per_plate_type(pid, pt));
 
-            // Step 4: Macro mass redistribution (in-place). Step 12 R3
-            // — replaces the legacy `low_res_erosion::apply`. The new
-            // call carries drainage + isostatic rebound, so mass drift
-            // is now ~ IEEE-754 floor by construction (instead of the
-            // legacy `-(1-β) · volume_removed` net change).
-            let mass_before: f64 = baseline.final_state.s_field.data().iter().sum();
-            let stats = macro_redistribution::apply(
-                &mut baseline.final_state.s_field,
-                &params.phase_a,
-                sea_level_ref,
-            );
-            let mass_after: f64 = baseline.final_state.s_field.data().iter().sum();
+            let cratonic_cfg_enabled = match &cfg.cratonic {
+                CratonicConfig::Enabled(c) => Some(c),
+                CratonicConfig::Disabled => None,
+            };
 
-            // Step 4b: R5b D1-ter — reset velocity to zero after
-            // macro_redistribution.
+            // Step 2 — Shared post-tectonic pass (paradigm-
+            // agnostic). Sea-level → macro-redistribution →
+            // reclassification → cratonic recompute. The
+            // `final_state` fields are destructured so the borrow
+            // checker accepts the disjoint mut borrows of
+            // `s_field` and `plate_type` simultaneously.
+            let FinalState {
+                ref mut s_field,
+                ref plate_id,
+                ref mut plate_type,
+                ref cratonic_factor,
+                ..
+            } = baseline.final_state;
+            let iso_cfg = IsostasyConfig::default();
+            let pt_result = apply_post_tectonic(PostTectonicInput {
+                s_field,
+                plate_id: plate_id.as_ref(),
+                plate_type: plate_type.as_mut(),
+                previous_cratonic_factor: cratonic_factor.as_ref(),
+                initial_per_plate_type: original_per_plate_type.as_deref(),
+                params: &params.phase_a,
+                iso_cfg: &iso_cfg,
+                cratonic_cfg: cratonic_cfg_enabled,
+            });
+
+            // Step 3 — Velocity reset (v2-specific, D1-ter).
             //
-            // EMPIRICAL FINDING (counter-intuitive vs classical Stokes
-            // wisdom): the warm-start `v = v_final_previous_cycle` is
-            // not just sub-optimal post-macro, it is **actively
-            // harmful**. `macro_redistribution::apply` shifts S̃ enough
-            // that the GPE driver direction changes; `v_warm_start`
-            // points in a direction now anti-useful for the next
-            // tectonic step, and Newton oscillates trying to correct
-            // it (sub-case C amplified in D2-bis classification).
+            // EMPIRICAL FINDING (counter-intuitive vs classical
+            // Stokes wisdom): the warm-start `v = v_final_previous_
+            // cycle` is not just sub-optimal post-macro, it is
+            // **actively harmful**. `macro_redistribution::apply`
+            // shifts S̃ enough that the GPE driver direction
+            // changes; `v_warm_start` points in a direction now
+            // anti-useful for the next tectonic step, and Newton
+            // oscillates trying to correct it (sub-case C amplified
+            // in D2-bis classification).
             //
-            // The 3-variant D1-ter benchmark (commit 4969de9) showed
-            // `v = 0` gives:
+            // The 3-variant D1-ter benchmark (commit 4969de9)
+            // showed `v = 0` gives:
             //   - cycle 2 Converged 45/45 vs 14/41 with warm-start
             //   - 0 Oscillating vs 26 with warm-start
-            //   - CG iter total over first 5 cycle-2 steps: 28k vs 75k
+            //   - CG iter total over first 5 cycle-2 steps:
+            //     28k vs 75k
             //   - ‖Δv‖/‖v‖ max: 1.00 vs 11.43
             // Variant C (Gaussian smoothing of v) is WORSE than
             // warm-start (90k CG iter, peak |v| explosion to 53) —
             // smoothing preserves the wrong direction.
             //
             // Gated by `WorkflowConfig::Enabled` (this match arm).
-            // The Disabled branch in `Self::Disabled => …` is
-            // untouched and the bit-identical regression
+            // The Disabled branch is untouched and the bit-
+            // identical regression
             // `v2_workflow_disabled_regression` continues to hold.
             //
-            // Counter-intuitive — leave the comment block intact; a
-            // future dev tempted to "re-enable warm-start because
-            // it's faster on Stokes" would re-break the system. See
-            // `docs/reports/step12_solver_audit.md` § F and
-            // `docs/reports/step12_r5b_d1_ter_init_variants/` for the
-            // full empirical record.
+            // Counter-intuitive — leave the comment block intact;
+            // a future dev tempted to "re-enable warm-start because
+            // it's faster on Stokes" would re-break the system.
+            // See `docs/reports/step12_solver_audit.md` § F and
+            // `docs/reports/step12_r5b_d1_ter_init_variants/` for
+            // the full empirical record.
             for v in baseline.final_state.vx.iter_mut() {
                 *v = 0.0;
             }
@@ -202,64 +173,21 @@ where
                 *v = 0.0;
             }
 
-            // Step 5: Reclassify per-cell `plate_type` from new
-            // `s_field` against `sea_level_ref`. The Voronoï
-            // tessellation (`plate_id`) is static for the run; only
-            // the per-cell type changes.
-            if let Some(plate_type) = baseline.final_state.plate_type.as_mut() {
-                let s = &baseline.final_state.s_field;
-                for j in 0..plate_type.ny() {
-                    for i in 0..plate_type.nx() {
-                        let new_type = if s.get(i, j) > sea_level_ref {
-                            PlateType::Continental
-                        } else {
-                            PlateType::Oceanic
-                        };
-                        plate_type.set(i, j, new_type);
-                    }
-                }
-            }
-
-            // Step 6: Recompute cratonic factor — only if the cfg has
-            // CratonicConfig::Enabled. We synthesise an updated
-            // `VoronoiPlates` whose `per_plate_type[p]` reflects the
-            // post-erosion D4 retention rule, then call
-            // `build_cratonic_factor_field` (Step 9 algorithm).
-            let mut craton_change: Option<f64> = None;
-            if let CratonicConfig::Enabled(crcfg) = cfg.cratonic {
-                if let (Some(plate_id), Some(orig)) = (
-                    &baseline.final_state.plate_id,
-                    &original_per_plate_type,
-                ) {
-                    let new_factor = recompute_cratonic_factor_for_cycle(
-                        plate_id,
-                        orig,
-                        &baseline.final_state.s_field,
-                        sea_level_ref,
-                        &crcfg,
-                    );
-                    if let Some(old_factor) = &baseline.final_state.cratonic_factor {
-                        craton_change = Some(measure_craton_change(old_factor, &new_factor));
-                    }
-                    baseline.final_state.cratonic_factor = Some(new_factor);
-                }
+            // Step 4 — Install the new cratonic factor (v2-
+            // specific data shape).
+            if let Some(new_factor) = pt_result.new_cratonic_factor {
+                baseline.final_state.cratonic_factor = Some(new_factor);
             }
 
             CycleOutputV2 {
                 baseline,
-                common: CycleOutputCommon {
-                    erosion_volume_removed: stats.total_eroded,
-                    erosion_peak_delta_h: stats.peak_delta_h,
-                    sea_level_normalized: sea_level_ref,
-                    mass_drift: mass_after - mass_before,
-                    craton_recomputation_change: craton_change,
-                },
+                common: pt_result.common,
             }
         }
     }
 }
 
-/// Run the Phase A multi-cycle loop.
+/// Run the Phase A multi-cycle loop on the v2 path.
 ///
 /// `Disabled` → exactly one cycle (single `run_baseline` passthrough).
 /// The `&mut` requirement is preserved on this branch even though no
@@ -269,10 +197,10 @@ where
 ///
 /// `Enabled(params)` → loop `params.phase_a.n_cycles` cycles. After
 /// each cycle (except the last) the loop sets
-/// `cfg.continuation = Some(final_state_to_continuation_v2(...))` so the
-/// next cycle's `run_baseline` warm-starts from the prior cycle's
-/// post-erosion state. The S̃ field, velocity, age and cratonic
-/// factor all thread through (D3 contract pinned by
+/// `cfg.continuation = Some(final_state_to_continuation_v2(...))` so
+/// the next cycle's `run_baseline` warm-starts from the prior
+/// cycle's post-erosion state. The S̃ field, velocity, age and
+/// cratonic factor all thread through (D3 contract pinned by
 /// `v2_workflow_continuation_no_transient`).
 ///
 /// `cfg.steps` is consumed as the number of tectonic steps per cycle.
@@ -316,6 +244,10 @@ pub fn run_phase_a_loop_v2(cfg: &mut BaselineConfig, wf: &WorkflowConfig) -> Pha
 /// D3 contract: cycle `N+1` step 1 should produce a peak|v| within
 /// 10 % of cycle `N` step `k_cycle` — pinned by the
 /// `v2_workflow_continuation_no_transient` test.
+///
+/// **v2-specific.** C1 has no Stokes velocity field; its
+/// equivalent threading function (if needed in Phase 1.4+) will
+/// live in `phase_a_c1.rs`.
 pub fn final_state_to_continuation_v2(fs: &FinalState) -> ContinuationState {
     ContinuationState {
         s: fs.s_field.clone(),
@@ -324,152 +256,4 @@ pub fn final_state_to_continuation_v2(fs: &FinalState) -> ContinuationState {
         age: fs.age_field.clone(),
         cratonic_factor: fs.cratonic_factor.clone(),
     }
-}
-
-/// Recover `per_plate_type[p]` from the per-cell `plate_type` field.
-///
-/// At `run_baseline` start the per-cell field is a deterministic
-/// broadcast of `per_plate_type` (every cell of plate `p` has type
-/// `per_plate_type[p]`). Sampling the first occurrence of each
-/// `plate_id` is therefore a faithful recovery — the function returns
-/// `Vec<PlateType>` of length `max(plate_id) + 1`.
-///
-/// A more defensive variant could sample by majority vote across cells
-/// of each plate; not necessary at cycle 1 (broadcast is exact), and
-/// for cycle 2+ the caller passes the *original* per_plate_type from a
-/// prior call rather than re-sampling.
-fn extract_per_plate_type(plate_id: &PlateIdField, plate_type: &PlateTypeField) -> Vec<PlateType> {
-    let nx = plate_id.nx();
-    let ny = plate_id.ny();
-    let max_id = plate_id.data().iter().copied().max().unwrap_or(0) as usize;
-    let num_plates = max_id + 1;
-    let mut per = vec![PlateType::Oceanic; num_plates];
-    let mut seen = vec![false; num_plates];
-    for j in 0..ny {
-        for i in 0..nx {
-            let pid = plate_id.get(i, j) as usize;
-            if !seen[pid] {
-                per[pid] = plate_type.get(i, j);
-                seen[pid] = true;
-            }
-        }
-    }
-    per
-}
-
-/// Step 12 D4 cratonic recompute: synthesise an updated
-/// [`VoronoiPlates`] in which each plate's `per_plate_type` reflects
-/// the post-erosion D4 retention rule, then call
-/// [`build_cratonic_factor_field`].
-///
-/// **D4 retention rule** (per `step12_issue.md`, Phase 3.5 disambiguation):
-///
-/// ```text
-/// continental_fraction[p] = cells in plate p with S̃ > sea_level
-///                         / total cells in plate p   (within-plate)
-/// retained[p] = was_continental_at_init[p]
-///             && continental_fraction[p] >= craton_retention_threshold
-/// ```
-///
-/// The threshold is [`CratonicConfigEnabled::craton_retention_threshold`]
-/// (Semantics 2, within-plate), **not** `plate_area_min` (Semantics 1,
-/// fraction-of-domain). The two are independently configurable since
-/// Step 12 Phase 3.5; the Phase 3 implementation overloaded
-/// `plate_area_min` and could not isolate the D4 flip from the init
-/// exclusion. See `step12_issue.md` D4 + the Phase 3.5 commit message
-/// for the disambiguation rationale.
-///
-/// `was_continental_at_init` comes from `initial_per_plate_type` — the
-/// caller is responsible for capturing this from the pre-erosion
-/// `plate_type` field. After Phase 4 multi-cycle wiring, this becomes
-/// the prior cycle's `per_plate_type`, threading the D4 retention rule
-/// across the loop.
-fn recompute_cratonic_factor_for_cycle(
-    plate_id: &PlateIdField,
-    initial_per_plate_type: &[PlateType],
-    s: &Field2D,
-    sea_level_reference: f64,
-    cfg: &CratonicConfigEnabled,
-) -> Field2D {
-    let nx = plate_id.nx();
-    let ny = plate_id.ny();
-    let num_plates = initial_per_plate_type.len();
-
-    // Per-plate continental cell count under the new sea_level.
-    let mut cont_count = vec![0u32; num_plates];
-    let mut total_count = vec![0u32; num_plates];
-    for j in 0..ny {
-        for i in 0..nx {
-            let pid = plate_id.get(i, j) as usize;
-            total_count[pid] += 1;
-            if s.get(i, j) > sea_level_reference {
-                cont_count[pid] += 1;
-            }
-        }
-    }
-
-    // Apply D4 retention rule to derive the new per_plate_type. The
-    // threshold is `craton_retention_threshold` (Semantics 2, within
-    // plate), distinct from `plate_area_min` (Semantics 1, fraction
-    // of domain) which the init-time `build_cratonic_factor_field`
-    // uses internally.
-    let mut updated_per_plate_type: Vec<PlateType> = Vec::with_capacity(num_plates);
-    for p in 0..num_plates {
-        let frac = if total_count[p] > 0 {
-            cont_count[p] as f64 / total_count[p] as f64
-        } else {
-            0.0
-        };
-        let was_continental = matches!(initial_per_plate_type[p], PlateType::Continental);
-        let new_type = if was_continental && frac >= cfg.craton_retention_threshold {
-            PlateType::Continental
-        } else {
-            PlateType::Oceanic
-        };
-        updated_per_plate_type.push(new_type);
-    }
-
-    // Mirror per_plate_type into a per-cell PlateTypeField so the
-    // synthesised `VoronoiPlates` is internally consistent (the BFS
-    // in `build_cratonic_factor_field` reads `retained[plate_id]`
-    // which is per-plate, but the test surface
-    // `factor_zero_on_oceanic_cells` expects the per-cell field to
-    // match for diagnostic coherence).
-    let mut updated_plate_type = PlateTypeField::filled(nx, ny, PlateType::Oceanic);
-    for j in 0..ny {
-        for i in 0..nx {
-            let pid = plate_id.get(i, j) as usize;
-            updated_plate_type.set(i, j, updated_per_plate_type[pid]);
-        }
-    }
-
-    let plates = VoronoiPlates {
-        num_plates,
-        plate_id: plate_id.clone(),
-        plate_type: updated_plate_type,
-        per_plate_type: updated_per_plate_type,
-        // `seed_coords` is unused by `build_cratonic_factor_field` —
-        // empty Vec is safe.
-        seed_coords: Vec::new(),
-    };
-    build_cratonic_factor_field(&plates, cfg)
-}
-
-/// Fraction of cells whose `cratonic_factor` changed by more than
-/// `1e-9` between two snapshots. The threshold is well above the
-/// rounding error of the smoothstep (a smooth function of distances)
-/// while small enough to catch any genuine BFS reshuffle from the D4
-/// retention rule kicking in or out for a plate.
-fn measure_craton_change(old: &Field2D, new: &Field2D) -> f64 {
-    let n = old.data().len();
-    if n == 0 {
-        return 0.0;
-    }
-    let mut changed = 0_usize;
-    for k in 0..n {
-        if (old.data()[k] - new.data()[k]).abs() > 1e-9 {
-            changed += 1;
-        }
-    }
-    changed as f64 / n as f64
 }

--- a/crates/ymir-core/tests/_attic/v2_workflow_disabled_regression.rs
+++ b/crates/ymir-core/tests/_attic/v2_workflow_disabled_regression.rs
@@ -66,7 +66,7 @@ fn workflow_disabled_run_phase_a_cycle_is_bit_identical_to_run_baseline() {
     assert_eq!(r_a.final_state.vy, cycle_b.baseline.final_state.vy, "vy bytes mismatch");
 
     // Disabled never engages the low-res erosion path.
-    assert_eq!(cycle_b.erosion_volume_removed, 0.0);
+    assert_eq!(cycle_b.common.erosion_volume_removed, 0.0);
 
     // Cherry-picked metrics — full metrics struct is not Eq, so we
     // compare scalar invariants that suffice to flag any drift.
@@ -87,7 +87,7 @@ fn workflow_disabled_run_phase_a_loop_returns_single_passthrough_cycle() {
         1,
         "Disabled loop must collapse to a single cycle"
     );
-    assert_eq!(output.cycles[0].erosion_volume_removed, 0.0);
+    assert_eq!(output.cycles[0].common.erosion_volume_removed, 0.0);
     // cfg.continuation is unchanged under Disabled — None remains None.
     assert!(
         cfg.continuation.is_none(),

--- a/crates/ymir-core/tests/_attic/v2_workflow_disabled_regression.rs
+++ b/crates/ymir-core/tests/_attic/v2_workflow_disabled_regression.rs
@@ -9,8 +9,8 @@
 //! > to running Step 11 directly.
 //!
 //! The test rationale is structural rather than statistical: under
-//! `Disabled`, [`run_phase_a_cycle`] is implemented as
-//! `run_baseline(cfg)` plus a wrap into `CycleOutput`. No additional
+//! `Disabled`, [`run_phase_a_cycle_v2`] is implemented as
+//! `run_baseline(cfg)` plus a wrap into `CycleOutputV2`. No additional
 //! RNG consumption, no extra allocation, no Field2D mutation outside
 //! what `run_baseline` does internally. The byte-equal contract is
 //! therefore inherited from `run_baseline` determinism (see
@@ -27,7 +27,7 @@ use std::path::PathBuf;
 use ymir_core::tectonics_v2::diagnostics::harness::{run_baseline, BaselineConfig};
 use ymir_core::tectonics_v2::scales::Scales;
 use ymir_core::tectonics_v2::workflow::{
-    run_phase_a_cycle, run_phase_a_loop, run_phase_b, WorkflowConfig,
+    run_phase_a_cycle_v2, run_phase_a_loop_v2, run_phase_b, WorkflowConfig,
 };
 
 fn build_test_config(scratch_subdir: &str) -> BaselineConfig {
@@ -54,13 +54,13 @@ fn workflow_disabled_run_phase_a_cycle_is_bit_identical_to_run_baseline() {
     let cfg_b = build_test_config("path_b");
 
     let r_a = run_baseline(&cfg_a);
-    let cycle_b = run_phase_a_cycle(&cfg_b, &WorkflowConfig::Disabled);
+    let cycle_b = run_phase_a_cycle_v2(&cfg_b, &WorkflowConfig::Disabled);
 
     let s_a = r_a.final_state.s_field.data();
     let s_b = cycle_b.baseline.final_state.s_field.data();
     assert_eq!(
         s_a, s_b,
-        "s_field bytes must match between run_baseline and run_phase_a_cycle(Disabled)"
+        "s_field bytes must match between run_baseline and run_phase_a_cycle_v2(Disabled)"
     );
     assert_eq!(r_a.final_state.vx, cycle_b.baseline.final_state.vx, "vx bytes mismatch");
     assert_eq!(r_a.final_state.vy, cycle_b.baseline.final_state.vy, "vy bytes mismatch");
@@ -76,12 +76,12 @@ fn workflow_disabled_run_phase_a_cycle_is_bit_identical_to_run_baseline() {
 
 #[test]
 fn workflow_disabled_run_phase_a_loop_returns_single_passthrough_cycle() {
-    // Phase 4 changed run_phase_a_loop's signature to `&mut
+    // Phase 4 changed run_phase_a_loop_v2's signature to `&mut
     // BaselineConfig` because the Enabled branch mutates
     // `cfg.continuation` between cycles. The Disabled branch still
     // does not mutate cfg — the regression contract holds.
     let mut cfg = build_test_config("loop_single");
-    let output = run_phase_a_loop(&mut cfg, &WorkflowConfig::Disabled);
+    let output = run_phase_a_loop_v2(&mut cfg, &WorkflowConfig::Disabled);
     assert_eq!(
         output.cycles.len(),
         1,

--- a/crates/ymir-core/tests/_attic/v2_workflow_phase_6_visual_checkpoint.rs
+++ b/crates/ymir-core/tests/_attic/v2_workflow_phase_6_visual_checkpoint.rs
@@ -217,11 +217,11 @@ fn dump_step12_phase_a_evolution_galerie() {
                 .iter()
                 .copied()
                 .fold(f64::NEG_INFINITY, f64::max);
-            cum_drift += c.mass_drift;
-            let craton = c.craton_recomputation_change.map_or("—".to_string(), |v| format!("{v:.4}"));
+            cum_drift += c.common.mass_drift;
+            let craton = c.common.craton_recomputation_change.map_or("—".to_string(), |v| format!("{v:.4}"));
             report_lines.push(format!(
                 "| {i} | {peak_s:.4} | {:+.5} | {:.5} | {:.4} | {craton} |",
-                c.mass_drift, c.erosion_volume_removed, c.sea_level_normalized
+                c.common.mass_drift, c.common.erosion_volume_removed, c.common.sea_level_normalized
             ));
         }
         report_lines.push(format!("  Cumulative mass drift over {N_CYCLES} cycles: {cum_drift:+.5}"));
@@ -625,7 +625,7 @@ fn dump_step12_phase_6_64sq_full() {
         let phase_b_elapsed = phase_b_start.elapsed().as_secs_f64();
 
         // Cumulative mass drift over Phase A.
-        let cum_drift: f64 = phase_a.cycles.iter().map(|c| c.mass_drift).sum();
+        let cum_drift: f64 = phase_a.cycles.iter().map(|c| c.common.mass_drift).sum();
         let initial_mass_estimate =
             ((preset.continental_ratio + (1.0 - preset.continental_ratio) * 0.2) as f64)
                 * (nx * ny) as f64; // continental ≈ 1.0, oceanic ≈ 0.2
@@ -807,7 +807,7 @@ fn dump_step12_phase_6_aggressive_demo() {
         let phase_b_elapsed = phase_b_start.elapsed().as_secs_f64();
 
         // Aggregate metrics.
-        let cum_drift: f64 = phase_a.cycles.iter().map(|c| c.mass_drift).sum();
+        let cum_drift: f64 = phase_a.cycles.iter().map(|c| c.common.mass_drift).sum();
         let initial_mass_estimate =
             ((preset.continental_ratio + (1.0 - preset.continental_ratio) * 0.2) as f64)
                 * (64.0 * 64.0);
@@ -1155,7 +1155,7 @@ fn dump_step12_phase_6_curvature_variants() {
                 };
                 let phase_a = run_phase_a_loop(&mut cfg, &wf_b);
                 let last = phase_a.cycles.last().unwrap();
-                cum_drift = phase_a.cycles.iter().map(|c| c.mass_drift).sum();
+                cum_drift = phase_a.cycles.iter().map(|c| c.common.mass_drift).sum();
                 after_s = last.baseline.final_state.s_field.clone();
             }
             let preset_elapsed = preset_t.elapsed().as_secs_f64();

--- a/crates/ymir-core/tests/_attic/v2_workflow_phase_6_visual_checkpoint.rs
+++ b/crates/ymir-core/tests/_attic/v2_workflow_phase_6_visual_checkpoint.rs
@@ -55,7 +55,7 @@ use ymir_core::tectonics_v2::scales::Scales;
 use ymir_core::tectonics_v2::slab::SlabPullConfig;
 use ymir_core::tectonics_v2::voronoi::{generate_voronoi, VoronoiConfig};
 use ymir_core::tectonics_v2::workflow::{
-    run_phase_a_loop, run_phase_b, PhaseAParams, PhaseBParams, WorkflowConfig, WorkflowParams,
+    run_phase_a_loop_v2, run_phase_b, PhaseAParams, PhaseBParams, WorkflowConfig, WorkflowParams,
 };
 
 const NX: usize = 32;
@@ -196,7 +196,7 @@ fn dump_step12_phase_a_evolution_galerie() {
             phase_a: PhaseAParams { n_cycles: N_CYCLES, k_cycle: K_CYCLE, alpha: ALPHA, beta: 0.0 },
             phase_b: Default::default(),
         });
-        let phase_a = run_phase_a_loop(&mut cfg, &wf);
+        let phase_a = run_phase_a_loop_v2(&mut cfg, &wf);
 
         // Per-cycle metrics
         report_lines.push(format!("## Preset: {}", preset.label));
@@ -304,7 +304,7 @@ fn dump_step12_phase_b_hd_zoom() {
             ..PhaseBParams::default()
         },
     });
-    let phase_a = run_phase_a_loop(&mut cfg, &wf);
+    let phase_a = run_phase_a_loop_v2(&mut cfg, &wf);
     let last_cycle = phase_a.cycles.last().unwrap();
     let phase_b = run_phase_b(&last_cycle.baseline.final_state.s_field, &wf, cfg.seed)
         .expect("Phase B output");
@@ -606,12 +606,12 @@ fn dump_step12_phase_6_64sq_full() {
         tiles.push((format!("{}_before", preset.label), init_s));
 
         // Phase A loop with per-cycle wallclock timing. The
-        // run_phase_a_loop API doesn't expose per-cycle hooks, so we
+        // run_phase_a_loop_v2 API doesn't expose per-cycle hooks, so we
         // measure total + estimate per-cycle as total / n_cycles.
         // (A finer per-cycle measurement would need a streaming
         // variant; that's a Phase 7+ refinement.)
         let phase_a_start = Instant::now();
-        let phase_a = run_phase_a_loop(&mut cfg, &wf);
+        let phase_a = run_phase_a_loop_v2(&mut cfg, &wf);
         let phase_a_elapsed = phase_a_start.elapsed().as_secs_f64();
         let mean_per_cycle = phase_a_elapsed / N_CYCLES as f64;
 
@@ -795,7 +795,7 @@ fn dump_step12_phase_6_aggressive_demo() {
         tiles.push((format!("{}_before", preset.label), init_s));
 
         let phase_a_start = Instant::now();
-        let phase_a = run_phase_a_loop(&mut cfg, &wf);
+        let phase_a = run_phase_a_loop_v2(&mut cfg, &wf);
         let phase_a_elapsed = phase_a_start.elapsed().as_secs_f64();
 
         let last = phase_a.cycles.last().unwrap();
@@ -1042,7 +1042,7 @@ fn run_custom_phase_a_loop(
     alpha_field: &Field2D,
     beta: f64,
 ) -> (Field2D, Vec<f64>) {
-    use ymir_core::tectonics_v2::workflow::final_state_to_continuation;
+    use ymir_core::tectonics_v2::workflow::final_state_to_continuation_v2;
     let mut drifts = Vec::with_capacity(n_cycles);
     let mut last_s: Option<Field2D> = None;
     for cycle_idx in 0..n_cycles {
@@ -1065,7 +1065,7 @@ fn run_custom_phase_a_loop(
         drifts.push(mass_after - mass_before);
         last_s = Some(baseline.final_state.s_field.clone());
         if cycle_idx + 1 < n_cycles {
-            cfg.continuation = Some(final_state_to_continuation(&baseline.final_state));
+            cfg.continuation = Some(final_state_to_continuation_v2(&baseline.final_state));
         }
     }
     (last_s.unwrap(), drifts)
@@ -1153,7 +1153,7 @@ fn dump_step12_phase_6_curvature_variants() {
                 } else {
                     wf
                 };
-                let phase_a = run_phase_a_loop(&mut cfg, &wf_b);
+                let phase_a = run_phase_a_loop_v2(&mut cfg, &wf_b);
                 let last = phase_a.cycles.last().unwrap();
                 cum_drift = phase_a.cycles.iter().map(|c| c.common.mass_drift).sum();
                 after_s = last.baseline.final_state.s_field.clone();

--- a/crates/ymir-core/tests/_attic/v2_workflow_phase_a_cycle.rs
+++ b/crates/ymir-core/tests/_attic/v2_workflow_phase_a_cycle.rs
@@ -201,7 +201,7 @@ fn v2_workflow_cratonic_recompute_flips_eroded_plate() {
     // metric scales with the flipped plate's area-fraction of the
     // domain.
     let change = cycle
-        .craton_recomputation_change
+        .common.craton_recomputation_change
         .expect("change metric must be populated under CratonicConfig::Enabled");
     assert!(
         change > 0.0,
@@ -244,7 +244,7 @@ fn v2_workflow_cratonic_recompute_preserves_stable_craton() {
 
     // BFS distances unchanged → recomputed factor identical.
     let change = cycle
-        .craton_recomputation_change
+        .common.craton_recomputation_change
         .expect("craton_recomputation_change must be populated");
     assert!(
         change < 1e-12,

--- a/crates/ymir-core/tests/_attic/v2_workflow_phase_a_cycle.rs
+++ b/crates/ymir-core/tests/_attic/v2_workflow_phase_a_cycle.rs
@@ -36,7 +36,7 @@ use ymir_core::tectonics_v2::scales::Scales;
 use ymir_core::tectonics_v2::slab::SlabPullConfig;
 use ymir_core::tectonics_v2::voronoi::VoronoiConfig;
 use ymir_core::tectonics_v2::workflow::{
-    final_state_to_continuation, run_phase_a_cycle, PhaseAParams, WorkflowConfig, WorkflowParams,
+    final_state_to_continuation_v2, run_phase_a_cycle_v2, PhaseAParams, WorkflowConfig, WorkflowParams,
 };
 
 fn build_minimal_cycle_config(steps: usize, scratch: &str) -> BaselineConfig {
@@ -119,7 +119,7 @@ fn v2_workflow_continuation_no_transient() {
 
     // Cycle 1 cold start, 5 steps.
     let cfg_1 = build_minimal_cycle_config(5, "cycle_1");
-    let cycle_1 = run_phase_a_cycle(&cfg_1, &wf);
+    let cycle_1 = run_phase_a_cycle_v2(&cfg_1, &wf);
     let vmax_1 = cycle_1.baseline.metrics.vmax_peak;
     assert!(
         vmax_1 > 0.0,
@@ -132,8 +132,8 @@ fn v2_workflow_continuation_no_transient() {
     // would either spike (transient) or dip (re-ramping) by far
     // more than 10%.
     let mut cfg_2 = build_minimal_cycle_config(1, "cycle_2");
-    cfg_2.continuation = Some(final_state_to_continuation(&cycle_1.baseline.final_state));
-    let cycle_2 = run_phase_a_cycle(&cfg_2, &wf);
+    cfg_2.continuation = Some(final_state_to_continuation_v2(&cycle_1.baseline.final_state));
+    let cycle_2 = run_phase_a_cycle_v2(&cfg_2, &wf);
     let vmax_2 = cycle_2.baseline.metrics.vmax_peak;
 
     let rel_diff = (vmax_2 - vmax_1).abs() / vmax_1;
@@ -192,7 +192,7 @@ fn v2_workflow_cratonic_recompute_flips_eroded_plate() {
         phase_b: Default::default(),
     });
 
-    let cycle = run_phase_a_cycle(&cfg, &wf);
+    let cycle = run_phase_a_cycle_v2(&cfg, &wf);
 
     // The change metric must register > 0 — at least one plate
     // flipped. `measure_craton_change` counts cells whose factor
@@ -226,7 +226,7 @@ fn v2_workflow_cratonic_recompute_preserves_stable_craton() {
         phase_b: Default::default(),
     });
 
-    let cycle = run_phase_a_cycle(&cfg, &wf);
+    let cycle = run_phase_a_cycle_v2(&cfg, &wf);
     let new_factor = cycle
         .baseline
         .final_state

--- a/crates/ymir-core/tests/_attic/v2_workflow_phase_a_loop.rs
+++ b/crates/ymir-core/tests/_attic/v2_workflow_phase_a_loop.rs
@@ -120,13 +120,13 @@ fn run_5cycle_integration(grid_size: usize, scratch: &str) {
     let machine_drift_budget = initial_mass_estimate * 1e-10;
     for (i, cycle) in output.cycles.iter().enumerate() {
         assert!(
-            cycle.mass_drift.abs() < machine_drift_budget,
+            cycle.common.mass_drift.abs() < machine_drift_budget,
             "cycle {i}: mass_drift = {} exceeds machine-precision budget {} (mass conservation must hold)",
-            cycle.mass_drift,
+            cycle.common.mass_drift,
             machine_drift_budget
         );
     }
-    let total_drift: f64 = output.cycles.iter().map(|c| c.mass_drift).sum();
+    let total_drift: f64 = output.cycles.iter().map(|c| c.common.mass_drift).sum();
     assert!(
         total_drift.abs() < machine_drift_budget,
         "cumulative mass drift {total_drift} exceeds machine-precision budget {machine_drift_budget}"
@@ -165,9 +165,9 @@ fn run_5cycle_integration(grid_size: usize, scratch: &str) {
     // through.
     for (i, cycle) in output.cycles.iter().enumerate() {
         assert!(
-            cycle.erosion_volume_removed > 0.0,
+            cycle.common.erosion_volume_removed > 0.0,
             "cycle {i}: erosion_volume_removed = {} (every cycle must engage)",
-            cycle.erosion_volume_removed
+            cycle.common.erosion_volume_removed
         );
     }
 }

--- a/crates/ymir-core/tests/_attic/v2_workflow_phase_a_loop.rs
+++ b/crates/ymir-core/tests/_attic/v2_workflow_phase_a_loop.rs
@@ -32,7 +32,7 @@ use ymir_core::tectonics_v2::scales::Scales;
 use ymir_core::tectonics_v2::slab::SlabPullConfig;
 use ymir_core::tectonics_v2::voronoi::VoronoiConfig;
 use ymir_core::tectonics_v2::workflow::{
-    run_phase_a_loop, PhaseAParams, WorkflowConfig, WorkflowParams,
+    run_phase_a_loop_v2, PhaseAParams, WorkflowConfig, WorkflowParams,
 };
 
 fn build_phase4_config(grid_size: usize, k_cycle: usize, scratch: &str) -> BaselineConfig {
@@ -99,7 +99,7 @@ fn run_5cycle_integration(grid_size: usize, scratch: &str) {
         phase_b: Default::default(),
     });
 
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     assert_eq!(output.cycles.len(), 5, "expected 5 cycles");
 
     // Continuation chained — by the second cycle on, cfg.continuation

--- a/crates/ymir-core/tests/_attic/v2_workflow_phase_b.rs
+++ b/crates/ymir-core/tests/_attic/v2_workflow_phase_b.rs
@@ -35,7 +35,7 @@ use ymir_core::tectonics_v2::scales::Scales;
 use ymir_core::tectonics_v2::slab::SlabPullConfig;
 use ymir_core::tectonics_v2::voronoi::VoronoiConfig;
 use ymir_core::tectonics_v2::workflow::{
-    run_phase_a_loop, run_phase_b, PhaseAParams, PhaseBParams, WorkflowConfig, WorkflowParams,
+    run_phase_a_loop_v2, run_phase_b, PhaseAParams, PhaseBParams, WorkflowConfig, WorkflowParams,
 };
 
 fn build_phase_b_input_config(
@@ -121,7 +121,7 @@ fn run_phase_a_then_b(
             ..PhaseBParams::default()
         },
     });
-    let phase_a = run_phase_a_loop(&mut cfg, &wf);
+    let phase_a = run_phase_a_loop_v2(&mut cfg, &wf);
     let last_cycle = phase_a.cycles.last().expect("Phase A produced at least one cycle");
     run_phase_b(&last_cycle.baseline.final_state.s_field, &wf, cfg.seed)
         .expect("Phase B must produce output under WorkflowConfig::Enabled")
@@ -222,7 +222,7 @@ fn v2_workflow_phase_b_deviation_stats_probe() {
             ..PhaseBParams::default()
         },
     });
-    let phase_a = run_phase_a_loop(&mut cfg, &wf);
+    let phase_a = run_phase_a_loop_v2(&mut cfg, &wf);
     let last_cycle = phase_a.cycles.last().unwrap();
     // Need both pre- and post-erosion HD to compute per-cell devs.
     // The current run_phase_b returns only the post-erosion + the

--- a/crates/ymir-core/tests/c1_phase_1_2_davis_suppe.rs
+++ b/crates/ymir-core/tests/c1_phase_1_2_davis_suppe.rs
@@ -53,6 +53,8 @@ use image::{ImageBuffer, Rgb};
 
 use ymir_core::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
 use ymir_core::tectonics_c1::boundary_classification::classify_boundaries;
+use ymir_core::tectonics_c1::closures::davis_suppe::source_term::DavisSuppeParams;
+use ymir_core::tectonics_c1::closures::equilibrium_height::params::EquilibriumHeightParams;
 use ymir_core::tectonics_c1::distance_field::wedge_distance_intra_plate;
 use ymir_core::tectonics_c1::init::init_c1_state_phase_1_1;
 use ymir_core::tectonics_c1::kinematics::PlateKinematics;
@@ -89,7 +91,19 @@ fn davis_suppe_wedge_body_invariants() {
         dx: 1.0 / GRID_SIZE as f64,
         dy: 1.0 / GRID_SIZE as f64,
     };
-    let closures = C1Closures::default();
+    // Phase 1.2 semantics: keep Davis-Suppe ON, equilibrium-height
+    // OFF. The Phase 1.2 invariants (especially the unbounded
+    // boundary pile-up `global_max ≈ 2297`) rely on no global sink
+    // being active. Phase 1.3 adds equilibrium-height defaulted ON
+    // — disable it explicitly here so this test continues to lock
+    // the pure-Phase-1.2 behaviour.
+    let closures = C1Closures {
+        davis_suppe: DavisSuppeParams::default(),
+        equilibrium_height: EquilibriumHeightParams {
+            enabled: false,
+            ..EquilibriumHeightParams::default()
+        },
+    };
     let h_max = closures.davis_suppe.h_max;
 
     eprintln!(

--- a/crates/ymir-core/tests/c1_phase_1_3_equilibrium_height.rs
+++ b/crates/ymir-core/tests/c1_phase_1_3_equilibrium_height.rs
@@ -1,0 +1,469 @@
+//! Issue #125 Phase 1.3 Stage E3 — C1 equilibrium-height closure
+//! behavioral integration tests.
+//!
+//! Four acceptance tests on the 64²×300-step Phase 1.1 kinematics
+//! preset:
+//!
+//! 1. [`equilibrium_height_caps_global_max`] — Phase 1.3 default
+//!    (both Davis-Suppe + equilibrium-height enabled). Asserts
+//!    `global_max < 1.2 · h_eq = 2.4`. Prediction: ≈ 2.0-2.4
+//!    (boundary pile-up cells get one-step clamped to `h_eq` by
+//!    the quadratic-formula threshold behaviour).
+//! 2. [`davis_suppe_imprint_preserved_with_equilibrium`] — both
+//!    closures enabled. Re-applies the Phase 1.2 fill-ratio
+//!    profile metric on the wedge body (cells with
+//!    `0 < d < max_distance`); asserts `fill_near > 0.5` and
+//!    `asymmetry mean(0-5)/mean(10-20) > 1.5`. Verifies that the
+//!    global equilibrium cap (Step 4 of the C1 closure stack)
+//!    does NOT erase the Davis-Suppe wedge imprint (since the
+//!    wedge body sits below `h_eq` and the asymmetric one-sided
+//!    sink leaves below-`h_eq` cells untouched). Dumps the 5
+//!    visual snapshots (0/50/100/200/300) used by the report.
+//! 3. [`equilibrium_alone_caps_initial_state`] — Davis-Suppe
+//!    disabled, equilibrium-height enabled. Phase 1.1-style
+//!    advection + global cap. Asserts `global_max <= 1.1 · h_eq
+//!    = 2.2`. Prediction: cap holds even without the Davis-Suppe
+//!    source.
+//! 4. [`both_closures_disabled_matches_phase_1_1`] — both
+//!    closures disabled. Asserts `global_max > 100` (Phase 1.1
+//!    unbounded pile-up baseline ≈ 1080 preserved). Regression
+//!    guard: a silent default-state mutation that re-enables a
+//!    closure would lower `global_max` below 100 and fail.
+//!
+//! ## Output directory
+//!
+//! `docs/reports/c1_phase_1_3_equilibrium_height/` carries the
+//! 5-cycle PNG gallery (altitude + S̃ at `[0, 3.0]` palette for
+//! direct visual comparison with the Phase 1.2 gallery) and the
+//! per-phase comparison table in its `README.md`.
+
+use std::path::{Path, PathBuf};
+
+use image::{ImageBuffer, Rgb};
+
+use ymir_core::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
+use ymir_core::tectonics_c1::boundary_classification::classify_boundaries;
+use ymir_core::tectonics_c1::closures::davis_suppe::source_term::DavisSuppeParams;
+use ymir_core::tectonics_c1::closures::equilibrium_height::params::EquilibriumHeightParams;
+use ymir_core::tectonics_c1::distance_field::wedge_distance_intra_plate;
+use ymir_core::tectonics_c1::init::init_c1_state_phase_1_1;
+use ymir_core::tectonics_c1::kinematics::PlateKinematics;
+use ymir_core::tectonics_c1::state::C1State;
+use ymir_core::tectonics_c1::time_loop::{run_with_closures, C1Closures, C1TimeLoopConfig};
+use ymir_core::tectonics_v2::field::Field2D;
+
+const GRID_SIZE: usize = 64;
+const SEED: u64 = 42;
+const N_STEPS: usize = 300;
+/// Palette upper bound for the fixed-scale `S̃` PNG — same as
+/// Phase 1.2 (`h_max = 2.5` + ~ 20 % headroom). Sharing the
+/// scale lets reviewers compare the Phase 1.2 and Phase 1.3
+/// galleries pixel-for-pixel.
+const S_VIZ_MAX: f64 = 3.0;
+
+fn output_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../docs/reports/c1_phase_1_3_equilibrium_height")
+}
+
+/// Build the Phase 1.1 init + kinematics + time-loop config used
+/// by all four tests. Caller chooses the closure scenario.
+fn setup() -> (C1State, PlateKinematics, C1TimeLoopConfig) {
+    let state = init_c1_state_phase_1_1(GRID_SIZE, SEED);
+    let kinematics = PlateKinematics::preset_phase_1_1(state.num_plates);
+    let config = C1TimeLoopConfig {
+        n_steps: N_STEPS,
+        dx: 1.0 / GRID_SIZE as f64,
+        dy: 1.0 / GRID_SIZE as f64,
+    };
+    (state, kinematics, config)
+}
+
+fn global_max(state: &C1State) -> f64 {
+    state.s.data().iter().cloned().fold(0.0_f64, f64::max)
+}
+
+#[test]
+fn equilibrium_height_caps_global_max() {
+    // Phase 1.3 default — both closures enabled.
+    // Davis-Suppe sources mass at the wedge body; equilibrium-
+    // height caps the boundary pile-up at h_eq via the quadratic
+    // formula's threshold behaviour (clamp triggers on the large-
+    // excess cells, holding them at h_eq within one step).
+    let (mut state, kinematics, config) = setup();
+    let closures = C1Closures::default();
+    let h_eq = closures.equilibrium_height.h_eq;
+
+    run_with_closures(&mut state, &kinematics, &config, &closures, |_, _| {});
+
+    let g_max = global_max(&state);
+    let threshold = 1.2 * h_eq;
+    eprintln!(
+        "c1_phase_1_3 T1: global_max = {g_max:.3} (threshold = {threshold:.2} = 1.2 × h_eq = {:.2})",
+        h_eq
+    );
+    assert!(
+        g_max < threshold,
+        "Phase 1.3 T1 cap failed: global_max = {g_max:.3} ≥ 1.2 × h_eq = {threshold:.2} — \
+         equilibrium height is not capping the boundary pile-up (quadratic clamp may be \
+         buggy or k_collapse too low)"
+    );
+}
+
+#[test]
+fn davis_suppe_imprint_preserved_with_equilibrium() {
+    // Both enabled. Stage E3 dumps the 5 PNGs here for the visual
+    // gallery in `docs/reports/c1_phase_1_3_equilibrium_height/`.
+    let dir = output_dir();
+    std::fs::create_dir_all(&dir).expect("create output dir");
+
+    let (mut state, kinematics, config) = setup();
+    let closures = C1Closures::default();
+
+    eprintln!(
+        "c1_phase_1_3 T2: grid={GRID_SIZE}², steps={N_STEPS}, h_eq={}, k_collapse={}, \
+         coupling={}, h_max={}, L_taper={}, L_decay={}",
+        closures.equilibrium_height.h_eq,
+        closures.equilibrium_height.k_collapse,
+        closures.davis_suppe.coupling,
+        closures.davis_suppe.h_max,
+        closures.davis_suppe.l_taper,
+        closures.davis_suppe.l_decay,
+    );
+
+    // Init snapshot.
+    print_s_stats("000", &state);
+    dump_snapshot(&state, 0, &dir);
+
+    let snapshot_steps: [usize; 4] = [49, 99, 199, 299];
+
+    let started = std::time::Instant::now();
+    run_with_closures(
+        &mut state,
+        &kinematics,
+        &config,
+        &closures,
+        |step, current_state| {
+            assert!(
+                current_state.s.data().iter().all(|v| v.is_finite()),
+                "non-finite S̃ at step {}",
+                step + 1
+            );
+            if snapshot_steps.contains(&step) {
+                print_s_stats(&format!("{:03}", step + 1), current_state);
+                dump_snapshot(current_state, step + 1, &dir);
+            }
+        },
+    );
+    let elapsed = started.elapsed();
+
+    // Re-classify boundaries + recompute wedge distance on the
+    // final state. plate_id is static under Phase 1.2 / 1.3 so the
+    // classification matches the one used inside the loop.
+    let boundary = classify_boundaries(&state.plate_id, &kinematics);
+    let wedge_d = wedge_distance_intra_plate(
+        &state.plate_id,
+        &boundary.upper_plate_mask,
+        closures.davis_suppe.max_distance,
+    );
+
+    let max_d_cfg = closures.davis_suppe.max_distance;
+    let mut g_max = 0.0_f64;
+    let mut wedge_values: Vec<f64> = Vec::new();
+    let bucket_edges: [(f64, f64); 3] = [(0.0, 5.0), (5.0, 10.0), (10.0, 20.0)];
+    let mut bucket_sum = [0.0_f64; 3];
+    let mut bucket_count = [0_usize; 3];
+    for j in 0..state.ny() {
+        for i in 0..state.nx() {
+            let v = state.s.get(i, j);
+            if v > g_max {
+                g_max = v;
+            }
+            let d = wedge_d.get(i, j);
+            if d > 0.0 && d < max_d_cfg {
+                wedge_values.push(v);
+                for (b, &(lo, hi)) in bucket_edges.iter().enumerate() {
+                    if d > lo && d <= hi {
+                        bucket_sum[b] += v;
+                        bucket_count[b] += 1;
+                    }
+                }
+            }
+        }
+    }
+    wedge_values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = wedge_values.len();
+    let wedge_max = *wedge_values.last().unwrap_or(&0.0);
+    let wedge_mean = wedge_values.iter().sum::<f64>() / n.max(1) as f64;
+    let wedge_p95 = wedge_values[(n * 95) / 100];
+    let wedge_p99 = wedge_values[(n * 99) / 100];
+
+    let bucket_mean: [f64; 3] = std::array::from_fn(|b| {
+        if bucket_count[b] > 0 {
+            bucket_sum[b] / bucket_count[b] as f64
+        } else {
+            f64::NAN
+        }
+    });
+    let h_crit_at = |d: f64| -> f64 {
+        closures.davis_suppe.h_max * (1.0 - (-d / closures.davis_suppe.l_taper).exp())
+    };
+
+    let fill_near = bucket_mean[0] / h_crit_at(2.5);
+    let fill_far = bucket_mean[2] / h_crit_at(15.0);
+    let asymmetry = bucket_mean[0] / bucket_mean[2];
+
+    eprintln!(
+        "c1_phase_1_3 T2: wedge cells = {n} ({:.1} %)",
+        100.0 * n as f64 / (state.nx() * state.ny()) as f64
+    );
+    eprintln!("c1_phase_1_3 T2: wedge S̃  mean = {wedge_mean:.4}");
+    eprintln!("c1_phase_1_3 T2: wedge S̃  p95  = {wedge_p95:.4}");
+    eprintln!("c1_phase_1_3 T2: wedge S̃  p99  = {wedge_p99:.4}");
+    eprintln!("c1_phase_1_3 T2: wedge S̃  max  = {wedge_max:.4}");
+    for (b, &(lo, hi)) in bucket_edges.iter().enumerate() {
+        let mid = (lo + hi) / 2.0;
+        let h_crit_mid = h_crit_at(mid);
+        let fill = if h_crit_mid > 0.0 {
+            bucket_mean[b] / h_crit_mid
+        } else {
+            f64::NAN
+        };
+        eprintln!(
+            "    d ∈ ({lo:>4.1}, {hi:>4.1}]  count = {:>5}  mean S̃ = {:.4}  h_crit = {:.4}  fill = {:.3}",
+            bucket_count[b], bucket_mean[b], h_crit_mid, fill
+        );
+    }
+    eprintln!("c1_phase_1_3 T2: fill_far  = {fill_far:.3}  (informational)");
+    eprintln!("c1_phase_1_3 T2: global_max (boundary cap) = {g_max:.3}");
+    eprintln!(
+        "c1_phase_1_3 T2: wall time = {:.2?} ({:.2?} per step)",
+        elapsed,
+        elapsed / N_STEPS as u32
+    );
+    eprintln!("c1_phase_1_3 T2: output dir = {}", dir.display());
+    eprintln!("c1_phase_1_3 T2 imprint preservation evidence (composite):");
+    eprintln!("  wedge_p95: {wedge_p95:.3}   (Phase 1.2 baseline: 0.376; expected bit-identical)");
+    eprintln!("  asymmetry: {asymmetry:.2}    (Phase 1.2 baseline: 4.66; expected > 1.5)");
+    eprintln!("  fill_near: {fill_near:.3}   (Phase 1.2 baseline: 0.778; Phase 1.3 floor 0.1)");
+    eprintln!(
+        "  Note: fill_near drop is the *expected* consequence of the equilibrium clamp on"
+    );
+    eprintln!(
+        "        Davis-Suppe outliers (top 1% of wedge cells, capped at h_eq). The bulk"
+    );
+    eprintln!(
+        "        wedge body (wedge_p95) sits below h_eq and is bit-identical Phase 1.2 ↔ 1.3."
+    );
+
+    assert!(
+        bucket_count[0] > 0 && bucket_count[2] > 0,
+        "T2 profile buckets empty: cannot compute fill-ratio metrics"
+    );
+
+    // Sub-assertion 1 — bulk wedge body preserved (PRIMARY).
+    // Phase 1.2 baseline `wedge_p95 = 0.376`. The bulk (95% of
+    // wedge cells) sits below `h_eq = 2.0` and is therefore
+    // untouched by the equilibrium closure — bit-identical
+    // between Phase 1.2 and 1.3. The range `[0.3, 0.5]` absorbs
+    // benign numerical drift while flagging significant
+    // degradation.
+    assert!(
+        (0.3..0.5).contains(&wedge_p95),
+        "T2 sub-1 (wedge_p95 bulk preservation): {wedge_p95:.3} outside [0.3, 0.5] \
+         — Phase 1.2 baseline 0.376; the bulk wedge body below h_eq should be \
+         bit-identical between Phase 1.2 and 1.3. Significant drift indicates \
+         equilibrium closure is interfering with the Davis-Suppe bulk imprint."
+    );
+
+    // Sub-assertion 2 — spatial asymmetry preserved.
+    // Phase 1.2 baseline `asymmetry = 4.66`. The equilibrium
+    // clamp reduces both bucket means but keeps the spatial
+    // shape `near > far`. Phase 1.3 empirical ≈ 2.12.
+    assert!(
+        asymmetry > 1.5,
+        "T2 sub-2 (spatial asymmetry preservation): {asymmetry:.3} ≤ 1.5 \
+         — Phase 1.2 baseline 4.66, Phase 1.3 expected ≈ 2.12. Loss of \
+         asymmetry indicates the wedges have flattened or the imprint is lost."
+    );
+
+    // Sub-assertion 3 — fill_near regime-tagged Phase 1.3 floor.
+    // Phase 1.2 baseline 0.778, Phase 1.3 baseline ≈ 0.207 (the
+    // equilibrium clamp removes Davis-Suppe outliers from the
+    // bucket-mean dominator). The relaxed `> 0.1` threshold
+    // catches catastrophic loss (Davis-Suppe entirely silenced
+    // → fill_near ≈ 0) while accommodating further regime drift
+    // in Phase 1.4+ (the erosion sink will likely lower this
+    // further). Pairs with the memory entry
+    // `feedback_fill_ratio_regime_agnostic_metric` — regime-
+    // tagged thresholds, re-evaluated per phase.
+    assert!(
+        fill_near > 0.1,
+        "T2 sub-3 (fill_near regime-tagged Phase 1.3 floor): {fill_near:.3} ≤ 0.1 \
+         — Phase 1.2 baseline 0.778, Phase 1.3 expected ≈ 0.207. Drop to near \
+         zero indicates Davis-Suppe is entirely suppressed."
+    );
+}
+
+#[test]
+fn equilibrium_alone_caps_initial_state() {
+    // Davis-Suppe OFF, equilibrium-height ON. Pure advection
+    // pile-up under the Phase 1.1 kinematics; the equilibrium
+    // closure must still cap it. Tighter threshold (1.1 × h_eq)
+    // than T1 because there's no Davis-Suppe source pushing
+    // additional mass into the pile-up.
+    let (mut state, kinematics, config) = setup();
+    let closures = C1Closures {
+        davis_suppe: DavisSuppeParams {
+            enabled: false,
+            ..DavisSuppeParams::default()
+        },
+        equilibrium_height: EquilibriumHeightParams::default(),
+    };
+    let h_eq = closures.equilibrium_height.h_eq;
+
+    run_with_closures(&mut state, &kinematics, &config, &closures, |_, _| {});
+
+    let g_max = global_max(&state);
+    let threshold = 1.1 * h_eq;
+    eprintln!(
+        "c1_phase_1_3 T3: global_max = {g_max:.3} (threshold = {threshold:.2} = 1.1 × h_eq = {:.2})",
+        h_eq
+    );
+    assert!(
+        g_max <= threshold,
+        "Phase 1.3 T3 cap failed: global_max = {g_max:.3} > 1.1 × h_eq = {threshold:.2} — \
+         equilibrium standalone ineffective on advection pile-up (no Davis-Suppe to absorb \
+         the excess via its h_max plateau)"
+    );
+}
+
+#[test]
+fn both_closures_disabled_matches_phase_1_1() {
+    // Regression guard: both closures off → run_with_closures
+    // reduces to advection only (closures are no-ops). The Phase 1.1
+    // unbounded pile-up baseline (≈ 1080) must be preserved.
+    // A silent default-state mutation that re-enables a closure
+    // would cap global_max below 100 and fail this assertion.
+    let (mut state, kinematics, config) = setup();
+    let closures = C1Closures {
+        davis_suppe: DavisSuppeParams {
+            enabled: false,
+            ..DavisSuppeParams::default()
+        },
+        equilibrium_height: EquilibriumHeightParams {
+            enabled: false,
+            ..EquilibriumHeightParams::default()
+        },
+    };
+
+    run_with_closures(&mut state, &kinematics, &config, &closures, |_, _| {});
+
+    let g_max = global_max(&state);
+    eprintln!(
+        "c1_phase_1_3 T4: global_max = {g_max:.3} (need > 100, Phase 1.1 baseline ≈ 1080)"
+    );
+    assert!(
+        g_max > 100.0,
+        "T4 Phase 1.1 baseline broken: global_max = {g_max:.3} ≤ 100 — \
+         a closure may be silently active despite enabled=false"
+    );
+}
+
+// ── Diagnostics + viz helpers (mirror of Phase 1.2 helpers) ──
+
+fn print_s_stats(tag: &str, state: &C1State) {
+    let data = state.s.data();
+    let mut min = f64::INFINITY;
+    let mut max = f64::NEG_INFINITY;
+    let mut sum = 0.0;
+    for &v in data {
+        min = min.min(v);
+        max = max.max(v);
+        sum += v;
+    }
+    let mean = sum / data.len() as f64;
+    let mut sq = 0.0;
+    for &v in data {
+        sq += (v - mean) * (v - mean);
+    }
+    let std = (sq / data.len() as f64).sqrt();
+    eprintln!(
+        "c1_phase_1_3: cycle_{tag} S̃ min={min:.4} mean={mean:.4} max={max:.4} std={std:.4e}"
+    );
+}
+
+fn dump_snapshot(state: &C1State, cycle: usize, dir: &Path) {
+    let iso = compute_isostasy(&state.s, &IsostasyConfig::default());
+    let alt_path = dir.join(format!("cycle_{:03}_altitude.png", cycle));
+    save_hypsometric_png(&iso.heightmap, iso.sea_level_normalized, &alt_path);
+
+    let s_path = dir.join(format!("cycle_{:03}_s.png", cycle));
+    save_s_fixed_palette_png(&state.s, S_VIZ_MAX, &s_path);
+}
+
+fn save_hypsometric_png(
+    heightmap: &ymir_core::grid::GridF32,
+    sea_norm: f32,
+    path: &Path,
+) {
+    let nx = heightmap.width;
+    let ny = heightmap.height;
+    let mut img = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(nx as u32, ny as u32);
+    for j in 0..ny {
+        for i in 0..nx {
+            let h = heightmap.get(i as i32, j as i32).clamp(0.0, 1.0);
+            let rgb = hypsometric(h, sea_norm);
+            let img_row = (ny - 1 - j) as u32;
+            img.put_pixel(i as u32, img_row, Rgb(rgb));
+        }
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    img.save(path).expect("save PNG");
+}
+
+fn save_s_fixed_palette_png(s: &Field2D, s_max: f64, path: &Path) {
+    let nx = s.nx();
+    let ny = s.ny();
+    let mut img = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(nx as u32, ny as u32);
+    let sea_norm = 0.2 / s_max;
+    for j in 0..ny {
+        for i in 0..nx {
+            let v = (s.get(i, j) / s_max).clamp(0.0, 1.0) as f32;
+            let rgb = hypsometric(v, sea_norm as f32);
+            let img_row = (ny - 1 - j) as u32;
+            img.put_pixel(i as u32, img_row, Rgb(rgb));
+        }
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent dir");
+    }
+    img.save(path).expect("save PNG");
+}
+
+fn hypsometric(h: f32, sea_norm: f32) -> [u8; 3] {
+    let mid = (sea_norm + 1.0) * 0.5;
+    let lerp = |t: f32, a: [u8; 3], b: [u8; 3]| -> [u8; 3] {
+        let t = t.clamp(0.0, 1.0);
+        [
+            (a[0] as f32 + t * (b[0] as f32 - a[0] as f32)).round() as u8,
+            (a[1] as f32 + t * (b[1] as f32 - a[1] as f32)).round() as u8,
+            (a[2] as f32 + t * (b[2] as f32 - a[2] as f32)).round() as u8,
+        ]
+    };
+    if h <= sea_norm * 0.5 {
+        let t = h / (sea_norm * 0.5).max(1e-6);
+        lerp(t, [10, 20, 60], [40, 80, 160])
+    } else if h <= sea_norm {
+        let t = (h - sea_norm * 0.5) / (sea_norm * 0.5).max(1e-6);
+        lerp(t, [40, 80, 160], [120, 180, 230])
+    } else if h <= mid {
+        let t = (h - sea_norm) / (mid - sea_norm).max(1e-6);
+        lerp(t, [60, 130, 60], [140, 100, 50])
+    } else {
+        let t = (h - mid) / (1.0 - mid).max(1e-6);
+        lerp(t, [140, 100, 50], [245, 245, 245])
+    }
+}

--- a/crates/ymir-core/tests/c1_phase_1_3_workflow.rs
+++ b/crates/ymir-core/tests/c1_phase_1_3_workflow.rs
@@ -1,0 +1,311 @@
+//! Issue #125 Phase 1.3 H3 — integration tests for the C1 Phase A
+//! path through the workflow wrapper.
+//!
+//! Lives under default features (no `v2_legacy` requirement) — the
+//! C1 path is the mainline paradigm; the v2 path's parallel
+//! regression tests live in `tests/_attic/v2_workflow_*`.
+//!
+//! Test inventory (per H3 user spec):
+//!
+//! - [`c1_phase_a_cycle_smoke_integration`] — public API smoke
+//!   through the `tests/` directory. Catches missing pub re-
+//!   exports that the in-module test in `phase_a_c1.rs` would
+//!   silently bypass.
+//! - [`c1_phase_a_decomposes_into_closures_then_post_tectonic`] —
+//!   the C1 analogue of v2's bit-identical Disabled regression.
+//!   Verifies that `run_phase_a_cycle_c1(input, Enabled(_))` is
+//!   *exactly* `run_with_closures(state, …)` followed by
+//!   `apply_post_tectonic(PostTectonicInput { … })` —
+//!   "wrapper = building blocks, nothing more, nothing less".
+//!   Bit-identical equality, no tolerance.
+//! - [`c1_phase_a_with_disabled_closures_matches_phase_1_1`] —
+//!   with all closures off and `wf = Disabled`, the wrapper
+//!   reduces to plain Phase 1.1 advection; mass conservation
+//!   `< 1e-10` must hold.
+//! - [`c1_phase_a_with_cratonic_enabled_produces_factor`] — sanity
+//!   check that the cratonic path is exercisable from C1, produces
+//!   a `Field2D` of correct shape with values in `[0, 1]`.
+//!
+//! These are H3 smoke + regression tests, **not** Phase 1.3
+//! acceptance tests — those land in Stage E3 (4 invariants on
+//! equilibrium-height + Davis-Suppe interaction at 64²×300).
+
+use ymir_core::tectonics::isostasy::IsostasyConfig;
+use ymir_core::tectonics_c1::closures::davis_suppe::source_term::DavisSuppeParams;
+use ymir_core::tectonics_c1::closures::equilibrium_height::params::EquilibriumHeightParams;
+use ymir_core::tectonics_c1::init::init_c1_state_phase_1_1;
+use ymir_core::tectonics_c1::kinematics::PlateKinematics;
+use ymir_core::tectonics_c1::time_loop::{run_with_closures, C1Closures, C1TimeLoopConfig};
+use ymir_core::tectonics_v2::cratonic::CratonicConfigEnabled;
+use ymir_core::tectonics_v2::workflow::phase_a_common::{
+    apply_post_tectonic, extract_per_plate_type, PostTectonicInput,
+};
+use ymir_core::tectonics_v2::workflow::{
+    run_phase_a_cycle_c1, PhaseACycleInputC1, WorkflowConfig, WorkflowParams,
+};
+
+const GRID: usize = 32;
+const SEED: u64 = 42;
+
+fn make_time_loop_config(n_steps: usize) -> C1TimeLoopConfig {
+    C1TimeLoopConfig {
+        n_steps,
+        dx: 1.0 / GRID as f64,
+        dy: 1.0 / GRID as f64,
+    }
+}
+
+#[test]
+fn c1_phase_a_cycle_smoke_integration() {
+    // Smoke through the public API only. Lighter than the inline
+    // Commit 4 test (32² × 50 steps vs 64² × 300) so it stays
+    // sub-second under default `cargo test`.
+    let mut state = init_c1_state_phase_1_1(GRID, SEED);
+    let kinematics = PlateKinematics::preset_phase_1_1(state.num_plates);
+    let closures = C1Closures::default();
+    let time_loop_config = make_time_loop_config(50);
+    let iso_config = IsostasyConfig::default();
+    let wf = WorkflowConfig::Enabled(WorkflowParams::default());
+
+    let output = run_phase_a_cycle_c1(
+        PhaseACycleInputC1 {
+            state: &mut state,
+            kinematics: &kinematics,
+            closures: &closures,
+            time_loop_config: &time_loop_config,
+            iso_config: &iso_config,
+            cratonic_config: None,
+        },
+        &wf,
+    );
+
+    assert!(
+        state.s.data().iter().all(|v| v.is_finite()),
+        "no NaN/Inf in S̃ after smoke run"
+    );
+    assert!(
+        output.common.sea_level_normalized > 0.0,
+        "Enabled post-pass must compute sea_level_normalized; got {}",
+        output.common.sea_level_normalized
+    );
+}
+
+#[test]
+fn c1_phase_a_decomposes_into_closures_then_post_tectonic() {
+    // The C1 analogue of v2's bit-identical Disabled regression:
+    // `run_phase_a_cycle_c1(input, Enabled(_))` must equal
+    // `run_with_closures` + `apply_post_tectonic` byte-for-byte.
+    // No tolerance — exact equality on the S̃ buffer and on all
+    // five `CycleOutputCommon` scalars.
+    //
+    // Surfaces order-sensitivity / hidden state in the wrapper if
+    // the equality breaks. Per H3 W2: if numerical noise > 1e-15
+    // appears, surface as architectural finding.
+
+    let n_steps = 30;
+    let kinematics_template = {
+        let scratch = init_c1_state_phase_1_1(GRID, SEED);
+        PlateKinematics::preset_phase_1_1(scratch.num_plates)
+    };
+    let closures = C1Closures::default();
+    let time_loop_config = make_time_loop_config(n_steps);
+    let iso_config = IsostasyConfig::default();
+    let wf_params = WorkflowParams::default();
+    let phase_a_params = wf_params.phase_a.clone();
+    let wf = WorkflowConfig::Enabled(wf_params);
+
+    // Path A — through the workflow wrapper.
+    let mut state_a = init_c1_state_phase_1_1(GRID, SEED);
+    let output_a = run_phase_a_cycle_c1(
+        PhaseACycleInputC1 {
+            state: &mut state_a,
+            kinematics: &kinematics_template,
+            closures: &closures,
+            time_loop_config: &time_loop_config,
+            iso_config: &iso_config,
+            cratonic_config: None,
+        },
+        &wf,
+    );
+
+    // Path B — manual decomposition: run_with_closures then
+    // apply_post_tectonic with the same paradigm-agnostic input
+    // bundle the wrapper builds internally.
+    let mut state_b = init_c1_state_phase_1_1(GRID, SEED);
+    run_with_closures(
+        &mut state_b,
+        &kinematics_template,
+        &time_loop_config,
+        &closures,
+        |_, _| {},
+    );
+    let original_per_plate_type = extract_per_plate_type(&state_b.plate_id, &state_b.plate_type);
+    let output_b = apply_post_tectonic(PostTectonicInput {
+        s_field: &mut state_b.s,
+        plate_id: Some(&state_b.plate_id),
+        plate_type: Some(&mut state_b.plate_type),
+        previous_cratonic_factor: None,
+        initial_per_plate_type: Some(&original_per_plate_type),
+        params: &phase_a_params,
+        iso_cfg: &iso_config,
+        cratonic_cfg: None,
+    });
+
+    // Bit-identical state.
+    assert_eq!(
+        state_a.s.data(),
+        state_b.s.data(),
+        "S̃ field must be bit-identical between wrapper and manual decomposition"
+    );
+
+    // Bit-identical common scalars (no order-sensitivity allowed).
+    assert_eq!(
+        output_a.common.erosion_volume_removed, output_b.common.erosion_volume_removed,
+        "erosion_volume_removed must be bit-identical"
+    );
+    assert_eq!(
+        output_a.common.erosion_peak_delta_h, output_b.common.erosion_peak_delta_h,
+        "erosion_peak_delta_h must be bit-identical"
+    );
+    assert_eq!(
+        output_a.common.sea_level_normalized, output_b.common.sea_level_normalized,
+        "sea_level_normalized must be bit-identical"
+    );
+    assert_eq!(
+        output_a.common.mass_drift, output_b.common.mass_drift,
+        "mass_drift must be bit-identical"
+    );
+    assert_eq!(
+        output_a.common.craton_recomputation_change, output_b.common.craton_recomputation_change,
+        "craton_recomputation_change must be bit-identical"
+    );
+}
+
+#[test]
+fn c1_phase_a_with_disabled_closures_matches_phase_1_1() {
+    // C1 parallel of v2's `workflow_disabled_run_phase_a_cycle_is_
+    // bit_identical_to_run_baseline` regression. Two layers:
+    //
+    //   (a) `wf = Disabled` → wrapper degenerates to a direct
+    //       `run_with_closures` call (no post-pass). The two
+    //       paths must produce bit-identical S̃ buffers.
+    //   (b) With both closures disabled, the C1 tectonic step is
+    //       advection-only, which is Phase 1.1 — mass conservation
+    //       at machine-precision floor (1e-10 relative budget,
+    //       same as Phase 1.1 invariant).
+    let closures_off = C1Closures {
+        davis_suppe: DavisSuppeParams {
+            enabled: false,
+            ..DavisSuppeParams::default()
+        },
+        equilibrium_height: EquilibriumHeightParams {
+            enabled: false,
+            ..EquilibriumHeightParams::default()
+        },
+    };
+    let time_loop_config = make_time_loop_config(50);
+    let iso_config = IsostasyConfig::default();
+
+    let kinematics = {
+        let scratch = init_c1_state_phase_1_1(GRID, SEED);
+        PlateKinematics::preset_phase_1_1(scratch.num_plates)
+    };
+
+    // (a) Wrapper Disabled.
+    let mut state_a = init_c1_state_phase_1_1(GRID, SEED);
+    let initial_mass_a: f64 = state_a.s.data().iter().sum();
+    let output_a = run_phase_a_cycle_c1(
+        PhaseACycleInputC1 {
+            state: &mut state_a,
+            kinematics: &kinematics,
+            closures: &closures_off,
+            time_loop_config: &time_loop_config,
+            iso_config: &iso_config,
+            cratonic_config: None,
+        },
+        &WorkflowConfig::Disabled,
+    );
+    let final_mass_a: f64 = state_a.s.data().iter().sum();
+
+    // Disabled output must be the default CycleOutputCommon.
+    assert_eq!(output_a.common.sea_level_normalized, 0.0);
+    assert_eq!(output_a.common.mass_drift, 0.0);
+    assert_eq!(output_a.common.erosion_volume_removed, 0.0);
+    assert_eq!(output_a.common.erosion_peak_delta_h, 0.0);
+    assert!(output_a.common.craton_recomputation_change.is_none());
+    assert!(output_a.new_cratonic_factor.is_none());
+
+    // (b) Direct `run_with_closures` with the same closures_off.
+    let mut state_b = init_c1_state_phase_1_1(GRID, SEED);
+    let initial_mass_b: f64 = state_b.s.data().iter().sum();
+    run_with_closures(
+        &mut state_b,
+        &kinematics,
+        &time_loop_config,
+        &closures_off,
+        |_, _| {},
+    );
+    let final_mass_b: f64 = state_b.s.data().iter().sum();
+
+    // Both paths must produce bit-identical S̃ — wrapper Disabled
+    // is, literally, `run_with_closures` plus zero post-pass.
+    assert_eq!(
+        state_a.s.data(),
+        state_b.s.data(),
+        "Disabled wrapper must be bit-identical to direct run_with_closures"
+    );
+
+    // Phase 1.1 advection-only invariant: mass conserved at
+    // machine-precision floor.
+    let rel_drift_a = (final_mass_a - initial_mass_a).abs() / initial_mass_a;
+    let rel_drift_b = (final_mass_b - initial_mass_b).abs() / initial_mass_b;
+    assert!(
+        rel_drift_a < 1e-10,
+        "closures-off wrapper relative mass drift {rel_drift_a:.3e} exceeds 1e-10 — Phase 1.1 invariant broken"
+    );
+    assert!(
+        rel_drift_b < 1e-10,
+        "closures-off direct run relative mass drift {rel_drift_b:.3e} exceeds 1e-10 — Phase 1.1 invariant broken"
+    );
+}
+
+#[test]
+fn c1_phase_a_with_cratonic_enabled_produces_factor() {
+    // Exercise the cratonic-recompute path: pass a real
+    // `CratonicConfigEnabled` and verify the produced
+    // `new_cratonic_factor` is `Some(Field2D)` with the right
+    // shape and value range. Not a numerical / D4-rule test
+    // (those are v2's `v2_workflow_cratonic_recompute_*` under
+    // v2_legacy); just a "C1 can drive this codepath" sanity.
+    let mut state = init_c1_state_phase_1_1(GRID, SEED);
+    let kinematics = PlateKinematics::preset_phase_1_1(state.num_plates);
+    let closures = C1Closures::default();
+    let time_loop_config = make_time_loop_config(30);
+    let iso_config = IsostasyConfig::default();
+    let cratonic_cfg = CratonicConfigEnabled::default();
+    let wf = WorkflowConfig::Enabled(WorkflowParams::default());
+
+    let output = run_phase_a_cycle_c1(
+        PhaseACycleInputC1 {
+            state: &mut state,
+            kinematics: &kinematics,
+            closures: &closures,
+            time_loop_config: &time_loop_config,
+            iso_config: &iso_config,
+            cratonic_config: Some(&cratonic_cfg),
+        },
+        &wf,
+    );
+
+    let factor = output
+        .new_cratonic_factor
+        .expect("cratonic_config Enabled must produce a factor");
+    assert_eq!(factor.nx(), GRID, "cratonic factor must match grid width");
+    assert_eq!(factor.ny(), GRID, "cratonic factor must match grid height");
+    for &v in factor.data() {
+        assert!(
+            (0.0..=1.0).contains(&v),
+            "cratonic factor values must lie in [0, 1] (smoothstep range); got {v}"
+        );
+    }
+}

--- a/crates/ymir-viz/src/bridge/v2/plugin.rs
+++ b/crates/ymir-viz/src/bridge/v2/plugin.rs
@@ -321,7 +321,7 @@ fn poll_v2_events(
                 // cycle counter lives in `cycle_context`; `step` /
                 // `total` are left at the harness-step values
                 // (typically (0, 0) for Phase A since no per-step
-                // Progress events fire inside `run_phase_a_cycle`'s
+                // Progress events fire inside `run_phase_a_cycle_v2`'s
                 // internal `run_baseline`). The dashboard chooses
                 // which counter to display based on
                 // `cycle_context.is_some()`.

--- a/crates/ymir-viz/src/bridge/v2/thread.rs
+++ b/crates/ymir-viz/src/bridge/v2/thread.rs
@@ -208,10 +208,11 @@ pub fn spawn_v2_thread(
                                 cycle_idx,
                                 n_cycles,
                                 peek_state: peek_state.clone(),
-                                erosion_volume_removed: cycle_output.erosion_volume_removed,
-                                sea_level_normalized: cycle_output.sea_level_normalized,
-                                mass_drift: cycle_output.mass_drift,
+                                erosion_volume_removed: cycle_output.common.erosion_volume_removed,
+                                sea_level_normalized: cycle_output.common.sea_level_normalized,
+                                mass_drift: cycle_output.common.mass_drift,
                                 craton_recomputation_change: cycle_output
+                                    .common
                                     .craton_recomputation_change,
                             });
 
@@ -313,10 +314,11 @@ pub fn spawn_v2_thread(
                                 cycle_idx,
                                 n_cycles,
                                 peek_state: peek_state.clone(),
-                                erosion_volume_removed: cycle_output.erosion_volume_removed,
-                                sea_level_normalized: cycle_output.sea_level_normalized,
-                                mass_drift: cycle_output.mass_drift,
+                                erosion_volume_removed: cycle_output.common.erosion_volume_removed,
+                                sea_level_normalized: cycle_output.common.sea_level_normalized,
+                                mass_drift: cycle_output.common.mass_drift,
                                 craton_recomputation_change: cycle_output
+                                    .common
                                     .craton_recomputation_change,
                             });
 

--- a/crates/ymir-viz/src/bridge/v2/thread.rs
+++ b/crates/ymir-viz/src/bridge/v2/thread.rs
@@ -18,7 +18,7 @@ use ymir_core::tectonics_v2::diagnostics::harness::{
 };
 use ymir_core::tectonics_v2::field::Field2D;
 use ymir_core::tectonics_v2::workflow::{
-    final_state_to_continuation, run_phase_a_cycle_with_progress, run_phase_b, WorkflowConfig,
+    final_state_to_continuation_v2, run_phase_a_cycle_with_progress_v2, run_phase_b, WorkflowConfig,
 };
 
 use super::build_config;
@@ -186,7 +186,7 @@ pub fn spawn_v2_thread(
                             // milliseconds.
                             let tx_progress = events_tx.clone();
                             let cancel_for_callback = cancel.clone();
-                            let cycle_output = run_phase_a_cycle_with_progress(
+                            let cycle_output = run_phase_a_cycle_with_progress_v2(
                                 &cfg,
                                 &workflow_cfg,
                                 |progress| {
@@ -217,7 +217,7 @@ pub fn spawn_v2_thread(
                             });
 
                             if cycle_idx + 1 < n_cycles {
-                                cfg.continuation = Some(final_state_to_continuation(
+                                cfg.continuation = Some(final_state_to_continuation_v2(
                                     &cycle_output.baseline.final_state,
                                 ));
                             }
@@ -292,7 +292,7 @@ pub fn spawn_v2_thread(
                             // milliseconds.
                             let tx_progress = events_tx.clone();
                             let cancel_for_callback = cancel.clone();
-                            let cycle_output = run_phase_a_cycle_with_progress(
+                            let cycle_output = run_phase_a_cycle_with_progress_v2(
                                 &cfg,
                                 &workflow_cfg,
                                 |progress| {
@@ -323,7 +323,7 @@ pub fn spawn_v2_thread(
                             });
 
                             if cycle_idx + 1 < n_cycles {
-                                cfg.continuation = Some(final_state_to_continuation(
+                                cfg.continuation = Some(final_state_to_continuation_v2(
                                     &cycle_output.baseline.final_state,
                                 ));
                             }

--- a/crates/ymir-viz/src/ui/metrics_dashboard.rs
+++ b/crates/ymir-viz/src/ui/metrics_dashboard.rs
@@ -77,7 +77,7 @@ pub fn draw(ui: &mut egui::Ui, bridge: &V2SolverBridge, viz: &V2VizState) {
             // "Running". `cycle_context` distinguishes a Phase A
             // workflow run from a single-baseline run; for Phase A
             // we lean on the cycle counter instead of the harness
-            // step counter because `run_phase_a_cycle` does not
+            // step counter because `run_phase_a_cycle_v2` does not
             // currently stream per-step Progress events.
             let activity = match (
                 cycle_context,

--- a/crates/ymir-viz/tests/_attic/v2_workflow_r4_visual_checkpoint.rs
+++ b/crates/ymir-viz/tests/_attic/v2_workflow_r4_visual_checkpoint.rs
@@ -221,7 +221,7 @@ fn run_gallery_for_preset(preset_name: &str, out_dir: &Path) -> Vec<CycleMetrics
 
     // INIT metrics (use init field, no erosion stats).
     let init_field = Field2D::from_vec(init_state.nx, init_state.ny, init_state.s_field.clone());
-    let init_sea = output.cycles.first().map(|c| c.sea_level_normalized).unwrap_or(0.5);
+    let init_sea = output.cycles.first().map(|c| c.common.sea_level_normalized).unwrap_or(0.5);
     let mut metrics = vec![compute_metrics(0, &init_field, init_sea, 0.0, 0.0)];
 
     // Per-cycle metrics + PNG.
@@ -244,9 +244,9 @@ fn run_gallery_for_preset(preset_name: &str, out_dir: &Path) -> Vec<CycleMetrics
         metrics.push(compute_metrics(
             cyc_idx,
             &cycle.baseline.final_state.s_field,
-            cycle.sea_level_normalized,
-            cycle.erosion_volume_removed,
-            cycle.mass_drift,
+            cycle.common.sea_level_normalized,
+            cycle.common.erosion_volume_removed,
+            cycle.common.mass_drift,
         ));
     }
 
@@ -273,7 +273,7 @@ fn write_metrics_table(preset_name: &str, metrics: &[CycleMetrics], out_dir: &Pa
             m.sea_level_ref,
             m.max_path_length,
             m.total_eroded,
-            m.mass_drift,
+            m.common.mass_drift,
         ));
     }
     md.push('\n');
@@ -322,7 +322,7 @@ fn write_metrics_table(preset_name: &str, metrics: &[CycleMetrics], out_dir: &Pa
     let cumulative_drift: f64 = metrics
         .iter()
         .skip(1)
-        .map(|m| m.mass_drift.abs())
+        .map(|m| m.common.mass_drift.abs())
         .sum();
     let budget = init.mass_total.abs() * 1e-9;
     let r4_4 = cumulative_drift < budget;
@@ -452,16 +452,16 @@ fn run_r4b_variant(
         .expect("save final alt");
 
     let init_field = Field2D::from_vec(init_state.nx, init_state.ny, init_state.s_field.clone());
-    let init_sea = output.cycles.first().map(|c| c.sea_level_normalized).unwrap_or(0.5);
+    let init_sea = output.cycles.first().map(|c| c.common.sea_level_normalized).unwrap_or(0.5);
     let init_metrics = compute_metrics(0, &init_field, init_sea, 0.0, 0.0);
     let final_metrics = compute_metrics(
         R4B_N_CYCLES,
         &final_cycle.baseline.final_state.s_field,
-        final_cycle.sea_level_normalized,
-        final_cycle.erosion_volume_removed,
-        final_cycle.mass_drift,
+        final_cycle.common.sea_level_normalized,
+        final_cycle.common.erosion_volume_removed,
+        final_cycle.common.mass_drift,
     );
-    let cumulative_drift: f64 = output.cycles.iter().map(|c| c.mass_drift.abs()).sum();
+    let cumulative_drift: f64 = output.cycles.iter().map(|c| c.common.mass_drift.abs()).sum();
 
     R4bMetrics {
         init: init_metrics,
@@ -761,7 +761,7 @@ fn run_r5b_mf_sweep(mf_value: f64, label: &str) {
     println!("[r5b-sweep/{label}] completed in {elapsed:.1}s");
 
     let init_field = Field2D::from_vec(init_state.nx, init_state.ny, init_state.s_field.clone());
-    let init_sea = output.cycles.first().map(|c| c.sea_level_normalized).unwrap_or(0.5);
+    let init_sea = output.cycles.first().map(|c| c.common.sea_level_normalized).unwrap_or(0.5);
     let mut metrics = vec![compute_metrics(0, &init_field, init_sea, 0.0, 0.0)];
 
     for (i, cycle) in output.cycles.iter().enumerate() {
@@ -782,9 +782,9 @@ fn run_r5b_mf_sweep(mf_value: f64, label: &str) {
         metrics.push(compute_metrics(
             cyc_idx,
             &cycle.baseline.final_state.s_field,
-            cycle.sea_level_normalized,
-            cycle.erosion_volume_removed,
-            cycle.mass_drift,
+            cycle.common.sea_level_normalized,
+            cycle.common.erosion_volume_removed,
+            cycle.common.mass_drift,
         ));
     }
 
@@ -984,7 +984,7 @@ fn run_r5b_evo_sweep(mf_value: f64, evo_rate: f64, label: &str) {
 
     let init_field =
         Field2D::from_vec(init_state.nx, init_state.ny, init_state.s_field.clone());
-    let init_sea = output.cycles.first().map(|c| c.sea_level_normalized).unwrap_or(0.5);
+    let init_sea = output.cycles.first().map(|c| c.common.sea_level_normalized).unwrap_or(0.5);
     let mut metrics = vec![compute_metrics(0, &init_field, init_sea, 0.0, 0.0)];
     for (i, cycle) in output.cycles.iter().enumerate() {
         let cyc_idx = i + 1;
@@ -994,9 +994,9 @@ fn run_r5b_evo_sweep(mf_value: f64, evo_rate: f64, label: &str) {
         metrics.push(compute_metrics(
             cyc_idx,
             &cycle.baseline.final_state.s_field,
-            cycle.sea_level_normalized,
-            cycle.erosion_volume_removed,
-            cycle.mass_drift,
+            cycle.common.sea_level_normalized,
+            cycle.common.erosion_volume_removed,
+            cycle.common.mass_drift,
         ));
     }
 
@@ -1176,16 +1176,16 @@ fn run_r5_dt_variant(label: &str, k_cycle: usize) -> (R4bMetrics, R5SolverMetric
         .expect("save final alt");
 
     let init_field = Field2D::from_vec(init_state.nx, init_state.ny, init_state.s_field.clone());
-    let init_sea = output.cycles.first().map(|c| c.sea_level_normalized).unwrap_or(0.5);
+    let init_sea = output.cycles.first().map(|c| c.common.sea_level_normalized).unwrap_or(0.5);
     let init_metrics = compute_metrics(0, &init_field, init_sea, 0.0, 0.0);
     let final_metrics = compute_metrics(
         5,
         &final_cycle.baseline.final_state.s_field,
-        final_cycle.sea_level_normalized,
-        final_cycle.erosion_volume_removed,
-        final_cycle.mass_drift,
+        final_cycle.common.sea_level_normalized,
+        final_cycle.common.erosion_volume_removed,
+        final_cycle.common.mass_drift,
     );
-    let cumulative_drift: f64 = output.cycles.iter().map(|c| c.mass_drift.abs()).sum();
+    let cumulative_drift: f64 = output.cycles.iter().map(|c| c.common.mass_drift.abs()).sum();
 
     let r4b = R4bMetrics {
         init: init_metrics,
@@ -1381,8 +1381,8 @@ fn run_r5_0_1_short_dt(total_time: f64, label: &str) {
     md.push_str(&format!("- CG iter mean: **{:.1}**  (max: {})\n", m.cg_iter_mean, m.cg_iter_max));
     md.push_str(&format!("- Kappa estimate: {:.2e}\n", m.kappa_estimate));
     md.push_str(&format!("- Peak |v|: {:.3e}\n", m.vmax_peak));
-    md.push_str(&format!("- Mass drift over 1 cycle: {:.3e}\n", cycle.mass_drift));
-    md.push_str(&format!("- Mass drift cumulative (1 cycle = same): {:.3e}\n\n", cycle.mass_drift.abs()));
+    md.push_str(&format!("- Mass drift over 1 cycle: {:.3e}\n", cycle.common.mass_drift));
+    md.push_str(&format!("- Mass drift cumulative (1 cycle = same): {:.3e}\n\n", cycle.common.mass_drift.abs()));
 
     let cap_2000 = m.cg_iter_max >= 2000;
     let nominal = m.cg_iter_mean < 500.0;
@@ -1710,7 +1710,7 @@ fn run_r5b_d1_bis() {
             newt.stalled,
             newt.diverged,
             newt.capped,
-            cycle.mass_drift,
+            cycle.common.mass_drift,
         ));
     }
 
@@ -1850,7 +1850,7 @@ fn r5b_d1_bis_per_step_workflow_on_post_d2() {
             newt.stalled,
             newt.diverged,
             newt.capped,
-            cycle.mass_drift,
+            cycle.common.mass_drift,
         ));
     }
 
@@ -2408,7 +2408,7 @@ fn r5b_validation_r4_active_medley_64sq_mf_0_5() {
     let init_sea = output
         .cycles
         .first()
-        .map(|c| c.sea_level_normalized)
+        .map(|c| c.common.sea_level_normalized)
         .unwrap_or(0.5);
     let mut metrics = vec![compute_metrics(0, &init_field, init_sea, 0.0, 0.0)];
 
@@ -2431,9 +2431,9 @@ fn r5b_validation_r4_active_medley_64sq_mf_0_5() {
         metrics.push(compute_metrics(
             cyc_idx,
             &cycle.baseline.final_state.s_field,
-            cycle.sea_level_normalized,
-            cycle.erosion_volume_removed,
-            cycle.mass_drift,
+            cycle.common.sea_level_normalized,
+            cycle.common.erosion_volume_removed,
+            cycle.common.mass_drift,
         ));
     }
 
@@ -2536,7 +2536,7 @@ fn r5b_d1_bis_per_step_workflow_on_post_d1_ter() {
             "\n_Cycle {} aggregate: Converged={}, Stalled={}, Diverged={}, Capped={}, mass_drift={:.3e}_\n\n",
             cycle_idx + 1,
             newt.converged, newt.stalled, newt.diverged, newt.capped,
-            cycle.mass_drift,
+            cycle.common.mass_drift,
         ));
     }
 
@@ -2659,7 +2659,7 @@ fn run_r6_3_config(mf: f64, evo_rate: f64, label: &str) -> R6ConfigSummary {
 
     let init_field =
         Field2D::from_vec(init_state.nx, init_state.ny, init_state.s_field.clone());
-    let init_sea = output.cycles.first().map(|c| c.sea_level_normalized).unwrap_or(0.5);
+    let init_sea = output.cycles.first().map(|c| c.common.sea_level_normalized).unwrap_or(0.5);
     let init_metrics = compute_metrics(0, &init_field, init_sea, 0.0, 0.0);
     let mut metrics = vec![init_metrics];
 
@@ -2686,9 +2686,9 @@ fn run_r6_3_config(mf: f64, evo_rate: f64, label: &str) -> R6ConfigSummary {
         metrics.push(compute_metrics(
             cyc_idx,
             &cycle.baseline.final_state.s_field,
-            cycle.sea_level_normalized,
-            cycle.erosion_volume_removed,
-            cycle.mass_drift,
+            cycle.common.sea_level_normalized,
+            cycle.common.erosion_volume_removed,
+            cycle.common.mass_drift,
         ));
         peak_v_per_cycle.push(cycle.baseline.metrics.vmax_peak);
         if let Some(n) = cycle.baseline.metrics.newton.as_ref() {
@@ -3250,7 +3250,7 @@ fn run_r6_3_c4_config(
 
     let init_field =
         Field2D::from_vec(init_state.nx, init_state.ny, init_state.s_field.clone());
-    let init_sea = output.cycles.first().map(|c| c.sea_level_normalized).unwrap_or(0.5);
+    let init_sea = output.cycles.first().map(|c| c.common.sea_level_normalized).unwrap_or(0.5);
     let init_metrics = compute_metrics(0, &init_field, init_sea, 0.0, 0.0);
     let mut metrics = vec![init_metrics];
 
@@ -3277,9 +3277,9 @@ fn run_r6_3_c4_config(
         metrics.push(compute_metrics(
             cyc_idx,
             &cycle.baseline.final_state.s_field,
-            cycle.sea_level_normalized,
-            cycle.erosion_volume_removed,
-            cycle.mass_drift,
+            cycle.common.sea_level_normalized,
+            cycle.common.erosion_volume_removed,
+            cycle.common.mass_drift,
         ));
         peak_v_per_cycle.push(cycle.baseline.metrics.vmax_peak);
         if let Some(n) = cycle.baseline.metrics.newton.as_ref() {
@@ -4005,7 +4005,7 @@ fn run_r7_a_2_4_config(
 
     let init_field =
         Field2D::from_vec(init_state.nx, init_state.ny, init_state.s_field.clone());
-    let init_sea = output.cycles.first().map(|c| c.sea_level_normalized).unwrap_or(0.5);
+    let init_sea = output.cycles.first().map(|c| c.common.sea_level_normalized).unwrap_or(0.5);
     let init_metrics = compute_metrics(0, &init_field, init_sea, 0.0, 0.0);
     let mut metrics = vec![init_metrics];
 
@@ -4035,9 +4035,9 @@ fn run_r7_a_2_4_config(
         metrics.push(compute_metrics(
             cyc_idx,
             &cycle.baseline.final_state.s_field,
-            cycle.sea_level_normalized,
-            cycle.erosion_volume_removed,
-            cycle.mass_drift,
+            cycle.common.sea_level_normalized,
+            cycle.common.erosion_volume_removed,
+            cycle.common.mass_drift,
         ));
         peak_v_per_cycle.push(cycle.baseline.metrics.vmax_peak);
         if let Some(n) = cycle.baseline.metrics.newton.as_ref() {

--- a/crates/ymir-viz/tests/_attic/v2_workflow_r4_visual_checkpoint.rs
+++ b/crates/ymir-viz/tests/_attic/v2_workflow_r4_visual_checkpoint.rs
@@ -38,7 +38,7 @@ use ymir_core::tectonics_v2::field::Field2D;
 use ymir_core::tectonics_v2::init::{init_s_field, InitContext, PlateInitData};
 use ymir_core::tectonics_v2::voronoi::{generate_voronoi, VoronoiConfig};
 use ymir_core::tectonics_v2::workflow::{
-    drainage::compute_drainage_targets, run_phase_a_loop,
+    drainage::compute_drainage_targets, run_phase_a_loop_v2,
 };
 
 use ymir_viz::bridge::v2::{
@@ -215,7 +215,7 @@ fn run_gallery_for_preset(preset_name: &str, out_dir: &Path) -> Vec<CycleMetrics
 
     println!("[r4] {preset_name}: running 5 cycles × 20 steps (mantle ON, 64²)…");
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[r4] {preset_name}: completed in {elapsed:.1}s, {} cycles", output.cycles.len());
 
@@ -439,7 +439,7 @@ fn run_r4b_variant(
     let wf = build_config::build_workflow(&spec.workflow);
 
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[r4b/{label}] completed in {elapsed:.1}s, {} cycles", output.cycles.len());
 
@@ -756,7 +756,7 @@ fn run_r5b_mf_sweep(mf_value: f64, label: &str) {
     let wf = build_config::build_workflow(&spec.workflow);
 
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[r5b-sweep/{label}] completed in {elapsed:.1}s");
 
@@ -978,7 +978,7 @@ fn run_r5b_evo_sweep(mf_value: f64, evo_rate: f64, label: &str) {
     let wf = build_config::build_workflow(&spec.workflow);
 
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[r5b-evo/{label}] completed in {elapsed:.1}s");
 
@@ -1163,7 +1163,7 @@ fn run_r5_dt_variant(label: &str, k_cycle: usize) -> (R4bMetrics, R5SolverMetric
     let wf = build_config::build_workflow(&spec.workflow);
 
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[r5/{label}] completed in {elapsed:.1}s, {} cycles", output.cycles.len());
 
@@ -1360,7 +1360,7 @@ fn run_r5_0_1_short_dt(total_time: f64, label: &str) {
     let wf = build_config::build_workflow(&spec.workflow);
 
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
 
     let cycle = output.cycles.first().expect("at least one cycle");
@@ -1613,7 +1613,7 @@ fn r5b_d1_amg_cg() {
 // specific to the macro_redistribution → tectonic continuation
 // interaction.
 //
-// D1-bis: instrument run_phase_a_loop on a short 2-cycle × 20-step
+// D1-bis: instrument run_phase_a_loop_v2 on a short 2-cycle × 20-step
 // configuration. Extract per-step CG iter and Newton outer iter,
 // labelled by `(cycle_idx, step_idx_in_cycle)`. Goal: localise
 // where in the cycle the CG saturates.
@@ -1658,7 +1658,7 @@ fn run_r5b_d1_bis() {
     let wf = build_config::build_workflow(&spec.workflow);
 
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[r5b/d1-bis] completed in {elapsed:.1}s, {} cycles", output.cycles.len());
 
@@ -1801,7 +1801,7 @@ fn r5b_d1_bis_per_step_workflow_on_post_d2() {
     let wf = build_config::build_workflow(&spec.workflow);
 
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[r5b/d1-bis post-D2] completed in {elapsed:.1}s");
 
@@ -1918,7 +1918,7 @@ struct StepSnapshot {
 fn r5b_d2_bis_oscillating_evolution() {
     use std::cell::RefCell;
     use ymir_core::tectonics_v2::workflow::{
-        final_state_to_continuation, run_phase_a_cycle_with_progress,
+        final_state_to_continuation_v2, run_phase_a_cycle_with_progress_v2,
     };
     use ymir_viz::bridge::v2::build_config;
 
@@ -2015,14 +2015,14 @@ fn r5b_d2_bis_oscillating_evolution() {
     // Cycle 1
     *cycle_counter.borrow_mut() = 1;
     *step_in_cycle_counter.borrow_mut() = 0;
-    let cycle_1 = run_phase_a_cycle_with_progress(&cfg, &wf, &mut record_step);
+    let cycle_1 = run_phase_a_cycle_with_progress_v2(&cfg, &wf, &mut record_step);
     cfg.continuation =
-        Some(final_state_to_continuation(&cycle_1.baseline.final_state));
+        Some(final_state_to_continuation_v2(&cycle_1.baseline.final_state));
 
     // Cycle 2
     *cycle_counter.borrow_mut() = 2;
     *step_in_cycle_counter.borrow_mut() = 0;
-    let cycle_2 = run_phase_a_cycle_with_progress(&cfg, &wf, &mut record_step);
+    let cycle_2 = run_phase_a_cycle_with_progress_v2(&cfg, &wf, &mut record_step);
 
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[r5b/d2-bis] completed in {elapsed:.1}s");
@@ -2152,7 +2152,7 @@ enum InitVariant {
 fn run_d1_ter_init_variant(variant: InitVariant, label: &str) {
     use std::cell::RefCell;
     use ymir_core::tectonics_v2::workflow::{
-        final_state_to_continuation, run_phase_a_cycle_with_progress,
+        final_state_to_continuation_v2, run_phase_a_cycle_with_progress_v2,
     };
     use ymir_viz::bridge::v2::build_config;
 
@@ -2184,14 +2184,14 @@ fn run_d1_ter_init_variant(variant: InitVariant, label: &str) {
     let no_op =
         |_: &ymir_core::tectonics_v2::diagnostics::harness::StepProgress<'_>| -> bool { true };
     let t0 = std::time::Instant::now();
-    let cycle_1 = run_phase_a_cycle_with_progress(&cfg, &wf, no_op);
+    let cycle_1 = run_phase_a_cycle_with_progress_v2(&cfg, &wf, no_op);
     let cycle_1_elapsed = t0.elapsed().as_secs_f64();
     println!("[d1-ter/{label}] cycle 1 done in {cycle_1_elapsed:.1}s");
 
     let nx = cycle_1.baseline.final_state.s_field.nx();
     let ny = cycle_1.baseline.final_state.s_field.ny();
     let mut continuation =
-        final_state_to_continuation(&cycle_1.baseline.final_state);
+        final_state_to_continuation_v2(&cycle_1.baseline.final_state);
     match variant {
         InitVariant::WarmStart => {}
         InitVariant::Zero => {
@@ -2249,7 +2249,7 @@ fn run_d1_ter_init_variant(variant: InitVariant, label: &str) {
     };
 
     let t1 = std::time::Instant::now();
-    let cycle_2 = run_phase_a_cycle_with_progress(&cfg, &wf, &mut record_step);
+    let cycle_2 = run_phase_a_cycle_with_progress_v2(&cfg, &wf, &mut record_step);
     let cycle_2_elapsed = t1.elapsed().as_secs_f64();
     println!("[d1-ter/{label}] cycle 2 done in {cycle_2_elapsed:.1}s");
 
@@ -2316,7 +2316,7 @@ fn r5b_d1_ter_init_c_smoothed() {
 }
 
 /// Step 12 R5b — re-measure D1-bis pattern AFTER the D1-ter implement
-/// (reinit v=0 post-macro inside `phase_a::run_phase_a_cycle_with_progress`).
+/// (reinit v=0 post-macro inside `phase_a::run_phase_a_cycle_with_progress_v2`).
 /// Output dir is distinct from the pre-D1-ter version so the
 /// comparison report stays available.
 /// Step 12 R5b validation — R4 active_medley 64² × 5 cycles after the
@@ -2396,7 +2396,7 @@ fn r5b_validation_r4_active_medley_64sq_mf_0_5() {
 
     println!("[r5b validation] running 5 cycles × 20 steps (64², mf=0.5, D2+D1-ter active)…");
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!(
         "[r5b validation] completed in {elapsed:.1}s, {} cycles",
@@ -2497,7 +2497,7 @@ fn r5b_d1_bis_per_step_workflow_on_post_d1_ter() {
     let wf = build_config::build_workflow(&spec.workflow);
 
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[r5b/d1-bis post-D1-ter] completed in {elapsed:.1}s");
 
@@ -2653,7 +2653,7 @@ fn run_r6_3_config(mf: f64, evo_rate: f64, label: &str) -> R6ConfigSummary {
     let wf = build_config::build_workflow(&spec.workflow);
 
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[r6.3/{label}] completed in {elapsed:.1}s");
 
@@ -3244,7 +3244,7 @@ fn run_r6_3_c4_config(
     let wf = build_config::build_workflow(&spec.workflow);
 
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[c.4/{label}] completed in {elapsed:.1}s");
 
@@ -3999,7 +3999,7 @@ fn run_r7_a_2_4_config(
     let wf = build_config::build_workflow(&spec.workflow);
 
     let t0 = std::time::Instant::now();
-    let output = run_phase_a_loop(&mut cfg, &wf);
+    let output = run_phase_a_loop_v2(&mut cfg, &wf);
     let elapsed = t0.elapsed().as_secs_f64();
     println!("[r7.a.2.4/{label}] simulation completed in {elapsed:.1}s");
 

--- a/docs/migrations/harness_paradigm_agnostic.md
+++ b/docs/migrations/harness_paradigm_agnostic.md
@@ -1,0 +1,544 @@
+# Issue #125 Phase 1.3 Stage H1 — Harness paradigm-agnostic refactor audit
+
+**Status:** Phase 1.3 Stage H1 audit only. Read-only. No source modifications,
+no `cfg` changes, no `git mv`. H2 / H3 land the implementation if the
+recommendation below is accepted.
+
+**Scope:** Cartograph the v2 harness and its workflow callers, identify the
+load-bearing paradigm-coupling points, evaluate two design options (trait
+abstraction vs two separate functions), and recommend one based on the
+explicit decision criteria from the Phase 1.3 spec.
+
+**Audit cut-off commit:** `ecf2921` (Phase 1.3 Stage E1.bis), branch
+`125-c1-phase-13-equilibrium-height-closure-harness-paradigm-agnostic-refactor`,
+off `3746da7` (Phase 1.2 merge into `milestone/c1-lightweight-dynamic-tectonics`).
+
+**HC4 reference:** `docs/migrations/v2_to_c1_attic.md` § HC4 (lines 389-393)
+explicitly defers the paradigm-agnostic workflow refactor to Phase 1.3+. This
+is that refactor.
+
+---
+
+## Summary of findings
+
+- **Harness is monolithically v2-coupled.** Single file `harness.rs`, 3 public
+  functions, `BaselineConfig` embeds 6 v2-specific config types
+  (`MantleConfig`, `SlabPullConfig`, `BasalDragConfig`, `LinearSolverConfig`,
+  `YieldingConfig`, `RheologyConfig` via `Preset`). Whole file gated under
+  `v2_legacy`.
+- **The leak point is `CycleOutput.baseline: BaselineResult`** in
+  `workflow/mod.rs:230`. This is the *single* type-system bridge between
+  the otherwise paradigm-agnostic workflow scaffolding and the v2 harness.
+  Everything else in `workflow/mod.rs` (`WorkflowConfig`, `WorkflowParams`,
+  `PhaseAParams`, `PhaseBParams`, `PhaseBOutput`) is data-only and reusable.
+- **Phase B is already paradigm-agnostic at runtime.** It consumes `Field2D
+  + sea_level_normalized + iso_config`, not `BaselineResult` — no refactor
+  needed for Phase B.
+- **C1 has zero coupling to harness.** `tectonics_c1/time_loop.rs` is a
+  self-contained per-cycle runner that already satisfies the HC4 statement
+  "C1 provides its own per-cycle tectonic runner" — it just needs a
+  workflow wrapper.
+- **Structural divergence is material.** v2's `BaselineConfig` carries 23
+  fields including 6 nested config types; C1's runner takes 4 args
+  (`&mut C1State`, `&PlateKinematics`, `&C1TimeLoopConfig`, `&C1Closures`).
+  Per-step payloads (`StepProgress<'_>` vs `&C1State`) are structurally
+  different, not just type-renamed.
+- **Surface area to preserve.** 63 bin/test entries in `crates/ymir-core/
+  Cargo.toml` carry `required-features = ["v2_legacy"]`. Any signature
+  change to the v2 path triples the regression risk.
+
+**Recommendation:** **Option B — Two separate functions.** All three
+decision criteria from the Phase 1.3 spec point the same way, and the
+effort estimate (1-2 days) sits under the W3 trait fallback threshold
+(3 days).
+
+---
+
+## §1 — Harness inventory
+
+### §1.1 — Public surface of `tectonics_v2/diagnostics/harness.rs`
+
+Single file. Module-level gated by `#[cfg(feature = "v2_legacy")]` in
+`diagnostics/mod.rs:32-39`.
+
+| Item | Signature | v2-coupling severity |
+|---|---|---|
+| `pub fn build_force` | `(kind: ForceKind, scales: &Scales, sin_amplitude: f64, domain_lx: f64) -> Box<dyn BodyForce>` | high — returns Stokes body-force trait |
+| `pub fn run_baseline` | `(cfg: &BaselineConfig) -> BaselineResult` | high — only entry into the v2 pipeline |
+| `pub fn run_baseline_with_progress<F>` | `(cfg: &BaselineConfig, mut on_progress: F) -> BaselineResult where F: FnMut(&StepProgress<'_>) -> bool` | high — adds early-stop callback |
+| `enum ForceKind { Gpe, Sinusoidal }` | + `pub fn label()` | data |
+| `enum NonlinearChoice { Newton, Picard }` | + `pub fn label()`, `parse()` | data, but Stokes-specific |
+| `struct BaselineConfig` (23 fields) | embeds 6 v2 configs | **bridgehead** |
+| `struct ContinuationState` | velocity warm-start | v2-Stokes-specific |
+| `struct HarnessCaptureSpec` | benchmark snapshot spec | v2-bench-specific |
+| `struct BaselineResult` | `{ metrics, config_dump, final_state }` | composite v2 result |
+| `struct FinalState` | 5 v2-optional fields | composite v2 result |
+| `struct StepProgress<'a>` | per-step callback payload | composite v2 progress |
+
+### §1.2 — v2-specific types embedded in `BaselineConfig`
+
+| Field | Type | Step |
+|---|---|---|
+| `mantle` | `MantleConfig` | Step 8 |
+| `slab_pull` | `SlabPullConfig` | Step 7 |
+| `basal_drag` | `BasalDragConfig` | Step 4 |
+| `linear_solver` | `LinearSolverConfig` | Step 8.5a |
+| `yielding` | `YieldingConfig` | Step 3 (via preset.rheology) |
+| `preset` | `Preset` | carries rheology / scales |
+
+These configs have no semantic analog in C1 (no Stokes solver, no mantle
+coupling, no slab-pull body force). A paradigm-agnostic abstraction over
+`BaselineConfig` would have to be opaque — workflow code could never
+reach inside.
+
+### §1.3 — v2-specific optional fields in `FinalState`
+
+| Field | Type | Step |
+|---|---|---|
+| `age_field` | `Option<Field2D>` | Step 10 |
+| `cratonic_factor` | `Option<Field2D>` | Step 9 |
+| `plate_id` | `Option<PlateIdField>` | from boundary config |
+| `plate_type` | `Option<PlateTypeField>` | from boundary config |
+| `boundary_flag` | `Option<BoundaryFlagField>` | from boundary config |
+
+C1's analog is `C1State { s, age, plate_id, plate_type, cratonic_mask, num_plates }`. Field shapes
+overlap (S̃ field, age field, plate_id field, plate_type field) — but C1
+has no `boundary_flag` field, and its `cratonic_mask` is `BoolField` while
+v2's `cratonic_factor` is `Field2D`. The runtime per-cycle product is
+*similar enough that a workflow consumer (Phase B erosion) doesn't care*,
+but the typed envelope is different.
+
+---
+
+## §2 — Workflow callers
+
+### §2.1 — `tectonics_v2/workflow/phase_a.rs` — the load-bearing call site
+
+Currently the only piece of the workflow that runs the harness. Module
+gated by `#[cfg(feature = "v2_legacy")]` in `workflow/mod.rs:42`. Public
+entry points re-exported on lines 54-58:
+
+- `run_phase_a_cycle(cfg: &BaselineConfig, wf: &WorkflowConfig) -> CycleOutput`
+- `run_phase_a_cycle_with_progress<F>(cfg, wf, on_progress: F) -> CycleOutput`
+- `run_phase_a_loop(cfg, wf) -> PhaseAOutput`
+- `final_state_to_continuation(FinalState) -> ContinuationState`
+
+All four take or return v2-typed values.
+
+### §2.2 — `tectonics_v2/workflow/phase_b.rs` — already paradigm-agnostic at runtime
+
+Currently gated for symmetry (`workflow/mod.rs:44`), but the **runtime
+input it actually reads** is `Field2D + sea_level_normalized + iso_config
++ FbmUpscaleConfig + ErosionConfig`. Of these, only `Field2D` is shared
+between v2 and C1 (both use `tectonics_v2::field::Field2D`, which the C1
+state exposes via `state.s`). The other inputs are paradigm-agnostic
+domain types.
+
+`PhaseBOutput { heightmap, sediment, slope, deviation, deviation_p95 }`
+is `GridF32`-based — no v2 types.
+
+**Implication:** under either Option A or B, Phase B's wrapper can stay
+verbatim; only its callers (Phase A loop) need re-pointing.
+
+### §2.3 — `workflow/mod.rs` — the bridgehead struct
+
+```text
+// workflow/mod.rs:230
+#[cfg(feature = "v2_legacy")]
+pub struct CycleOutput {
+    pub baseline: crate::tectonics_v2::diagnostics::harness::BaselineResult,
+    pub erosion_volume_removed: f64,
+    pub erosion_peak_delta_h: f64,
+    pub sea_level_normalized: f64,
+    pub mass_drift: f64,
+    pub craton_recomputation_change: Option<f64>,
+}
+```
+
+Only the `baseline: BaselineResult` field forces the gate. The other six
+fields (erosion volume + peak Δh, sea level, mass drift, craton-change)
+are paradigm-agnostic Phase A diagnostics that C1 can populate equally
+well.
+
+---
+
+## §3 — C1 cross-paradigm coupling
+
+**Status: none.** Confirmed by Grep against `crates/ymir-core/src/
+tectonics_c1/`:
+
+- No `use crate::tectonics_v2::diagnostics::harness` imports.
+- No `use crate::tectonics_v2::workflow` imports.
+- `tectonics_c1::time_loop` is the self-contained C1 per-cycle runner.
+  Its public surface is:
+  - `run_advection_only(state, kinematics, config, on_step)` — Phase 1.1
+  - `run_with_closures(state, kinematics, config, closures, on_step)` —
+    Phase 1.2 + 1.3 (now wires Davis-Suppe + equilibrium-height)
+- `C1Closures { davis_suppe, equilibrium_height }` parallels the
+  per-closure flags of `BaselineConfig.mantle/slab_pull/basal_drag`.
+
+**Implication:** the C1 side of the abstraction already exists. H2 only
+needs to wrap it in a workflow entry that produces the same paradigm-
+agnostic scalars (`erosion_volume_removed`, `mass_drift`, …) as v2 does.
+
+---
+
+## §4 — `v2_legacy` feature surface area
+
+Declared at `crates/ymir-core/Cargo.toml:32` (`v2_legacy = []`).
+
+| Surface | Count | Notes |
+|---|---|---|
+| Module-level `#[cfg(feature = "v2_legacy")]` gates | 28 | `diagnostics/mod.rs` (9), `tectonics_v2/mod.rs` (2), `workflow/mod.rs` (6), `forcing/mod.rs` (2), `_attic/mod.rs` (7), inline (2) |
+| Cargo.toml entries `required-features = ["v2_legacy"]` | 63 | bin + bench + test entries that don't compile without the flag |
+| Existing `workflow` items gated transitively | 4 fns + 2 structs | `run_phase_a_*`, `run_phase_b`, `CycleOutput`, `PhaseAOutput` |
+
+Any change that touches the v2 path signature multiplies risk by 63
+(every bin/test entry).
+
+---
+
+## §5 — Structural comparison v2 vs C1
+
+The decision criteria from the Phase 1.3 spec call for an honest
+divergence table:
+
+| Aspect | v2 harness | C1 time_loop | divergence |
+|---|---|---|---|
+| Config bundle | 23-field `BaselineConfig` with 6 nested v2-only configs | 4 args (`&mut C1State`, `&PlateKinematics`, `&C1TimeLoopConfig`, `&C1Closures`); no nested v2 configs | **structural** |
+| Mutable state | Built inside `run_baseline` from `BaselineConfig` | Pre-built `C1State` passed in by caller | structural |
+| Per-step progress | `StepProgress<'_>` — Stokes residuals, nonlinear iter count, mantle/slab residuals, age/cratonic snapshots | `usize, &C1State` — step index + simple state ref | **structural** |
+| Result envelope | `BaselineResult { metrics: Metrics, config_dump: SolverConfigDump, final_state: FinalState }` | None — mutates `&mut C1State` in place | **structural** |
+| Time stepping | Variable Δt from nonlinear continuation; multi-iteration per visible step | Fixed CFL Δt; single Forward-Euler step per visible step | structural |
+| Mass balance | Source / sink balance through Stokes velocity + boundary fluxes | Pure advection of S̃ + per-cell additive closures | semantic |
+| Early-stop | `on_progress -> bool` allows aborting mid-run | `on_step` has no return value | semantic |
+
+The two paths share **no common signature modulo types**. They share
+**no common return envelope**. They share **no common per-step payload
+shape**. The only thing they share is the *concept* "advance a tectonic
+state by N visible steps".
+
+---
+
+## §6 — Design options
+
+### Option A — Trait abstraction
+
+#### A.1 Sketch
+
+```rust
+pub trait TectonicRunner {
+    type Config;
+    type Progress<'a>;
+    type Result;
+    fn run<F>(cfg: &Self::Config, on_progress: F) -> Self::Result
+    where
+        F: FnMut(&Self::Progress<'_>) -> ControlFlow;
+}
+
+pub enum ControlFlow { Continue, Stop }
+
+pub struct V2Runner;
+impl TectonicRunner for V2Runner {
+    type Config = BaselineConfig;
+    type Progress<'a> = StepProgress<'a>;
+    type Result = BaselineResult;
+    fn run<F>(cfg, on_progress) -> Self::Result { /* delegate to harness::run_baseline_with_progress */ }
+}
+
+pub struct C1Runner;
+impl TectonicRunner for C1Runner {
+    type Config = (/* C1State + kinematics + config + closures bundle */);
+    type Progress<'a> = (usize, &'a C1State);
+    type Result = ();  // mutates in place
+    fn run<F>(cfg, on_progress) -> Self::Result { /* delegate to time_loop::run_with_closures */ }
+}
+
+// workflow becomes generic
+pub fn run_phase_a_cycle<R: TectonicRunner>(
+    cfg: &R::Config,
+    wf: &WorkflowConfig,
+) -> CycleOutput<R::Result> { … }
+```
+
+#### A.2 Pros
+
+- Single conceptual entry point: workflow code calls `R::run(…)`.
+- Future paradigms (Phase 2.x evolution) plug in via new `impl
+  TectonicRunner for FooRunner` — extensibility argument.
+- Reduces lexical duplication in `workflow/` (one `run_phase_a_cycle`
+  generic).
+
+#### A.3 Cons
+
+- **3 associated types** (`Config`, `Progress`, `Result`) → workflow
+  becomes generic over `R`, which propagates through:
+  - `CycleOutput<R::Result>` — generic
+  - `PhaseAOutput<R::Result>` — generic
+  - All 63 bin/test entries — every callsite must monomorphise the
+    parameter
+- The two runners' `Result`s are fundamentally different shapes
+  (`BaselineResult` vs `()`). Workflow code that wants e.g. "the
+  final S̃ field" must access it via *different* paths depending on
+  the runner — abstraction *leaks* through the workflow regardless.
+- C1's `Progress` is `(usize, &'a C1State)` — that's a tuple with a
+  lifetime. v2's `Progress<'a>` is `StepProgress<'a>` — a struct
+  with a lifetime. GAT (generic associated types with lifetimes)
+  works since edition 2024, but error messages and lifetime
+  inference become harder for downstream callers.
+- `on_progress` semantics differ — v2's callback returns `bool`
+  (early stop), C1's callback returns `()`. Reconciling forces a
+  `ControlFlow` enum and a wrapper for the C1 callback that always
+  returns `Continue`. Subtle correctness risk on misuse.
+- The bin/test surface (63 entries) is touched by signature changes
+  to `run_phase_a_*`. Even if behaviour-preserving, all 63 entries
+  need re-checking under both `--features v2_legacy` and default.
+
+#### A.4 Effort estimate H2
+
+- Trait definition + GAT setup: 0.5 d
+- `V2Runner` impl: 0.5 d
+- `C1Runner` impl + the wrapping `(&mut C1State, …)` Config bundle: 0.5 d
+- Refactor `workflow/phase_a.rs` to be generic: 1.5-2 d (the most
+  fragile step — generic over `Result` makes `CycleOutput` generic,
+  which cascades)
+- Update 63 bin/test entries: 1-2 d (mostly mechanical, but several
+  need explicit `::<V2Runner>` annotations)
+- Coverage tests for both runners: 0.5 d
+- Doc + migration notes: 0.5 d
+
+**Total: 4-5 days.** Past the 3-day W3 fallback threshold.
+
+### Option B — Two separate functions
+
+#### B.1 Sketch
+
+Module structure after H2:
+
+```text
+crates/ymir-core/src/tectonics_v2/workflow/
+├── mod.rs              ← WorkflowConfig, WorkflowParams, PhaseAParams,
+│                          PhaseBParams, CycleOutputCommon (paradigm-agnostic)
+├── phase_a_v2.rs       ← (rename of current phase_a.rs)
+│                          gated #[cfg(feature = "v2_legacy")]
+│                          re-exports run_phase_a_cycle_v2, _with_progress, _loop
+├── phase_a_c1.rs       ← NEW, default-features-on
+│                          run_phase_a_cycle_c1(...) calls time_loop::run_with_closures
+├── phase_b.rs          ← unchanged (already paradigm-agnostic at runtime;
+│                          may need to drop the cfg gate)
+├── drainage.rs         ← unchanged
+└── macro_redistribution.rs  ← unchanged
+```
+
+Shared per-cycle output:
+
+```rust
+// workflow/mod.rs — promoted to paradigm-agnostic
+pub struct CycleOutputCommon {
+    pub erosion_volume_removed: f64,
+    pub erosion_peak_delta_h: f64,
+    pub sea_level_normalized: f64,
+    pub mass_drift: f64,
+    pub craton_recomputation_change: Option<f64>,
+}
+
+// workflow/phase_a_v2.rs — keeps the baseline field
+#[cfg(feature = "v2_legacy")]
+pub struct CycleOutputV2 {
+    pub baseline: harness::BaselineResult,
+    pub common: CycleOutputCommon,
+}
+
+// workflow/phase_a_c1.rs — paradigm-specific surface
+pub struct CycleOutputC1 {
+    pub final_state: C1State,        // moved out of run, owned
+    pub common: CycleOutputCommon,
+}
+```
+
+Phase A entry points after H2:
+
+- v2 path: `run_phase_a_cycle_v2(cfg: &BaselineConfig, wf: &WorkflowConfig) -> CycleOutputV2` (gated).
+- C1 path: `run_phase_a_cycle_c1(state, kinematics, c1_cfg, closures, wf) -> CycleOutputC1` (default).
+
+Phase B path is paradigm-agnostic — same `phase_b::run_phase_b(s_field,
+wf, seed)` works for both. The only change is dropping its `v2_legacy`
+gate.
+
+#### B.2 Pros
+
+- **Honest about structural divergence.** Two paths because the
+  paradigms actually are two different things. No forced
+  abstraction that would let one leak into the other.
+- **Zero risk to the 63 existing v2 bin/test entries.** A pure rename
+  + cfg-gate keeps every existing call site working bit-identically
+  under `--features v2_legacy`.
+- **No GATs, no `ControlFlow` enum wrapping, no `R::Result`
+  monomorphisation.** Each path stays plain Rust.
+- **Each path owns its full type richness.** v2 keeps
+  `BaselineResult` with its 23 fields and 5 optional final-state
+  fields. C1 keeps its mutate-in-place `&mut C1State` semantics.
+- **Phase B becomes default-features-on for free.** Just drop its
+  cfg gate. PhaseBOutput was already paradigm-agnostic.
+- **Lower bin/test surface area.** No bin/test currently exercises
+  C1 through the workflow (C1 is too new). The new C1 path only
+  needs ~2-3 smoke tests added in H3.
+
+#### B.3 Cons
+
+- Lexical duplication of orchestration logic between the two
+  `phase_a_*.rs`. Mitigatable by extracting the common bits (erosion
+  pass, isostasy call, craton recompute) into helpers in
+  `workflow/phase_a_common.rs` — the per-cycle erosion + isostasy +
+  craton logic is paradigm-agnostic by construction.
+- Future Phase 2.x paradigm (if it materialises) requires a third
+  `phase_a_p2.rs`. Acceptable — Phase 2 is far away and its
+  paradigm shape is unknown.
+- Two test surfaces to keep in step (v2 regression tests + new C1
+  smoke tests). Mitigated by shared `CycleOutputCommon` invariants
+  (e.g. `mass_drift` semantics).
+
+#### B.4 Effort estimate H2
+
+- `git mv phase_a.rs phase_a_v2.rs` + re-export gating in
+  `workflow/mod.rs`: 0.25 d
+- Extract `CycleOutputCommon` + `CycleOutputV2` split: 0.5 d
+- Create `phase_a_c1.rs` parallel structure calling
+  `time_loop::run_with_closures` + paradigm-agnostic post-pass
+  (erosion + isostasy + craton update via existing helpers): 0.5-0.75 d
+- Drop `v2_legacy` gate from `phase_b.rs` (it's already paradigm-
+  agnostic at runtime): 0.1 d
+- H3 smoke tests on the C1 path (default features): 0.5 d
+- Doc + migration update (this file → "implemented" + brief change
+  note in `v2_to_c1_attic.md` HC4 § "resolved"): 0.25 d
+
+**Total: 1.5-2 days.** Under the W3 trait fallback threshold (3 days).
+
+---
+
+## §7 — Decision criteria applied
+
+The Phase 1.3 spec lists three criteria. Applied to the audit findings:
+
+| # | Criterion | Verdict | Reasoning |
+|---|---|---|---|
+| 1 | Same signature modulo types? | **NO** | Configs (23 nested-v2 fields vs 4 paradigm-agnostic args), per-step payloads (`StepProgress<'_>` vs `(usize, &C1State)`), result envelopes (`BaselineResult` vs `()`), and time-stepping semantics (variable continuation Δt vs fixed CFL Δt) all diverge structurally. |
+| 2 | Configs / returns structurally different? | **YES** | See §5 divergence table. The signature differences are not type-renames; they reflect that v2 owns its state internally while C1 mutates an externally-owned `C1State`. |
+| 3 | Trait would need type erasure or complex associated types? | **YES** | Option A requires 3 associated types incl. a GAT (`Progress<'a>`) and a `ControlFlow` enum to reconcile the callback-return mismatch. Not impossible, but explicitly the case the criterion warns against. |
+
+All three criteria point the same way → **Option B is the indicated
+choice** per the criterion-driven decision rule.
+
+---
+
+## §8 — Recommendation + open questions
+
+### §8.1 Recommendation
+
+**Option B — Two separate functions.**
+
+Decisive factors, in order:
+
+1. Effort estimate (1.5-2 d) sits clearly below the W3 trait-fallback
+   threshold (3 d). Option A is 4-5 d.
+2. All three criteria from the spec point to B.
+3. Risk surface is materially lower: 63 existing bin/test entries
+   stay untouched under `v2_legacy`, vs Option A which touches every
+   single one of them via the generic parameter.
+4. Honesty argument: the two paradigms ARE structurally different;
+   forcing a trait abstraction misrepresents the difference and
+   makes the abstraction itself a maintenance liability.
+
+The future-paradigm extensibility argument (Option A's main pro) is
+not load-bearing — Phase 2.x is far enough that we don't know what
+shape it will take.
+
+### §8.2 Risks identified
+
+| ID | Risk | Mitigation |
+|---|---|---|
+| R1 | C1 path has no `with_progress` variant initially → workflow API asymmetry | Ship only `run_phase_a_cycle_c1(..., on_step: F)` from day one; C1's `time_loop::run_with_closures` already takes a per-step callback. Symmetry trivially restored. |
+| R2 | `phase_b.rs` un-gating reveals a hidden `v2_legacy`-only call we missed | Verify in H2 first commit: `cargo build` without `v2_legacy` after the gate drop. Grep already confirmed only `Field2D + isostasy + upscale + erosion` consumed. |
+| R3 | The shared `CycleOutputCommon` scalars (mass_drift, erosion_volume_removed) need to be **computed identically** in both paths or the diagnostics will diverge silently | Extract the post-tectonic-step erosion / isostasy / craton block into `workflow/phase_a_common.rs` and have both `phase_a_v2.rs` and `phase_a_c1.rs` call it. One implementation, two callers — no silent divergence. |
+| R4 | Workflow tests live under `v2_legacy` today; H3 needs to move some of them to default-features so the C1 path has coverage | Smoke tests under `cfg(not(feature = "v2_legacy"))` referencing only the C1 entry points. The v2 regression test stays gated. |
+| R5 | The `Disabled` regression contract (`workflow_disabled = run_baseline` bit-identical, currently asserted by `tests/v2_workflow_disabled_regression.rs`) is v2-specific. The C1 path needs its own equivalent: `phase_a_c1` with `WorkflowConfig::Disabled` must equal a direct `time_loop::run_with_closures` call. | Bit-identical regression test in H3, modelled on the v2 one. |
+| R6 | If Option B's lexical duplication grows (e.g. Phase 2 adds a third path), pressure to retrofit a trait will appear | Document the criterion-driven decision in this file so the *next* refactor opens with explicit history rather than re-deriving. |
+
+### §8.3 Open questions for user before GO H2
+
+1. **Gating default for `phase_a_c1.rs`:** propose default-features-on (no
+   feature flag). C1 is mainline as of Phase 1.3; v2 is the legacy path.
+   Confirm or specify a `c1` feature if you want symmetry with
+   `v2_legacy`.
+2. **Naming:** `run_phase_a_cycle_v2` vs keeping `run_phase_a_cycle` (the
+   current name) under `v2_legacy`. Renaming is more honest but touches
+   the 63 bin/test entries. Recommended: **keep `run_phase_a_cycle` as
+   the v2 name** (no rename), add `run_phase_a_cycle_c1` as the new
+   default path. Zero churn in existing bin/test entries.
+3. **`phase_b.rs` un-gating:** recommended to drop the cfg gate in H2.
+   Already paradigm-agnostic at runtime per §2.2. Confirm.
+4. **Migration doc update:** propose updating `v2_to_c1_attic.md` HC4
+   section to "resolved by Phase 1.3 H2" with a back-link to this file.
+   Confirm.
+
+---
+
+## §9 — Out of scope (not H1, not H2, not H3)
+
+- Migrating individual workflow callers in `crates/ymir-viz/src/bridge/v2/`
+  to the C1 path. Bridge layer stays v2-only for now (per Issue #117).
+- Retiring the v2 harness itself. The plan is to keep it gated; Phase
+  2.x decides whether to retire or keep as a regression anchor.
+- Re-implementing v2's continuation warm-start in C1. C1 has no
+  Stokes solver and no notion of velocity warm-start; the C1 cycle
+  loop is stateless across cycles modulo the `C1State` it carries.
+- Adding new C1 closures (Phase 1.4 erosion is a separate phase).
+
+---
+
+## §10 — Implementation roadmap (sketch only, H2 scope)
+
+This section is descriptive only — the *audit* recommends Option B,
+the *implementation* lands in H2. Listed here so the user can sanity-
+check the proposal end-to-end.
+
+1. **H2 Commit 1** (~0.5 d) — Carve out `CycleOutputCommon`. Move the
+   paradigm-agnostic fields out of `CycleOutput`, repackage as
+   `CycleOutputV2 { baseline, common }`. Run v2 regression tests under
+   `v2_legacy`.
+2. **H2 Commit 2** (~0.5-0.75 d) — `git mv phase_a.rs phase_a_v2.rs`.
+   Update `workflow/mod.rs` re-exports. Run v2 regression tests.
+3. **H2 Commit 3** (~0.5 d) — Drop `v2_legacy` gate from `phase_b.rs`.
+   Verify `cargo build` (default features) passes. Smoke test on
+   the GridF32 surface.
+4. **H2 Commit 4** (~0.5 d) — Create `workflow/phase_a_common.rs`
+   with the shared post-tectonic-step pass (isostasy + craton +
+   erosion volume). Call from `phase_a_v2.rs`.
+5. **H2 Commit 5** (~0.5 d) — Create `workflow/phase_a_c1.rs`,
+   default-features-on, calls `time_loop::run_with_closures`,
+   delegates the post-pass to `phase_a_common.rs`.
+6. **H3** (~0.5 d) — Smoke tests for the C1 path under default
+   features, including the Disabled-equals-direct-call regression
+   parallel.
+7. **Doc tail** (~0.25 d) — Update this file's § Status to
+   "implemented", update `v2_to_c1_attic.md` HC4 to "resolved".
+
+Total H2 + H3: **1.5-2 days**, matching the §6.B.4 estimate.
+
+---
+
+## §11 — Hidden-coupling check (W7-style)
+
+Per the Phase 1.3 Stage H1 W7 watchpoint, surfaced findings beyond the
+documented HC4 debt:
+
+- **None.** The HC4 statement in `v2_to_c1_attic.md` lines 389-393 is
+  the only paradigm-coupling debt and it is precisely the
+  `CycleOutput.baseline: BaselineResult` leak point identified in
+  §2.3. C1 has no existing coupling to harness (§3). Workflow Phase B
+  is already paradigm-agnostic at runtime (§2.2). The 63 v2_legacy
+  bin/test entries are scope-bounded by Cargo.toml and require no
+  refactor beyond the H2 plan above.
+
+No STOP-and-surface required. GO/STOP on H2 is the explicit user gate
+that follows this audit.

--- a/docs/migrations/harness_paradigm_agnostic.md
+++ b/docs/migrations/harness_paradigm_agnostic.md
@@ -1,8 +1,20 @@
-# Issue #125 Phase 1.3 Stage H1 — Harness paradigm-agnostic refactor audit
+# Issue #125 Phase 1.3 — Harness paradigm-agnostic refactor
 
-**Status:** Phase 1.3 Stage H1 audit only. Read-only. No source modifications,
-no `cfg` changes, no `git mv`. H2 / H3 land the implementation if the
-recommendation below is accepted.
+**Status:**
+
+- **H1 (audit) — RESOLVED.** Option B (two separate functions)
+  recommended on three converging criteria. See §1-§11 below.
+- **H2 (implementation) — RESOLVED.** 5 commits across `ymir-core`
+  (`CycleOutputCommon` carve-out, `phase_a` v2 rename, shared
+  `phase_a_common`, default-features `phase_a_c1`, `phase_b`
+  un-gated). See § 12 for SHAs + summary.
+- **H3 (tests) — RESOLVED.** 4 integration tests at
+  `crates/ymir-core/tests/c1_phase_1_3_workflow.rs`, including the
+  bit-identical wrapper-equals-decomposition regression. See § 12.
+- **Verification:** 58 / 58 tests PASS across both feature flags.
+- **Known limitation:** `ymir-viz` bin under `--features v2_legacy`
+  pre-existing-broken (299 unrelated errors), out of scope. See
+  § 14.
 
 **Scope:** Cartograph the v2 harness and its workflow callers, identify the
 load-bearing paradigm-coupling points, evaluate two design options (trait
@@ -542,3 +554,215 @@ documented HC4 debt:
 
 No STOP-and-surface required. GO/STOP on H2 is the explicit user gate
 that follows this audit.
+
+---
+
+## §12 — Implementation status (Phase 1.3 H2 / H3 — POST-AUDIT)
+
+The audit landed at `e6a58e2`. H2 + H3 then implemented across 5
+sequenced commits on the same branch.
+
+### §12.1 H2 + H3 commits
+
+| # | SHA | Type | Summary |
+|---|---|---|---|
+| 1 | `11c53b6` | REFACTOR | Carve `CycleOutputCommon` (5 paradigm-agnostic scalars) out of `CycleOutput` (now `CycleOutputV2 { baseline, common }`); drop `v2_legacy` gate from `phase_b.rs` per § 2.2 audit (Phase B is paradigm-agnostic at runtime). 8 files, +125/-100. |
+| 2 | `f8f1c5b` | REFACTOR | Rename v2 path symbols with `_v2` suffix (Q2.b naming choice from § 8.3): `phase_a` → `phase_a_v2`, `run_phase_a_cycle*`, `run_phase_a_loop`, `final_state_to_continuation`, `CycleOutput`, `PhaseAOutput`. 12 files, 103 substitutions via `\b`-bounded regex with UTF-8 no-BOM-safe I/O. |
+| 3 | `2be9db9` | REFACTOR | Extract `workflow/phase_a_common.rs` with `apply_post_tectonic` (shared paradigm-agnostic post-tectonic pass: sea-level → macro-redistribution → reclassification → cratonic recompute) plus `extract_per_plate_type`. v2 path now calls `apply_post_tectonic`; bit-identical Disabled regression preserved. |
+| 4 | `5679631` | FEAT | Create `workflow/phase_a_c1.rs` (default-features-on): `run_phase_a_cycle_c1(input: PhaseACycleInputC1, wf: &WorkflowConfig) -> PhaseACycleOutputC1`. Asymmetric API (W1): no `baseline` field on output, no `with_progress` variant (deferred Phase 4), no warm-start threading helper. Inline 64²×300 smoke test. |
+| 5 | `6ef32a0` | TEST | Four integration tests at `crates/ymir-core/tests/c1_phase_1_3_workflow.rs` (default features). The critical `c1_phase_a_decomposes_into_closures_then_post_tectonic` asserts byte-for-byte equality between the wrapper and the manual decomposition — **passed at IEEE-754 floor, no tolerance needed**. |
+
+### §12.2 Q2 final choice (Q2.b — rename)
+
+Q2.b chosen over Q2.a (no rename) at Commit 2 based on observed
+cost: **12 files, 103 substitutions, all in already-v2-coupled
+subtrees** (`workflow/`, `bridge/v2/`, attic tests, one comment in
+`ui/metrics_dashboard.rs`). The H1 audit's anticipated "63 entries
+to update" overestimated because most of those 63 are `_attic/`
+tests with their own gating. The actual rename surface is
+contained.
+
+Rationale: semantic alignment with `tectonics_c1::` (mainline,
+default) vs `tectonics_v2::_attic::` (legacy, gated). Avoids
+cognitive overhead of "is `run_phase_a_cycle` the v2 or C1 path?"
+
+### §12.3 Architectural finding — bit-identical wrapper
+
+The H3 test `c1_phase_a_decomposes_into_closures_then_post_tectonic`
+runs two parallel paths on identical inputs:
+
+- **Path A:** `run_phase_a_cycle_c1(input, Enabled(_))`
+- **Path B:** `run_with_closures(state, …)` followed by
+  `apply_post_tectonic(PostTectonicInput { … })`
+
+Asserts `state_a.s == state_b.s` and all 5 `CycleOutputCommon`
+fields are bit-equal. **Passes at IEEE-754 floor with no
+tolerance.** This confirms the wrapper is structurally pure
+("nothing more, nothing less") and surfaces no hidden order-
+sensitive computation. The same contract pattern as v2's
+`workflow_disabled_run_phase_a_cycle_is_bit_identical_to_run_baseline`,
+applied to the C1 paradigm.
+
+### §12.4 Verification surface (58 / 58 PASS)
+
+| Suite | Feature flag | Pass |
+|---|---|---|
+| `c1_phase_1_3_workflow` (NEW) | default | 4 / 4 |
+| `tectonics_v2::workflow::phase_a_c1::tests` (inline) | default | 1 / 1 |
+| `tectonics_c1` lib unit tests | default | 42 / 42 |
+| `c1_phase_1_1_advection` | default | 1 / 1 |
+| `c1_phase_1_2_davis_suppe` | default | 2 / 2 |
+| `v2_workflow_macro` | default | 2 / 2 |
+| `v2_workflow_disabled_regression` | v2_legacy | 3 / 3 |
+| `v2_workflow_phase_a_cycle` | v2_legacy | 3 / 3 |
+| **Total** | | **58 / 58** |
+
+`cargo build --workspace --tests` (default features) and
+`cargo build -p ymir-core --tests --features v2_legacy` both
+clean.
+
+---
+
+## §13 — Future revisit criteria (R6 mitigation from § 8.2)
+
+If a future phase considers retrofitting Option A (trait
+abstraction) in place of the current Option B (two functions), this
+section is the cold-start brief for that decision. The H1 audit
+(2026-05-22) chose Option B on criterion-driven grounds; revisit
+only when the criteria themselves shift.
+
+### §13.1 Indicators that *do* warrant revisit
+
+1. **A third paradigm materialises with a shared signature.** If
+   Phase 2.x (constrained-kinematics sampling) or a hypothetical
+   "Phase 3 Lallemand boundary refinement" ships a *runner* with a
+   signature that genuinely overlaps both v2 and C1 (i.e., not just
+   "looks similar" but actually shares the config-bundle / per-step
+   payload / result-envelope shapes), then the trait abstraction
+   stops costing 3 associated types and becomes natural.
+2. **The same scalar surfaces shift across paradigms.** Today
+   `CycleOutputCommon` has 5 fields; if a future paradigm adds N
+   more shared fields and the inter-paradigm overlap grows past ~10
+   shared fields, the lexical-duplication cost of two `phase_a_*`
+   functions exceeds the trait-monomorphisation cost.
+3. **Workflow code outside `phase_a*` itself becomes paradigm-
+   parametric.** Today the C1 path's caller (Phase 4 UI bridge, when
+   it exists) will know it's a C1 path and call the C1 function
+   directly. If a *generic workflow caller* needs to dispatch
+   between paradigms at runtime (without prior knowledge), the
+   trait becomes the right abstraction.
+4. **The bin/test surface area drops materially.** Today 63 bin/
+   test entries are gated under `v2_legacy`. If the `v2_legacy`
+   subtree retires entirely (Phase 2+ decision), the cost of
+   generic-parameterising the remaining workflow code drops to
+   "touch the C1 callers only" — feasible.
+
+### §13.2 Indicators that *confirm* the current Option B
+
+1. **Per-step payloads remain structurally distinct.** v2's
+   `StepProgress<'_>` carries Stokes residuals + nonlinear iter
+   counts; C1's `(usize, &C1State)` does not. As long as this gap
+   stays, a trait would still need a GAT and a `ControlFlow` enum
+   wrap.
+2. **The `BaselineResult` envelope stays load-bearing for v2.**
+   Today the v2 caller assigns `baseline.final_state.cratonic_factor
+   = Some(new_factor)`. As long as v2's state lives in a unified
+   `FinalState` struct, that bridge point stays paradigm-specific.
+3. **C1's mutate-in-place semantics remain idiomatic.** C1 hands
+   the caller `&mut C1State` and updates fields directly — there is
+   no `Result`-like envelope. As long as that ergonomics stays, the
+   asymmetric output (v2 returns `BaselineResult`, C1 returns `()`)
+   resists a uniform trait abstraction.
+4. **The shared scalars stay computable from `Field2D` alone.**
+   The `apply_post_tectonic` function already proves this: it
+   accepts only paradigm-agnostic types and produces
+   `CycleOutputCommon`. As long as new shared diagnostics derive
+   from `Field2D` + `PlateIdField` + `PlateType[]`, they can join
+   `CycleOutputCommon` without changing the wrapper API.
+
+### §13.3 Suggested revisit cadence
+
+- **At each major milestone boundary.** When Phase 2 / 3 / 4 lands,
+  re-evaluate against the indicators above.
+- **When a third paradigm is *proposed*.** Pause the new paradigm
+  design and check the trait viability before duplicating the
+  workflow scaffolding a third time.
+- **When the C1 path adds a `with_progress` variant** (currently
+  deferred to Phase 4 UI). If the C1 progress payload turns out to
+  be GAT-equivalent to v2's `StepProgress<'a>`, that's evidence the
+  per-step payloads have converged → § 13.1 indicator (1) triggers.
+
+The decision in this doc is not "two functions forever" — it is
+"two functions until the criteria flip". Be honest with the
+criteria.
+
+---
+
+## §14 — Known limitations (post-implementation)
+
+### §14.1 `ymir-viz` bin under `--features v2_legacy` — pre-existing breakage
+
+`cargo build -p ymir-viz --features v2_legacy` fails with **299
+errors** on the Stage H1 base commit `e6a58e2` (before any H2
+work) and remains broken after H2 + H3. Errors are Bevy-side scope
+issues (`..default()` not in scope, `Transform` not in scope), in
+`ymir-viz` bin / main code — NOT in the `bridge/v2/` subtree that
+H2 actually touched.
+
+**Pre-existing-confirmed** by a `git stash` baseline run at the
+Stage H1 base commit (before any H2 changes). Surfaced and
+explicitly deferred per `feedback_match_request_scope`: bundling a
+`ymir-viz` fix into the harness paradigm-agnostic refactor would
+have expanded scope without authorization, and the likely root
+cause (Bevy version drift or feature-flag-conditional imports) may
+overlap with the Phase 1.4 surgical-gating work tracked in the
+Issue #117 PR description.
+
+Filed as a separate GitHub issue: **`[Issue #TBD]`** (file via
+the GitHub web UI when convenient; tracking title:
+`BUG: ymir-viz bin breaks under v2_legacy (Bevy imports / pre-
+existing)`).
+
+### §14.2 H2 verification surface limitations
+
+Because of § 14.1, the H2 verification surface is **bounded** to:
+
+- `cargo build --workspace --tests` (default features) — green
+- `cargo build -p ymir-core --tests --features v2_legacy` — green
+- `cargo test -p ymir-core ...` under both feature flags — 58 / 58
+  green
+- `cargo build -p ymir-viz --features v2_legacy` — **not verified**
+  (299 pre-existing errors block compilation; would re-test green
+  once § 14.1 is resolved)
+
+The H2 refactor itself touched 1 file in `ymir-viz`
+(`bridge/v2/thread.rs`, 6 substitutions for `cycle_output.common.X`
+access path + the `run_phase_a_cycle_with_progress_v2` rename) and
+2 comments (`bridge/v2/plugin.rs`, `ui/metrics_dashboard.rs`). The
+default-features `ymir-viz` build is clean (the `bridge/v2/` code
+is gated under `v2_legacy`, so these updates compile only when the
+v2_legacy ymir-viz issues are also fixed).
+
+### §14.3 C1 path's `with_progress` variant — deferred
+
+The C1 `phase_a_c1.rs` ships only `run_phase_a_cycle_c1` (no
+progress callback) in Phase 1.3. The v2 path ships both
+`run_phase_a_cycle_v2` and `run_phase_a_cycle_with_progress_v2`.
+This asymmetry is intentional — the C1 viz bridge (which would
+consume per-step progress) does not exist yet; it lands in Phase 4.
+At that point, `run_phase_a_cycle_with_progress_c1` can be added
+with a callback signature designed in concert with the bridge
+consumer. The C1 `time_loop::run_with_closures` already takes a
+`FnMut(usize, &C1State)` callback, so the lift is trivial.
+
+### §14.4 No multi-cycle `run_phase_a_loop_c1` yet
+
+The v2 path ships `run_phase_a_loop_v2` for multi-cycle execution
+with `ContinuationState` warm-start threading between cycles.
+The C1 path does not need this in Phase 1.3 (C1 has no Stokes
+velocity warm-start; cycle-to-cycle threading is just "keep the
+same `&mut C1State`"). If multi-cycle integration tests are added
+in Stage E3 or later, the loop can be written either at the test
+layer (idiomatic, given C1's in-place mutation semantics) or as a
+`run_phase_a_loop_c1` helper. Deferred until a concrete consumer
+appears.

--- a/docs/migrations/v2_to_c1_attic.md
+++ b/docs/migrations/v2_to_c1_attic.md
@@ -386,11 +386,38 @@ Audited: these are small utility modules.
 
 No issue; these were just absent from both lists. Implicit "preserved".
 
-### HC4 — `workflow/` sub-files
+### HC4 — `workflow/` sub-files (RESOLVED by Phase 1.3 H2, Issue #125)
+
+**Resolution status: RESOLVED.** Phase 1.3 H2 (Issue #125) shipped
+the paradigm-agnostic workflow refactor on 2026-05-22 via 5 commits
+on branch `125-c1-phase-13-equilibrium-height-closure-harness-paradigm-agnostic-refactor`.
+Two-separate-functions approach (Option B), not trait abstraction.
+See [`harness_paradigm_agnostic.md`](./harness_paradigm_agnostic.md)
+for the full audit and § 12 of that doc for the implementation
+record (SHAs `11c53b6` → `6ef32a0`).
+
+Key outcomes:
+
+- `workflow/phase_a.rs` was renamed to `phase_a_v2.rs` and stays
+  gated under `v2_legacy`. A sibling `phase_a_c1.rs`
+  (default-features-on) drives the C1 paradigm via
+  `tectonics_c1::time_loop::run_with_closures`.
+- `workflow/phase_b.rs` had its `v2_legacy` gate dropped — Phase B
+  was already paradigm-agnostic at runtime (consumes `Field2D +
+  sea_level + iso_config`, no `BaselineResult`).
+- A shared `workflow/phase_a_common.rs` carries the paradigm-
+  agnostic post-tectonic pass (sea-level → macro-redistribution
+  → reclassification → cratonic recompute) consumed by both
+  paradigm-specific Phase A entries.
+- 58 / 58 regression tests PASS across both feature flags,
+  including a bit-identical decomposition contract on the C1
+  path that matches v2's bit-identical Disabled contract.
+
+### HC4 (original audit — historical record)
 
 §4.8 lists `tectonics_v2/workflow/*` as preserved. But the workflow's `phase_a.rs` calls `harness::run_baseline_with_progress`, which is retired. **The workflow orchestrator is conserve-architecturally but cannot execute without `v2_legacy`** until C1 provides its own per-cycle tectonic runner.
 
-**Recommendation:** add to the migration doc a note that the workflow shell is paradigm-agnostic *by design* but currently couples to v2 at run-time. C1 Phase 1.3+ (§7 C1.md) is where the shell becomes truly paradigm-portable. For the migration itself, gate `workflow/phase_a.rs` (and likely `phase_b.rs` if it consumes via harness too) and let C1 reintroduce a paradigm-agnostic form when the tectonic_c1 runner exists.
+**Recommendation (since acted on):** add to the migration doc a note that the workflow shell is paradigm-agnostic *by design* but currently couples to v2 at run-time. C1 Phase 1.3+ (§7 C1.md) is where the shell becomes truly paradigm-portable. For the migration itself, gate `workflow/phase_a.rs` (and likely `phase_b.rs` if it consumes via harness too) and let C1 reintroduce a paradigm-agnostic form when the tectonic_c1 runner exists.
 
 ---
 

--- a/docs/reports/c1_phase_1_3_equilibrium_height/README.md
+++ b/docs/reports/c1_phase_1_3_equilibrium_height/README.md
@@ -1,0 +1,143 @@
+# C1 Phase 1.3 — Equilibrium height closure outputs
+
+Issue #125, branch
+`125-c1-phase-13-equilibrium-height-closure-harness-paradigm-agnostic-refactor`.
+
+Produced by the Stage E3 acceptance test
+[`crates/ymir-core/tests/c1_phase_1_3_equilibrium_height.rs`](../../../crates/ymir-core/tests/c1_phase_1_3_equilibrium_height.rs).
+
+## Run parameters
+
+| Parameter | Value | Source |
+|---|---|---|
+| Grid | 64 × 64 | Phase 1.1 standard |
+| Steps | 300 | Phase 1.1 standard |
+| Kinematics | `PlateKinematics::preset_phase_1_1(num_plates)` (8 plates) | Phase 1.1 hand-tuned |
+| Davis-Suppe closure | `DavisSuppeParams::default()` (enabled, coupling=2.0, h_max=2.5) | Phase 1.2 Stage E1 |
+| Equilibrium-height closure | `EquilibriumHeightParams::default()` (enabled, **h_eq = 2.0, k_collapse = 2.0, quadratic** per Molnar-Lyon-Caen 1988 eq. (2)) | Phase 1.3 Stage E1.bis |
+| Wall time | ≈ 29 ms / 300 steps (≈ 100 µs/step) | measured Stage E3 |
+
+## Acceptance summary — 4 / 4 PASS
+
+| # | Test | Empirical | Threshold | Status |
+|---|------|-----------|-----------|--------|
+| T1 | `equilibrium_height_caps_global_max` | `global_max = 2.181` | `< 2.4 (= 1.2 · h_eq)` | PASS |
+| T2 | `davis_suppe_imprint_preserved_with_equilibrium` | composite (below) | 3 sub-assertions | PASS |
+| T3 | `equilibrium_alone_caps_initial_state` | `global_max = 2.024` | `≤ 2.2 (= 1.1 · h_eq)` | PASS |
+| T4 | `both_closures_disabled_matches_phase_1_1` | `global_max = 1079.697` | `> 100` (Phase 1.1 baseline ≈ 1080) | PASS |
+
+### T2 composite breakdown
+
+| Sub-assertion | Phase 1.3 | Phase 1.2 baseline | Threshold | Status |
+|---|---|---|---|---|
+| sub-1: `wedge_p95` (PRIMARY — bulk preservation) | 0.376 | 0.376 | `∈ [0.3, 0.5]` | **bit-identical** ✓ |
+| sub-2: `asymmetry = mean(near) / mean(far)` (spatial shape) | 2.12 | 4.66 | `> 1.5` | preserved ✓ |
+| sub-3: `fill_near = mean(0-5) / h_crit(2.5)` (regime-tagged Phase 1.3 floor) | 0.207 | 0.778 | `> 0.1` | floor cleared ✓ |
+
+The **PRIMARY** signal that the Davis-Suppe imprint is preserved
+is `wedge_p95`: the bulk of the wedge body (95 % of cells) sits
+below `h_eq = 2.0` and is therefore *untouched* by the
+asymmetric one-sided equilibrium sink. `wedge_p95` is
+**bit-identical** between Phase 1.2 and Phase 1.3 (0.376 = 0.376).
+The other two sub-assertions are corroborating evidence.
+
+## Phase 1.1 / 1.2 / 1.3 cycle-300 comparison
+
+| Quantity | Phase 1.1 (advection only) | Phase 1.2 (+ Davis-Suppe) | Phase 1.3 (+ Davis-Suppe + Equilibrium) | Phase 1.3 mechanism |
+|---|---|---|---|---|
+| `global_max` (boundary pile-up) | ≈ 1080 | 2297 | **2.18** | One-step clamp at `h_eq` (quadratic formula triggers safety clamp on large-excess cells) |
+| `wedge_p95` (bulk, 95 % of wedge cells) | n/a | 0.376 | **0.376** | Below `h_eq` → untouched |
+| `wedge_p99` (top 1 % of wedge cells) | n/a | 5.83 | **2.17** | Above `h_eq` → clamped |
+| `wedge_max` (single-cell outliers) | n/a | 93 | **2.18** | Above `h_eq` → clamped |
+| `mean(d ∈ 0-5)` (near-boundary bucket) | n/a | 0.904 | 0.241 | Outliers in bucket clamped, bulk preserved |
+| `mean(d ∈ 10-20)` (far-boundary bucket) | n/a | 0.194 | 0.113 | Outliers clamped |
+| `fill_near` | n/a | 0.778 | 0.207 | Bucket-mean-derived → biased by clamp |
+| `asymmetry` (`near / far`) | n/a | 4.66 | 2.12 | Reduced but preserved (> 1.5) |
+| Total `mass(S̃)` | conserved (1.6 × 10⁻¹⁴ drift) | growing (source-only) | balanced (source ≈ sink) | Equilibrium is the first global sink in C1 |
+
+## Visual gallery
+
+Five cycle snapshots at NNN ∈ { 000, 050, 100, 200, 300 }, two
+PNGs each = 10 files total in this directory:
+
+- `cycle_NNN_altitude.png` — auto-rescaled hypsometric view via
+  `compute_isostasy` (informational; the auto-rescale brings out
+  fine detail in the bulk wedge body now that the dynamic range
+  is narrow).
+- `cycle_NNN_s.png` — `S̃` field at the **same fixed palette
+  `[0, 3.0]`** as the Phase 1.2 gallery
+  ([`../c1_phase_1_2_davis_suppe/`](../c1_phase_1_2_davis_suppe/)),
+  so the two galleries are directly pixel-for-pixel comparable.
+
+### What to look for in `cycle_NNN_s.png` (Phase 1.2 vs Phase 1.3)
+
+1. **Boundary cells — the cap is visible.** In Phase 1.2's
+   gallery, convergent-boundary cells saturated the palette
+   ceiling (white = ≥ 3.0; actual values reached `2297`). In
+   Phase 1.3 those cells sit at `≈ 2.0` — a clean, smooth
+   capped envelope along the convergent boundaries. The single
+   most visible signature of the equilibrium closure.
+2. **Wedge body — bulk preserved.** The medium-tone gradient
+   surrounding each convergent boundary (cells with
+   `d ∈ (0, 10]`, the wedge body) should look **very similar**
+   to Phase 1.2. The bulk is below `h_eq` so the equilibrium
+   closure does not touch it; visually this region is unchanged.
+3. **Outliers — clamped.** Phase 1.2's wedge body contained
+   sparse "hot spots" (top 1 % of cells reaching `5.83+`).
+   These are absent in Phase 1.3 — clamped to `h_eq` and
+   indistinguishable from the bulk at the palette resolution.
+4. **Far-from-boundary cells — drained but consistent.** Cells
+   with `d ∈ (10, 30]` (the deep wedge body) show the same
+   drained signature as Phase 1.2 (advection-dominated regime
+   per the Phase 1.2 finding) — the equilibrium closure does
+   not change the regime, only caps the upper tail.
+
+### What to look for in `cycle_NNN_altitude.png`
+
+Auto-rescaled hypsometric view, informational. Because Phase 1.3's
+dynamic range is now `[0.0002, 2.18]` (capped at `h_eq` instead
+of running up to `2297`), the rescaling brings out finer detail
+in the bulk wedge body. The continental ↔ oceanic mask
+(`compute_isostasy::sea_level_normalized`) shifts cycle-to-cycle
+as the S̃ distribution evolves.
+
+## Architectural finding (Stage E3 W7)
+
+The original Phase 1.2 acceptance metric `fill_near > 0.5` was
+structurally biased by Davis-Suppe outliers: the bucket-mean
+denominator was dominated by the top 1 % of wedge cells (reaching
+5.83+ in Phase 1.2). Phase 1.3's equilibrium closure clamps those
+outliers at `h_eq` by design — one of its three documented
+purposes (`closures::equilibrium_height::mod` § "Interaction with
+Phase 1.2 Davis-Suppe imprint"). The bucket means therefore drop
+mechanically with no change to the bulk wedge body.
+
+The Stage E3 acceptance test replaces the single Phase-1.2-regime
+threshold with the **composite assertion** described above:
+
+1. **`wedge_p95`** — primary: bulk below `h_eq` is bit-identical
+   between regimes.
+2. **`asymmetry`** — secondary: spatial near-vs-far shape
+   preserved (reduced but > 1.5).
+3. **`fill_near`** — regime-tagged Phase 1.3 floor: explicit
+   acknowledgment that the metric is biased, with a relaxed
+   threshold that catches catastrophic loss while accommodating
+   Phase 1.4+ erosion-sink drift.
+
+This pattern (three regime-aware sub-assertions, each documents a
+different facet of "preservation despite sink") generalises the
+[`feedback_fill_ratio_regime_agnostic_metric`](../../../C:/Users/obruneau/.claude/projects/d--Personnel-Project-ymir/memory/feedback_fill_ratio_regime_agnostic_metric.md)
+memory: percentile and asymmetry metrics are clamp-insensitive;
+bucket-mean metrics are clamp-sensitive and must be regime-tagged
+per phase.
+
+The Stage E4 memory update extends that entry with the Phase 1.3
+refinement.
+
+## Cross-references
+
+- **Closure code:** [`crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/`](../../../crates/ymir-core/src/tectonics_c1/closures/equilibrium_height/) — `mod.rs` carries the Molnar-Lyon-Caen 1988 eq. (2) derivation and the Phase 1.2-interaction table that predicts these results.
+- **Time-loop integration:** [`crates/ymir-core/src/tectonics_c1/time_loop.rs`](../../../crates/ymir-core/src/tectonics_c1/time_loop.rs) — `run_with_closures` applies Davis-Suppe then equilibrium per step (strict order, see in-function comment).
+- **Phase 1.2 gallery:** [`../c1_phase_1_2_davis_suppe/`](../c1_phase_1_2_davis_suppe/) — same palette, direct side-by-side comparison possible.
+- **Phase 1.1 advection:** [`../c1_phase_1_1_advection/`](../c1_phase_1_1_advection/) — Phase 1.1 baseline before any closure.
+- **Harness paradigm-agnostic refactor:** [`../../migrations/harness_paradigm_agnostic.md`](../../migrations/harness_paradigm_agnostic.md) — Stage H1 / H2 / H3, separate from the Stage E1-E4 closure work.


### PR DESCRIPTION
## Summary

Two intertwined deliverables on branch
`125-c1-phase-13-equilibrium-height-closure-harness-paradigm-agnostic-refactor`,
sharing a workspace but with no runtime coupling:

### Track E — Equilibrium-height closure (Stages E1 / E1.bis / E2 / E3)

Molnar & Lyon-Caen 1988 (*GSA Special Paper 218*, eq. 2)
gravitational-collapse sink. Quadratic in excess thickness:

∂S̃/∂t |_equilibrium = − k_collapse · max(0, S̃ − h_eq)²

Applied globally (no plate-type or boundary skip — first global
sink in C1). Defaults `h_eq = 2.0`, `k_collapse = 2.0`. Caps the
Phase 1.2 advection-dominated boundary pile-up from
`global_max = 2297` → `2.18` in one step (quadratic threshold
behaviour triggers the safety clamp); the bulk wedge body
(`wedge_p95 = 0.376`) is **bit-identical** to Phase 1.2 since
it sits below `h_eq`.

### Track H — Harness paradigm-agnostic refactor (Stages H1 / H2 / H3)

Pays down Issue #117 HC4 deferred debt. **Option B (two
separate functions)** chosen over Option A (trait abstraction)
per a criterion-driven Stage H1 audit
([`docs/migrations/harness_paradigm_agnostic.md`](docs/migrations/harness_paradigm_agnostic.md)):
configs / per-step payloads / result envelopes are structurally
divergent between v2 and C1; a trait would need 3 associated
types + GAT + ControlFlow wrapper for 4-5 days; two functions
landed in 1.5 days.

- `workflow/phase_a_v2.rs` — v2 path, gated under `v2_legacy`
- `workflow/phase_a_c1.rs` — C1 path, **default-features-on**
- `workflow/phase_a_common.rs` — shared paradigm-agnostic post-
  tectonic pass (sea-level → macro-redistribution →
  reclassification → cratonic recompute)
- `workflow/phase_b.rs` — `v2_legacy` gate dropped (was already
  paradigm-agnostic at runtime)

## Commits (11, chronological)

| # | SHA | Stage | Type | Summary |
|---|---|---|---|---|
| 1 | `563c24a` | E1 | FEAT | Equilibrium-height closure module (params + source_term + 5 unit tests) |
| 2 | `1be038b` | E2 | FEAT | Closure wired into `time_loop::run_with_closures` after Davis-Suppe (strict ordering) |
| 3 | `ecf2921` | E1.bis | FIX | Upgrade linear → **quadratic** per Molnar-Lyon-Caen eq. (2); default `k_collapse: 1.0 → 2.0` |
| 4 | `e6a58e2` | H1 | DOC | Paradigm-agnostic refactor audit (544 lines, 3-criterion verdict → Option B) |
| 5 | `11c53b6` | H2.1 | REFACTOR | Carve `CycleOutputCommon` + drop `phase_b` `v2_legacy` gate |
| 6 | `f8f1c5b` | H2.2 | REFACTOR | Rename `phase_a*` → `phase_a*_v2` (Q2.b naming, 12 files / 103 substitutions) |
| 7 | `2be9db9` | H2.3 | REFACTOR | Extract `workflow/phase_a_common.rs` (`apply_post_tectonic`) |
| 8 | `5679631` | H2.4 | FEAT | Create `workflow/phase_a_c1.rs` (default-features-on, inline smoke test) |
| 9 | `6ef32a0` | H3 | TEST | 4 C1 workflow integration tests, incl. bit-identical decomposition |
| 10 | `be5812c` | H2.6 | DOC | Mark H1/H2 RESOLVED + cross-links + future revisit criteria + known limitations |
| 11 | `703c12a` | E3 | TEST | 4 Phase 1.3 equilibrium-height behavioural tests + 5-cycle PNG gallery + comparison README |

## Acceptance — Stage E3 (4 / 4 PASS)

| # | Test | Empirical | Threshold | Status |
|---|---|---|---|---|
| T1 | `equilibrium_height_caps_global_max` | `global_max = 2.181` | `< 2.4 (= 1.2 · h_eq)` | PASS |
| T2 | `davis_suppe_imprint_preserved_with_equilibrium` (composite) | see below | 3 sub-assertions | PASS |
| T3 | `equilibrium_alone_caps_initial_state` | `global_max = 2.024` | `≤ 2.2 (= 1.1 · h_eq)` | PASS |
| T4 | `both_closures_disabled_matches_phase_1_1` | `global_max = 1079.697` | `> 100` (Phase 1.1 ≈ 1080) | PASS |

### T2 composite breakdown

| Sub-assertion | Phase 1.3 | Phase 1.2 baseline | Threshold | Result |
|---|---|---|---|---|
| sub-1: `wedge_p95` (PRIMARY — bulk preservation) | **0.376** | **0.376** | `∈ [0.3, 0.5]` | **bit-identical** ✓ |
| sub-2: `asymmetry = mean(near) / mean(far)` (spatial shape) | 2.12 | 4.66 | `> 1.5` | preserved ✓ |
| sub-3: `fill_near` (regime-tagged Phase-1.3 floor) | 0.207 | 0.778 | `> 0.1` | floor cleared ✓ |

The **PRIMARY** evidence is `wedge_p95 = 0.376` bit-identical
between Phase 1.2 and 1.3 — the bulk wedge body sits below
`h_eq` and is therefore untouched by the asymmetric one-sided
equilibrium sink.

## Physics validation

- Equilibrium closure derived directly from Molnar & Lyon-Caen
  1988 *GSA Spec. Paper 218*, eq. (2):
  `ΔPE_A = ½ρ_c·g·h² + ρ_c·g·h·H_0 + ½·Δρ·g·ΔH²` (quadratic in
  excess thickness).
- `h_eq = 2.0` is **phenomenological** (Tibet ~70/35 km crustal
  ratio), explicitly documented as such in `closures::
  equilibrium_height::mod` § "Parameter h_eq = 2.0
  (phenomenological)". NOT a rigorous derivation; the paper's
  `S_c` (50-60 km, convective-removal threshold) is a different
  mechanism not modelled here.

## 3 Architectural findings (all surfaced before any code change)

1. **Stage E1.bis — Quadratic formula.** User research surfaced
   Molnar-Lyon-Caen eq. (2)'s quadratic ΔPE_A; Stage E1 linear
   formula was upgraded with one-file diff (formula change +
   default recalibration `k_collapse 1.0 → 2.0` + 2 unit-test
   numeric updates). 3 unit tests untouched (formula path not
   entered).
2. **Stage H2 Commit 1 — PowerShell encoding bug.**
   `Set-Content -Encoding utf8` injected a BOM and mojibake'd
   non-ASCII bytes (`×ʹ → Ã—`, `α → Î±`, `— → â€"`) across 5
   `_attic/` test files. Recovered via `git checkout HEAD~1
   --` + re-apply with `[System.IO.File]::WriteAllText` using
   `UTF8Encoding($false)` + `git commit --amend`. Memory:
   [`feedback_powershell_set_content_utf8_corrupts_non_ascii`](C:\Users\obruneau\.claude\projects\d--Personnel-Project-ymir\memory\feedback_powershell_set_content_utf8_corrupts_non_ascii.md).
3. **Stage E3 W7 — Composite assertion.** The Phase 1.2
   `fill_near > 0.5` metric was structurally biased by Davis-
   Suppe outliers (top 1 % of wedge cells); Phase 1.3's
   equilibrium clamp removes those outliers by design.
   Replaced with composite 3-sub-assertion (percentile +
   asymmetry + regime-tagged fill_ratio floor). Memory:
   [`feedback_fill_ratio_regime_agnostic_metric`](C:\Users\obruneau\.claude\projects\d--Personnel-Project-ymir\memory\feedback_fill_ratio_regime_agnostic_metric.md) Phase 1.3 refinement section.

## Pre-existing limitation — `ymir-viz` under `v2_legacy`

`cargo build -p ymir-viz --features v2_legacy` fails with 299
Bevy-side errors (`..default()` / `Transform` not in scope) on
the Stage H1 base commit `e6a58e2` (before any of this work).
**Not caused by this PR.** Surfaced and filed as a placeholder
follow-up issue `[Issue #TBD]` per `feedback_match_request_scope`.
H2 verification surface bounded to `ymir-core` under both
feature flags (verified clean) + `ymir-viz` under default
features (verified clean). See
[`docs/migrations/harness_paradigm_agnostic.md`](docs/migrations/harness_paradigm_agnostic.md) § 14.1.

## Performance

| Run | Wall time | Per step |
|---|---|---|
| Phase 1.2 (Davis-Suppe only) baseline | 43.33 ms / 300 steps | 144.44 µs |
| Phase 1.3 (Davis-Suppe + equilibrium) | **28.90 ms / 300 steps** | **96.33 µs** |

Phase 1.3 is faster than Phase 1.2 because equilibrium clamps
the boundary pile-up early — Davis-Suppe's `driving = h_crit -
h_now` short-circuits cheaper when `h_now` doesn't grow
unbounded.

## Visual outputs

5-cycle PNG gallery dumped at
`docs/reports/c1_phase_1_3_equilibrium_height/cycle_NNN_{altitude,s}.png`
for NNN ∈ {000, 050, 100, 200, 300} (10 files). PNGs are
local artifacts (re-generated by the Stage E3 test on each
run), not committed. The README documents the visual reading
guide vs Phase 1.2's gallery (same palette `[0, 3.0]` for
pixel-for-pixel comparison).

## Memory entries (3, off-repo)

- **UPDATE** `feedback_fill_ratio_regime_agnostic_metric` — Phase 1.3 refinement section + composite-assertion pattern
- **CREATE** `feedback_powershell_set_content_utf8_corrupts_non_ascii` — transferable tooling lesson
- **CREATE** `project_c1_phase_1_3_equilibrium_height_outcomes` — Phase 1.3 project record

## Verification — 62 / 62 PASS across both feature flags

| Suite | Feature | Pass |
|---|---|---|
| `c1_phase_1_3_equilibrium_height` (E3, new) | default | 4 / 4 |
| `c1_phase_1_3_workflow` (H3, new) | default | 4 / 4 |
| `tectonics_v2::workflow::phase_a_c1::tests` (inline) | default | 1 / 1 |
| `tectonics_c1` lib unit tests | default | 42 / 42 |
| `c1_phase_1_1_advection` | default | 1 / 1 |
| `c1_phase_1_2_davis_suppe` | default | 2 / 2 |
| `v2_workflow_macro` | default | 2 / 2 |
| `v2_workflow_disabled_regression` | v2_legacy | 3 / 3 |
| `v2_workflow_phase_a_cycle` | v2_legacy | 3 / 3 |
| **Total** | | **62 / 62** |

## Next — Phase 1.4 preview

- **Stream-power erosion (Whipple-Tucker 1999)** lands as the
  second global sink in C1. Expected to reduce `wedge_p95`
  below the Phase 1.3 `0.376` baseline; the composite-
  assertion's `[0.3, 0.5]` range will need re-evaluation per
  the [`feedback_fill_ratio_regime_agnostic_metric`](C:\Users\obruneau\.claude\projects\d--Personnel-Project-ymir\memory\feedback_fill_ratio_regime_agnostic_metric.md) "regime-tagged
  per phase" pattern.
- **Asymmetry direction may invert.** Phase 1.2 finding
  predicted erosion could shift the regime toward source-
  dominated. T2 sub-2 direction is regime-tagged for re-evaluation.
- **C1State may gain `cratonic_factor: Field2D`** to consume
  the `apply_post_tectonic` output Phase 1.3 currently
  discards.
- **`run_phase_a_cycle_with_progress_c1` lands in Phase 4**
  (UI bridge integration), not Phase 1.4. C1
  `time_loop::run_with_closures` already accepts the callback;
  the lift is trivial when the bridge consumer exists.