### PR TITLE
Issue #139 Viz-0.5 — hover + calibrated workflow mode + hypsometric lens + continuation-ready

### DIFF
--- a/crates/ymir-viz/src/bridge/c1/commands.rs
+++ b/crates/ymir-viz/src/bridge/c1/commands.rs
@@ -21,14 +21,31 @@
 //! `tectonics_v2::cancel`), threaded through `run_with_closures`'s
 //! per-step boundary. ~1 day effort.
 
+use ymir_core::tectonics_v2::workflow::PhaseAParams;
+
 use super::spec::C1RunSpec;
 
 #[derive(Clone, Debug)]
 pub enum C1Command {
-    /// Launch a baseline run with `spec`. Worker emits
-    /// `Started → StepCompleted × n_steps → Completed` (or
-    /// `Failed` on panic, currently unreachable per Q-E1.2).
+    /// Launch a **gallery-path** baseline run with `spec`: standalone
+    /// `run_with_closures`, NO `apply_post_tectonic`. Worker emits
+    /// `Started → StepCompleted × n_steps → Completed` (or `Failed`
+    /// on panic, currently unreachable per Q-E1.2). Reproduces the
+    /// Track A/B/D visual gallery (Issue #137 gallery contract).
     RunBaseline { spec: C1RunSpec },
+    /// Launch a **workflow-path** run (Issue #139 Stage E2): the
+    /// calibrated Phase A loop — `n_cycles` cycles of
+    /// `run_with_closures(k_cycle)` each followed by
+    /// `apply_post_tectonic` (sea-level → macro-redistribution →
+    /// reclassify). `phase_a` defaults to `PhaseAParams::default()`
+    /// (n_cycles 5, k_cycle 20, alpha 0.01) — the calibrated cadence.
+    /// Total tectonic steps = `n_cycles × k_cycle`, NEVER `n_steps`
+    /// (the A1-c over-erosion guard). The gallery `RunBaseline` path
+    /// is left untouched (W4).
+    RunWorkflow {
+        spec: C1RunSpec,
+        phase_a: PhaseAParams,
+    },
     /// Set the shared cancel flag. Does NOT interrupt the
     /// current run — see module docstring.
     Cancel,

--- a/crates/ymir-viz/src/bridge/c1/events.rs
+++ b/crates/ymir-viz/src/bridge/c1/events.rs
@@ -27,15 +27,43 @@
 
 use std::time::Duration;
 
+use ymir_core::tectonics_v2::workflow::PhaseAParams;
+
 use super::snapshot::C1Snapshot;
 use super::spec::C1RunSpec;
 
+/// Which pipeline a run is exercising (Issue #139 Stage E2). Carried
+/// on `Started` so the poll system can resolve the step-counter total
+/// and the UI can show the per-cycle counter in workflow mode.
+#[derive(Clone, Debug)]
+pub enum C1RunKind {
+    /// Gallery path — standalone `run_with_closures`, total tectonic
+    /// steps = `spec.n_steps` (Issue #137 contract).
+    Gallery,
+    /// Workflow path — calibrated Phase A loop, total tectonic steps
+    /// = `phase_a.n_cycles × phase_a.k_cycle` (NOT `n_steps`).
+    Workflow { phase_a: PhaseAParams },
+}
+
+impl C1RunKind {
+    /// Total **tectonic** steps for the run — the `/N` denominator in
+    /// the UI step counter. Workflow's per-cycle `apply_post_tectonic`
+    /// snapshots are extra and do NOT advance this count.
+    pub fn total_tectonic_steps(&self, spec: &C1RunSpec) -> usize {
+        match self {
+            C1RunKind::Gallery => spec.n_steps,
+            C1RunKind::Workflow { phase_a } => phase_a.n_cycles * phase_a.k_cycle,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum C1Event {
-    /// Worker has accepted a `RunBaseline` command and is about
-    /// to start the C1 time loop. Caller can reset UI state on
-    /// receipt.
-    Started { spec: C1RunSpec },
+    /// Worker has accepted a run command and is about to start.
+    /// `kind` distinguishes the gallery vs workflow pipeline and
+    /// carries the workflow cadence for the UI counter. Caller can
+    /// reset UI state on receipt.
+    Started { spec: C1RunSpec, kind: C1RunKind },
     /// One C1 step has just completed; `snapshot` carries the
     /// post-step state + Track D stats (Issue #137 Viz-D0
     /// Option B).

--- a/crates/ymir-viz/src/bridge/c1/mod.rs
+++ b/crates/ymir-viz/src/bridge/c1/mod.rs
@@ -18,7 +18,7 @@ pub mod spec;
 pub mod thread;
 
 pub use commands::C1Command;
-pub use events::C1Event;
+pub use events::{C1Event, C1RunKind};
 pub use plugin::{C1BridgePlugin, C1CumulativeStats, C1RunState, C1SolverBridge};
 pub use snapshot::C1Snapshot;
 pub use spec::C1RunSpec;

--- a/crates/ymir-viz/src/bridge/c1/plugin.rs
+++ b/crates/ymir-viz/src/bridge/c1/plugin.rs
@@ -24,8 +24,10 @@ use std::time::{Duration, Instant};
 use bevy::prelude::*;
 use crossbeam_channel::{bounded, Receiver, Sender};
 
+use ymir_core::tectonics_v2::workflow::PhaseAParams;
+
 use super::commands::C1Command;
-use super::events::C1Event;
+use super::events::{C1Event, C1RunKind};
 use super::snapshot::C1Snapshot;
 use super::spec::C1RunSpec;
 use super::thread::spawn_c1_thread;
@@ -57,6 +59,9 @@ pub enum C1RunState {
     Idle,
     Running {
         spec: C1RunSpec,
+        /// Pipeline kind (gallery vs workflow + cadence). Drives the
+        /// UI step/cycle counter (Issue #139 Stage E2/E3).
+        kind: C1RunKind,
         step: usize,
         total: usize,
         started_at: Option<Instant>,
@@ -69,6 +74,8 @@ pub enum C1RunState {
     },
     Completed {
         spec: C1RunSpec,
+        /// Pipeline kind of the completed run (Issue #139 Stage E2).
+        kind: C1RunKind,
         elapsed: Duration,
         final_snapshot: Box<C1Snapshot>,
         /// Run-cumulative Track D totals at end of run.
@@ -109,11 +116,24 @@ pub struct C1SolverBridge {
 }
 
 impl C1SolverBridge {
-    /// Queue a baseline run. Returns `Err` if the channel is
-    /// full or disconnected.
+    /// Queue a gallery-path baseline run. Returns `Err` if the
+    /// channel is full or disconnected.
     pub fn submit_run(&self, spec: C1RunSpec) -> Result<(), &'static str> {
         self.commands_tx
             .send(C1Command::RunBaseline { spec })
+            .map_err(|_| "c1 bridge channel send failed")
+    }
+
+    /// Queue a workflow-path run (Issue #139 Stage E2). `phase_a`
+    /// carries the calibrated Phase A cadence (default
+    /// `PhaseAParams::default()`).
+    pub fn submit_workflow(
+        &self,
+        spec: C1RunSpec,
+        phase_a: PhaseAParams,
+    ) -> Result<(), &'static str> {
+        self.commands_tx
+            .send(C1Command::RunWorkflow { spec, phase_a })
             .map_err(|_| "c1 bridge channel send failed")
     }
 
@@ -153,10 +173,11 @@ impl Plugin for C1BridgePlugin {
 fn poll_c1_events(mut bridge: ResMut<C1SolverBridge>) {
     while let Ok(event) = bridge.events_rx.try_recv() {
         match event {
-            C1Event::Started { spec } => {
-                let total = spec.n_steps;
+            C1Event::Started { spec, kind } => {
+                let total = kind.total_tectonic_steps(&spec);
                 bridge.state = C1RunState::Running {
                     spec,
+                    kind,
                     step: 0,
                     total,
                     started_at: Some(Instant::now()),
@@ -170,15 +191,16 @@ fn poll_c1_events(mut bridge: ResMut<C1SolverBridge>) {
                 // `snapshot.stats` are this-step-only; for rare
                 // events the panel needs the cumulative figure
                 // accumulated across the StepCompleted stream.
-                let (spec, total, started_at, mut cumulative) =
+                let (spec, kind, total, started_at, mut cumulative) =
                     match std::mem::take(&mut bridge.state) {
                         C1RunState::Running {
                             spec,
+                            kind,
                             total,
                             started_at,
                             cumulative,
                             ..
-                        } => (spec, total, started_at, cumulative),
+                        } => (spec, kind, total, started_at, cumulative),
                         other => {
                             bridge.state = other;
                             continue;
@@ -198,6 +220,7 @@ fn poll_c1_events(mut bridge: ResMut<C1SolverBridge>) {
                 let step = snapshot.step;
                 bridge.state = C1RunState::Running {
                     spec,
+                    kind,
                     step,
                     total,
                     started_at,
@@ -210,14 +233,17 @@ fn poll_c1_events(mut bridge: ResMut<C1SolverBridge>) {
                 final_snapshot,
                 elapsed,
             } => {
-                // Transfer cumulative from Running → Completed.
-                let cumulative =
+                // Transfer cumulative + kind from Running → Completed.
+                let (kind, cumulative) =
                     match std::mem::take(&mut bridge.state) {
-                        C1RunState::Running { cumulative, .. } => cumulative,
-                        _ => C1CumulativeStats::default(),
+                        C1RunState::Running {
+                            kind, cumulative, ..
+                        } => (kind, cumulative),
+                        _ => (C1RunKind::Gallery, C1CumulativeStats::default()),
                     };
                 bridge.state = C1RunState::Completed {
                     spec,
+                    kind,
                     elapsed,
                     final_snapshot: Box::new(final_snapshot),
                     cumulative,

--- a/crates/ymir-viz/src/bridge/c1/thread.rs
+++ b/crates/ymir-viz/src/bridge/c1/thread.rs
@@ -74,15 +74,17 @@ use ymir_core::tectonics::isostasy::IsostasyConfig;
 use ymir_core::tectonics_c1::init_r7::init_c1_state_phase_2_r7;
 use ymir_core::tectonics_c1::kinematics::PlateKinematics;
 use ymir_core::tectonics_c1::time_loop::{run_with_closures, C1TimeLoopConfig};
+use ymir_core::tectonics_v2::workflow::phase_a_common::{apply_post_tectonic, PostTectonicInput};
+use ymir_core::tectonics_v2::workflow::PhaseAParams;
 
 use super::commands::C1Command;
-use super::events::C1Event;
+use super::events::{C1Event, C1RunKind};
 use super::snapshot::C1Snapshot;
+use super::spec::C1RunSpec;
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bridge::c1::spec::C1RunSpec;
     use crossbeam_channel::bounded;
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
@@ -417,6 +419,7 @@ pub fn spawn_c1_thread(
 
                         let _ = events_tx.send(C1Event::Started {
                             spec: spec.clone(),
+                            kind: C1RunKind::Gallery,
                         });
 
                         let mut state = init_c1_state_phase_2_r7(
@@ -495,6 +498,9 @@ pub fn spawn_c1_thread(
                             elapsed,
                         });
                     }
+                    C1Command::RunWorkflow { spec, phase_a } => {
+                        run_workflow(&spec, &phase_a, &events_tx);
+                    }
                     C1Command::Cancel => {
                         // MVP Option C — set the flag; takes
                         // effect on the next RunBaseline only.
@@ -504,4 +510,114 @@ pub fn spawn_c1_thread(
             }
         })
         .expect("ymir-c1-bridge thread spawn")
+}
+
+/// Workflow-path run (Issue #139 Stage E2) — the **calibrated** Phase
+/// A loop. Reproduces `run_phase_a_cycle_c1(Enabled)` `n_cycles`
+/// times, inlining `run_with_closures` only to inject the per-step
+/// animation hook (the wrapper hardcodes `on_step = |_, _| {}`).
+///
+/// Cadence is the calibration anchor: `phase_a.n_cycles × phase_a.
+/// k_cycle` tectonic steps with one `apply_post_tectonic` per cycle
+/// (default 5×20 = 100 steps, 5 macro-redistribution passes). This is
+/// **NOT** the A1-c failure mode (6 passes over 300 steps = 6× the
+/// calibrated cadence → over-erosion); `macro_redistribution`'s
+/// `alpha = 0.01` is calibrated for exactly this cadence.
+///
+/// `cratonic_cfg = None` ⇒ `apply_post_tectonic` Step 4 (cratonic
+/// recompute) is skipped, so `initial_per_plate_type = None` is
+/// bit-identical to `run_phase_a_cycle_c1` with `cratonic_config =
+/// None` (only Step 4 reads it — see `phase_a_common.rs` Step 4 gate).
+///
+/// Snapshot stream: cycle-0 (step 0) + per cycle `{ k_cycle per-step
+/// snapshots + 1 post-tectonic snapshot }` + `Completed`. Per-step
+/// indices are the global tectonic step `cycle·k_cycle + s + 1`; the
+/// post-cycle snapshot reuses the cycle-boundary index (so the step
+/// sequence is monotone non-decreasing and the "step N/total" counter
+/// tracks tectonic steps, not emission ordinal).
+fn run_workflow(spec: &C1RunSpec, phase_a: &PhaseAParams, events_tx: &Sender<C1Event>) {
+    let _ = events_tx.send(C1Event::Started {
+        spec: spec.clone(),
+        kind: C1RunKind::Workflow {
+            phase_a: phase_a.clone(),
+        },
+    });
+
+    let mut state =
+        init_c1_state_phase_2_r7(spec.grid_size, spec.seed, &spec.init_params);
+    let mut kinematics = PlateKinematics::preset_phase_1_1(state.num_plates);
+
+    // Init-time velocities for the snapshot (mid-run kinematics
+    // mutations from accretion/rifting are NOT reflected — same MVP
+    // caveat as the gallery path; Viz-0-bis item 1).
+    let initial_velocities: Vec<(f64, f64)> = kinematics.velocities.clone();
+
+    let n_cycles = phase_a.n_cycles;
+    let k_cycle = phase_a.k_cycle;
+    let iso_config = IsostasyConfig::default();
+
+    // Cycle-0 pre-run snapshot (step 0).
+    let _ = events_tx.send(C1Event::StepCompleted {
+        snapshot: C1Snapshot::from_state(0, &state, &initial_velocities),
+    });
+
+    let t0 = Instant::now();
+
+    for cycle in 0..n_cycles {
+        let cfg = C1TimeLoopConfig {
+            n_steps: k_cycle,
+            dx: 1.0 / spec.grid_size as f64,
+            dy: 1.0 / spec.grid_size as f64,
+            iso_config: iso_config.clone(),
+            drainage_max_distance: spec.drainage_max_distance,
+        };
+        let base = cycle * k_cycle;
+
+        // Per-step tectonic loop (animation hook). The closure
+        // captures only `events_tx`, `initial_velocities`, `base` by
+        // reference / copy — none alias `state` / `kinematics`, so no
+        // borrow conflict with `run_with_closures`'s `&mut` args.
+        run_with_closures(
+            &mut state,
+            &mut kinematics,
+            &cfg,
+            &spec.closures,
+            |s_in_c, st| {
+                let step = base + s_in_c + 1;
+                let _ = events_tx.send(C1Event::StepCompleted {
+                    snapshot: C1Snapshot::from_state(step, st, &initial_velocities),
+                });
+            },
+        );
+
+        // Calibrated post-tectonic pass (split borrow: &mut s /
+        // &plate_id / &mut plate_type are disjoint fields).
+        let _ = apply_post_tectonic(PostTectonicInput {
+            s_field: &mut state.s,
+            plate_id: Some(&state.plate_id),
+            plate_type: Some(&mut state.plate_type),
+            previous_cratonic_factor: None,
+            initial_per_plate_type: None,
+            params: phase_a,
+            iso_cfg: &iso_config,
+            cratonic_cfg: None,
+        });
+
+        // Post-cycle snapshot — coast reclassified. Reuses the
+        // boundary tectonic step index.
+        let boundary_step = base + k_cycle;
+        let _ = events_tx.send(C1Event::StepCompleted {
+            snapshot: C1Snapshot::from_state(boundary_step, &state, &initial_velocities),
+        });
+    }
+
+    let elapsed = t0.elapsed();
+    let final_step = n_cycles * k_cycle;
+    let final_snapshot =
+        C1Snapshot::from_state(final_step, &state, &initial_velocities);
+    let _ = events_tx.send(C1Event::Completed {
+        spec: spec.clone(),
+        final_snapshot,
+        elapsed,
+    });
 }

--- a/crates/ymir-viz/src/bridge/c1/thread.rs
+++ b/crates/ymir-viz/src/bridge/c1/thread.rs
@@ -688,6 +688,84 @@ mod tests {
         handle.join().unwrap();
     }
 
+    /// Issue #139 Stage A acceptance — DISTINCT product angle from the
+    /// Stage V mechanism guard. Stage V asserts mass-conservation /
+    /// convergence / isostatic-floor; this asserts the PRODUCT promise
+    /// of workflow mode: the coast actually MIGRATES (the displayed
+    /// land/sea boundary moves substantially from init), AND the
+    /// continent does not vanish (emergent land stays nonzero). This
+    /// is what distinguishes workflow mode from the static-coast
+    /// gallery path (Issue #137 contract). 64² seed 42, calibrated
+    /// default cadence.
+    #[test]
+    fn workflow_acceptance_continent_preserved_seed_42() {
+        use ymir_core::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
+        use ymir_core::tectonics_v2::field::Field2D;
+
+        let (cmd_tx, cmd_rx) = bounded(4);
+        let (evt_tx, evt_rx) = bounded(2);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let handle = spawn_c1_thread(cmd_rx, evt_tx, cancel);
+        cmd_tx
+            .send(C1Command::RunWorkflow {
+                spec: C1RunSpec {
+                    grid_size: 64,
+                    seed: 42,
+                    ..C1RunSpec::default()
+                },
+                phase_a: PhaseAParams::default(),
+            })
+            .unwrap();
+        let events = drain_run(&evt_rx);
+        drop(cmd_tx);
+        handle.join().unwrap();
+
+        // init (cycle-0) plate_type vs final plate_type.
+        let init_pt = events
+            .iter()
+            .find_map(|e| match e {
+                C1Event::StepCompleted { snapshot } if snapshot.step == 0 => {
+                    Some(snapshot.plate_type.clone())
+                }
+                _ => None,
+            })
+            .expect("cycle-0 snapshot");
+        let final_snap = match events.last() {
+            Some(C1Event::Completed { final_snapshot, .. }) => final_snapshot,
+            other => panic!("expected Completed; got {other:?}"),
+        };
+
+        let coast_moved = init_pt
+            .iter()
+            .zip(&final_snap.plate_type)
+            .filter(|(a, b)| a != b)
+            .count();
+
+        let emergent_land = {
+            let f = Field2D::from_vec(final_snap.nx, final_snap.ny, final_snap.s.clone());
+            compute_isostasy(&f, &IsostasyConfig::default()).land_ratio as f64
+        };
+
+        eprintln!("Stage A acceptance (workflow, seed 42, 64², 5×20):");
+        eprintln!("  coast cells reclassified vs init = {coast_moved}");
+        eprintln!("  final emergent land fraction      = {emergent_land:.4}");
+
+        // PRODUCT: the coast migrated substantially (workflow mode's
+        // raison d'être — gallery would not reclassify on sea level).
+        // Seed 42 measured ~1500 net flips; assert a robust lower
+        // bound.
+        assert!(
+            coast_moved > 500,
+            "workflow coast did not migrate: only {coast_moved} cells reclassified vs init (expected > 500)"
+        );
+        // PRODUCT: the continent did not vanish — emergent land stays
+        // nonzero (the converged equilibrium, ~0.058 at seed 42).
+        assert!(
+            emergent_land > 0.02,
+            "continent vanished: emergent land = {emergent_land:.4} (expected > 0.02)"
+        );
+    }
+
     /// Issue #139 Stage V diagnostic (user-requested, `#[ignore]`'d):
     /// resolve whether the ~0.058 workflow continental fraction is an
     /// apples/oranges metric artefact, an adaptive-threshold drift, or

--- a/crates/ymir-viz/src/bridge/c1/thread.rs
+++ b/crates/ymir-viz/src/bridge/c1/thread.rs
@@ -403,6 +403,524 @@ mod tests {
         drop(cmd_tx);
         handle.join().unwrap();
     }
+
+    // ----- Issue #139 Stage V — workflow-mode worker tests -----
+
+    /// Workflow emits cycle-0 + per cycle `{ k_cycle per-step + 1
+    /// post-cycle }` snapshots, with monotone (non-decreasing) step
+    /// indices and `total = n_cycles × k_cycle`. Reduced cadence
+    /// (2×5) — this tests emission structure, not erosion.
+    #[test]
+    fn workflow_mode_produces_calibrated_cycle_count() {
+        let (cmd_tx, cmd_rx) = bounded(4);
+        let (evt_tx, evt_rx) = bounded(2);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let handle = spawn_c1_thread(cmd_rx, evt_tx, cancel);
+
+        let n_cycles = 2;
+        let k_cycle = 5;
+        let phase_a = PhaseAParams {
+            n_cycles,
+            k_cycle,
+            ..PhaseAParams::default()
+        };
+        cmd_tx
+            .send(C1Command::RunWorkflow {
+                spec: small_spec(0, 42), // n_steps unused in workflow
+                phase_a,
+            })
+            .unwrap();
+
+        let events = drain_run(&evt_rx);
+
+        // Started carries Workflow kind with the calibrated total.
+        match events.first() {
+            Some(C1Event::Started { spec, kind }) => {
+                assert!(matches!(kind, C1RunKind::Workflow { .. }));
+                assert_eq!(kind.total_tectonic_steps(spec), n_cycles * k_cycle);
+            }
+            other => panic!("expected Started first; got {other:?}"),
+        }
+
+        let step_indices: Vec<usize> = events
+            .iter()
+            .filter_map(|e| match e {
+                C1Event::StepCompleted { snapshot } => Some(snapshot.step),
+                _ => None,
+            })
+            .collect();
+
+        // Count = cycle-0 (1) + n_cycles × (k_cycle per-step + 1 post).
+        assert_eq!(
+            step_indices.len(),
+            1 + n_cycles * (k_cycle + 1),
+            "snapshot count mismatch: {step_indices:?}"
+        );
+        // Monotone non-decreasing (post-cycle reuses the boundary
+        // step, so equality is allowed at cycle boundaries).
+        assert!(
+            step_indices.windows(2).all(|w| w[0] <= w[1]),
+            "step indices must be monotone non-decreasing: {step_indices:?}"
+        );
+        // Last per-step / post-cycle step reaches the total.
+        assert_eq!(*step_indices.last().unwrap(), n_cycles * k_cycle);
+
+        drop(cmd_tx);
+        handle.join().unwrap();
+    }
+
+    /// THE A1-c REGRESSION GUARD (Issue #139 Stage V). The A1-c
+    /// disaster ran macro_redistribution 6× the calibrated cadence
+    /// (50/300) and **diverged** — continental crust runaway-eroded
+    /// without convergence. The calibrated workflow (5×20) instead
+    /// **converges**, conserves mass, and lands ABOVE the gallery's
+    /// pure-tectonic isostatic land floor. The guard tests that
+    /// QUALITATIVE signature, not a magic band — the Stage V
+    /// diagnostic (`workflow_continent_diagnostic`) established that
+    /// the absolute fraction (~0.058 at seed 42) is the honest
+    /// above-sea-level land, NOT a regression:
+    ///
+    ///   1. mass-conserving: `|Δmass|/mass < 1e-3` per cycle
+    ///      (macro_redistribution is rebound-balanced; A1-c runaway
+    ///      would bleed mass);
+    ///   2. converges: last-cycle `|Δfrac| < 0.01` (stable
+    ///      equilibrium, not A1-c's monotone collapse);
+    ///   3. above the isostatic floor: workflow final `iso_land ≥
+    ///      0.9 × gallery iso_land`, comparing the S̃-only emergent
+    ///      land (`compute_isostasy(s).land_ratio`) apples-to-apples
+    ///      at the SAME 100-step duration. (NB: rendered altitude>0
+    ///      is Stein-Stein plate_type-GATED, so gallery's rendered
+    ///      land is the static geometric label ≈0.27 — using it here
+    ///      would re-violate the apples/oranges lesson; `iso_land` is
+    ///      the ungated emergent measure that gives the ≈0.045 floor.)
+    ///
+    /// 64² seed 42, calibrated default cadence (5×20 = 100 steps),
+    /// plus a gallery control at the same 100 steps.
+    #[test]
+    fn workflow_mode_continent_preserved() {
+        use ymir_core::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
+        use ymir_core::tectonics_v2::field::Field2D;
+
+        let continental_fraction = |snap: &C1Snapshot| -> f64 {
+            let c = snap.plate_type.iter().filter(|&&t| t == 1).count();
+            c as f64 / snap.plate_type.len() as f64
+        };
+        // S̃-only emergent land (ungated by plate_type) — the
+        // apples-to-apples measure for the isostatic floor.
+        let iso_land = |snap: &C1Snapshot| -> f64 {
+            let f = Field2D::from_vec(snap.nx, snap.ny, snap.s.clone());
+            compute_isostasy(&f, &IsostasyConfig::default()).land_ratio as f64
+        };
+        let mass = |s: &[f64]| -> f64 { s.iter().sum() };
+
+        // ---- Calibrated workflow run ----
+        let (cmd_tx, cmd_rx) = bounded(4);
+        let (evt_tx, evt_rx) = bounded(2);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let handle = spawn_c1_thread(cmd_rx, evt_tx, cancel);
+        cmd_tx
+            .send(C1Command::RunWorkflow {
+                spec: C1RunSpec {
+                    grid_size: 64,
+                    seed: 42,
+                    ..C1RunSpec::default()
+                },
+                phase_a: PhaseAParams::default(), // CALIBRATED 5×20
+            })
+            .unwrap();
+        let events = drain_run(&evt_rx);
+        drop(cmd_tx);
+        handle.join().unwrap();
+
+        let k_cycle = PhaseAParams::default().k_cycle;
+        let n_cycles = PhaseAParams::default().n_cycles;
+        let snaps_at = |step: usize| -> Vec<&C1Snapshot> {
+            events
+                .iter()
+                .filter_map(|e| match e {
+                    C1Event::StepCompleted { snapshot } if snapshot.step == step => {
+                        Some(snapshot)
+                    }
+                    _ => None,
+                })
+                .collect()
+        };
+
+        // (1) mass-conservation per cycle: |Δmass|/mass from the
+        //     pre-macro (last per-step) → post-macro (post-cycle) pair.
+        // Trajectory of the continental fraction for the convergence
+        // check.
+        let mut frac_traj: Vec<f64> = Vec::new();
+        if let Some(s0) = snaps_at(0).first() {
+            frac_traj.push(continental_fraction(s0));
+        }
+        for c in 1..=n_cycles {
+            let pair = snaps_at(c * k_cycle);
+            assert!(
+                pair.len() >= 2,
+                "cycle {c}: expected pre+post snapshots at boundary"
+            );
+            let (pre, post) = (pair[0], pair[1]);
+            let m_pre = mass(&pre.s);
+            let rel_dmass = (mass(&post.s) - m_pre).abs() / m_pre.max(1e-12);
+            assert!(
+                rel_dmass < 1e-3,
+                "cycle {c}: macro_redistribution not mass-conserving — |Δmass|/mass = {rel_dmass:.2e} (≥ 1e-3 would indicate A1-c-style runaway erosion)"
+            );
+            frac_traj.push(continental_fraction(post));
+        }
+
+        // (2) convergence: last-cycle delta is small.
+        let n = frac_traj.len();
+        let last_delta = (frac_traj[n - 1] - frac_traj[n - 2]).abs();
+        assert!(
+            last_delta < 0.01,
+            "workflow did not converge — last-cycle |Δfrac| = {last_delta:.4} (≥ 0.01 suggests A1-c-style ongoing collapse). Trajectory: {frac_traj:?}"
+        );
+
+        let workflow_iso = match events.last() {
+            Some(C1Event::Completed { final_snapshot, .. }) => iso_land(final_snapshot),
+            other => panic!("expected Completed; got {other:?}"),
+        };
+
+        // ---- Gallery control (same 100 steps, NO post-tectonic) ----
+        let (cmd_tx2, cmd_rx2) = bounded(4);
+        let (evt_tx2, evt_rx2) = bounded(2);
+        let cancel2 = Arc::new(AtomicBool::new(false));
+        let handle2 = spawn_c1_thread(cmd_rx2, evt_tx2, cancel2);
+        cmd_tx2
+            .send(C1Command::RunBaseline {
+                spec: C1RunSpec {
+                    grid_size: 64,
+                    seed: 42,
+                    n_steps: n_cycles * k_cycle, // SAME duration (100)
+                    ..C1RunSpec::default()
+                },
+            })
+            .unwrap();
+        let gevents = drain_run(&evt_rx2);
+        drop(cmd_tx2);
+        handle2.join().unwrap();
+        let gallery_iso = match gevents.last() {
+            Some(C1Event::Completed { final_snapshot, .. }) => iso_land(final_snapshot),
+            other => panic!("expected gallery Completed; got {other:?}"),
+        };
+
+        eprintln!("Stage V workflow_mode_continent_preserved (seed 42, 64², 5×20):");
+        eprintln!("  continental fraction trajectory: {frac_traj:?}");
+        eprintln!("  last-cycle |Δfrac| = {last_delta:.4}");
+        eprintln!("  workflow iso_land = {workflow_iso:.4}, gallery iso_land = {gallery_iso:.4}");
+
+        // (3) above the isostatic floor (apples-to-apples iso_land).
+        assert!(
+            workflow_iso >= 0.9 * gallery_iso,
+            "workflow emergent land {workflow_iso:.4} fell below 0.9× gallery isostatic floor {gallery_iso:.4} — macro+reclassify destroyed crust beyond the pure-tectonic S̃ land (A1-c signature)"
+        );
+    }
+
+    /// The per-cycle `apply_post_tectonic` reclassification actually
+    /// fires: at some cycle boundary the post-tectonic snapshot's
+    /// `plate_type` differs from the pre-tectonic (last per-step)
+    /// snapshot at the same boundary step. Isolates reclassify — the
+    /// only difference between the two snapshots is the
+    /// `apply_post_tectonic` call.
+    #[test]
+    fn workflow_mode_coast_reclassifies() {
+        let (cmd_tx, cmd_rx) = bounded(4);
+        let (evt_tx, evt_rx) = bounded(2);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let handle = spawn_c1_thread(cmd_rx, evt_tx, cancel);
+
+        let n_cycles = 3;
+        let k_cycle = 20;
+        let phase_a = PhaseAParams {
+            n_cycles,
+            k_cycle,
+            ..PhaseAParams::default()
+        };
+        cmd_tx
+            .send(C1Command::RunWorkflow {
+                spec: small_spec(0, 42),
+                phase_a,
+            })
+            .unwrap();
+
+        let events = drain_run(&evt_rx);
+
+        // Group plate_type vectors by step. Cycle boundaries (step =
+        // c·k_cycle, c ≥ 1) have exactly two snapshots: [0] pre-
+        // reclassify (last per-step), [1] post-reclassify (post-cycle).
+        use std::collections::HashMap;
+        let mut by_step: HashMap<usize, Vec<Vec<u8>>> = HashMap::new();
+        for e in &events {
+            if let C1Event::StepCompleted { snapshot } = e {
+                by_step
+                    .entry(snapshot.step)
+                    .or_default()
+                    .push(snapshot.plate_type.clone());
+            }
+        }
+
+        let mut any_reclassify = false;
+        for c in 1..=n_cycles {
+            let boundary = c * k_cycle;
+            if let Some(pair) = by_step.get(&boundary) {
+                if pair.len() == 2 && pair[0] != pair[1] {
+                    let changed = pair[0]
+                        .iter()
+                        .zip(&pair[1])
+                        .filter(|(a, b)| a != b)
+                        .count();
+                    eprintln!(
+                        "Stage V reclassify: cycle {c} boundary step {boundary} flipped {changed} cells"
+                    );
+                    any_reclassify = true;
+                }
+            }
+        }
+
+        assert!(
+            any_reclassify,
+            "no cycle-boundary reclassification observed — apply_post_tectonic reclassify did not change plate_type at any boundary"
+        );
+
+        drop(cmd_tx);
+        handle.join().unwrap();
+    }
+
+    /// Issue #139 Stage V diagnostic (user-requested, `#[ignore]`'d):
+    /// resolve whether the ~0.058 workflow continental fraction is an
+    /// apples/oranges metric artefact, an adaptive-threshold drift, or
+    /// genuine macro_redistribution over-erosion. Logs, per cycle:
+    ///   (1a) plate_type==Continental fraction (the label, post-reclassify)
+    ///   (1b) rendered altitude>0 fraction (derive_altitude_field, Stein-
+    ///        Stein plate_type-gated)
+    ///   (1c) isostatic land fraction (compute_isostasy(s).land_ratio,
+    ///        S̃-only, NOT plate_type-gated)
+    ///   (2)  s_min / s_max / sea_level_ref (s-space adaptive threshold)
+    ///   (3)  reclassify C→O / O→C counts + macro Δmass (loss decomposition)
+    /// plus a GALLERY control (100 steps, no post-tectonic) for the
+    /// "no macro erosion" reference. Run with:
+    ///   cargo test --release -p ymir-viz --features v2_legacy --bin ymir-viz \
+    ///     workflow_continent_diagnostic -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn workflow_continent_diagnostic() {
+        use ymir_core::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
+        use ymir_core::tectonics_v2::field::Field2D;
+
+        let nx = 64usize;
+        let ny = 64usize;
+        let n_cells = (nx * ny) as f64;
+
+        let plate_type_cont = |snap: &C1Snapshot| -> f64 {
+            snap.plate_type.iter().filter(|&&t| t == 1).count() as f64 / n_cells
+        };
+        let iso_land = |s: &[f64]| -> f64 {
+            let f = Field2D::from_vec(nx, ny, s.to_vec());
+            compute_isostasy(&f, &IsostasyConfig::default()).land_ratio as f64
+        };
+        let rendered_land = |snap: &C1Snapshot| -> f64 {
+            let alt = crate::visualization::c1_viz::derive_altitude_field(snap);
+            let mut c = 0usize;
+            for j in 0..ny {
+                for i in 0..nx {
+                    if alt.get(i as i32, j as i32) > 0.0 {
+                        c += 1;
+                    }
+                }
+            }
+            c as f64 / n_cells
+        };
+        let s_stats = |s: &[f64]| -> (f64, f64, f64) {
+            let mut lo = f64::INFINITY;
+            let mut hi = f64::NEG_INFINITY;
+            for &v in s {
+                lo = lo.min(v);
+                hi = hi.max(v);
+            }
+            // s-space adaptive sea level (sea_level_fraction = 0.4).
+            let sea = lo + 0.4 * (hi - lo);
+            (lo, hi, sea)
+        };
+        let mass = |s: &[f64]| -> f64 { s.iter().sum() };
+
+        // ---- WORKFLOW run ----
+        let (cmd_tx, cmd_rx) = bounded(4);
+        let (evt_tx, evt_rx) = bounded(2);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let handle = spawn_c1_thread(cmd_rx, evt_tx, cancel);
+        let spec = C1RunSpec {
+            grid_size: 64,
+            seed: 42,
+            ..C1RunSpec::default()
+        };
+        cmd_tx
+            .send(C1Command::RunWorkflow {
+                spec: spec.clone(),
+                phase_a: PhaseAParams::default(),
+            })
+            .unwrap();
+        let events = drain_run(&evt_rx);
+        drop(cmd_tx);
+        handle.join().unwrap();
+
+        let k_cycle = PhaseAParams::default().k_cycle;
+        let n_cycles = PhaseAParams::default().n_cycles;
+
+        let snaps_at = |step: usize| -> Vec<&C1Snapshot> {
+            events
+                .iter()
+                .filter_map(|e| match e {
+                    C1Event::StepCompleted { snapshot } if snapshot.step == step => {
+                        Some(snapshot)
+                    }
+                    _ => None,
+                })
+                .collect()
+        };
+
+        eprintln!("=== WORKFLOW (seed 42, 64², default 5×20) ===");
+        eprintln!(
+            "cyc | pt_cont | rend>0 | iso_land | s_min  s_max  sea_ref | mass    | C->O O->C | macroDmass"
+        );
+        // cycle 0 (init).
+        if let Some(s0) = snaps_at(0).first() {
+            let (lo, hi, sea) = s_stats(&s0.s);
+            eprintln!(
+                "  0 | {:.4} | {:.4} | {:.4}  | {:.3} {:.3} {:.3} | {:.1} |   -    -  |    -",
+                plate_type_cont(s0),
+                rendered_land(s0),
+                iso_land(&s0.s),
+                lo,
+                hi,
+                sea,
+                mass(&s0.s),
+            );
+        }
+        for c in 1..=n_cycles {
+            let boundary = c * k_cycle;
+            let pair = snaps_at(boundary);
+            if pair.len() < 2 {
+                continue;
+            }
+            let pre = pair[0]; // last per-step (pre macro/reclassify)
+            let post = pair[1]; // post macro+reclassify
+            let (lo, hi, sea) = s_stats(&pre.s); // threshold from pre-macro s
+            let c_to_o = pre
+                .plate_type
+                .iter()
+                .zip(&post.plate_type)
+                .filter(|(a, b)| **a == 1 && **b == 0)
+                .count();
+            let o_to_c = pre
+                .plate_type
+                .iter()
+                .zip(&post.plate_type)
+                .filter(|(a, b)| **a == 0 && **b == 1)
+                .count();
+            let macro_dmass = mass(&post.s) - mass(&pre.s);
+            eprintln!(
+                "  {} | {:.4} | {:.4} | {:.4}  | {:.3} {:.3} {:.3} | {:.1} | {:>4} {:>4} | {:+.3}",
+                c,
+                plate_type_cont(post),
+                rendered_land(post),
+                iso_land(&post.s),
+                lo,
+                hi,
+                sea,
+                mass(&post.s),
+                c_to_o,
+                o_to_c,
+                macro_dmass,
+            );
+        }
+
+        // ---- GALLERY control (no post-tectonic) ----
+        let (cmd_tx2, cmd_rx2) = bounded(4);
+        let (evt_tx2, evt_rx2) = bounded(2);
+        let cancel2 = Arc::new(AtomicBool::new(false));
+        let handle2 = spawn_c1_thread(cmd_rx2, evt_tx2, cancel2);
+        let gallery_spec = C1RunSpec {
+            grid_size: 64,
+            seed: 42,
+            n_steps: 100,
+            ..C1RunSpec::default()
+        };
+        cmd_tx2
+            .send(C1Command::RunBaseline { spec: gallery_spec })
+            .unwrap();
+        let gevents = drain_run(&evt_rx2);
+        drop(cmd_tx2);
+        handle2.join().unwrap();
+        if let Some(C1Event::Completed { final_snapshot, .. }) = gevents.last() {
+            eprintln!("=== GALLERY control (seed 42, 64², 100 steps, NO post-tectonic) ===");
+            eprintln!(
+                "final: pt_cont={:.4}  rend>0={:.4}  iso_land={:.4}  mass={:.1}",
+                plate_type_cont(final_snapshot),
+                rendered_land(final_snapshot),
+                iso_land(&final_snapshot.s),
+                mass(&final_snapshot.s),
+            );
+        }
+    }
+
+    /// Continuation capability (Stage E4): `run_workflow_cycles` run
+    /// twice on the SAME state — feeding the first run's end as the
+    /// second run's `base_step` — carries the state forward (the step
+    /// offset advances and the field keeps evolving). Exercises the
+    /// continuation core directly; no `ContinueRun` command exists yet.
+    #[test]
+    fn worker_retains_state_for_continuation() {
+        use crossbeam_channel::unbounded;
+        use ymir_core::tectonics_c1::init_r7::init_c1_state_phase_2_r7;
+
+        // Unbounded so synchronous in-test sends never deadlock.
+        let (tx, _rx) = unbounded::<C1Event>();
+
+        let spec = small_spec(0, 42); // 32² for speed
+        let phase_a = PhaseAParams {
+            n_cycles: 2,
+            k_cycle: 5,
+            ..PhaseAParams::default()
+        };
+
+        let mut state = init_c1_state_phase_2_r7(
+            spec.grid_size,
+            spec.seed,
+            &spec.init_params,
+        );
+        let mut kinematics = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let vel: Vec<(f64, f64)> = kinematics.velocities.clone();
+
+        // Run 1 from a fresh state (base_step 0).
+        let last1 = run_workflow_cycles(
+            &mut state, &mut kinematics, &spec, &phase_a, &vel, &tx, 0,
+        );
+        assert_eq!(last1, phase_a.n_cycles * phase_a.k_cycle);
+        let s_after_run1: Vec<f64> = state.s.data().to_vec();
+
+        // Run 2 RESUMING the same state (base_step = last1).
+        let last2 = run_workflow_cycles(
+            &mut state, &mut kinematics, &spec, &phase_a, &vel, &tx, last1,
+        );
+
+        // Step offset carried forward.
+        assert_eq!(
+            last2,
+            last1 + phase_a.n_cycles * phase_a.k_cycle,
+            "continuation must advance the global step from the retained total"
+        );
+        assert_eq!(last2, 2 * phase_a.n_cycles * phase_a.k_cycle);
+
+        // State carried forward — the second run continued evolving
+        // the SAME state rather than restarting from init.
+        assert_ne!(
+            s_after_run1,
+            state.s.data().to_vec(),
+            "resuming must continue evolving the retained state"
+        );
+    }
 }
 
 pub fn spawn_c1_thread(

--- a/crates/ymir-viz/src/bridge/c1/thread.rs
+++ b/crates/ymir-viz/src/bridge/c1/thread.rs
@@ -73,6 +73,7 @@ use crossbeam_channel::{Receiver, Sender};
 use ymir_core::tectonics::isostasy::IsostasyConfig;
 use ymir_core::tectonics_c1::init_r7::init_c1_state_phase_2_r7;
 use ymir_core::tectonics_c1::kinematics::PlateKinematics;
+use ymir_core::tectonics_c1::state::C1State;
 use ymir_core::tectonics_c1::time_loop::{run_with_closures, C1TimeLoopConfig};
 use ymir_core::tectonics_v2::workflow::phase_a_common::{apply_post_tectonic, PostTectonicInput};
 use ymir_core::tectonics_v2::workflow::PhaseAParams;
@@ -412,7 +413,22 @@ pub fn spawn_c1_thread(
     std::thread::Builder::new()
         .name("ymir-c1-bridge".into())
         .spawn(move || {
+            // Continuation-ready retention (Issue #139 Stage E4): the
+            // last completed run's (state, kinematics). A future
+            // `C1Command::ContinueRun { additional_cycles,
+            // new_kinematics }` would resume from here via
+            // `run_workflow_cycles` instead of re-initialising. No
+            // command consumes it yet (capability only) — retention is
+            // passive and does not change current-run behaviour (W2).
+            let mut retained: Option<(C1State, PlateKinematics)> = None;
+
             while let Ok(cmd) = commands_rx.recv() {
+                // Read the retained handle so its presence is
+                // observable to the (future) continuation path; today
+                // this is purely the W1 "worker holds state across
+                // commands" capability marker.
+                let _resumable = retained.is_some();
+
                 match cmd {
                     C1Command::RunBaseline { spec } => {
                         cancel.store(false, Ordering::Relaxed);
@@ -497,9 +513,13 @@ pub fn spawn_c1_thread(
                             final_snapshot,
                             elapsed,
                         });
+
+                        // Retain for a future continuation (Stage E4).
+                        retained = Some((state, kinematics));
                     }
                     C1Command::RunWorkflow { spec, phase_a } => {
-                        run_workflow(&spec, &phase_a, &events_tx);
+                        retained =
+                            Some(run_workflow(&spec, &phase_a, &events_tx));
                     }
                     C1Command::Cancel => {
                         // MVP Option C — set the flag; takes
@@ -535,7 +555,11 @@ pub fn spawn_c1_thread(
 /// post-cycle snapshot reuses the cycle-boundary index (so the step
 /// sequence is monotone non-decreasing and the "step N/total" counter
 /// tracks tectonic steps, not emission ordinal).
-fn run_workflow(spec: &C1RunSpec, phase_a: &PhaseAParams, events_tx: &Sender<C1Event>) {
+fn run_workflow(
+    spec: &C1RunSpec,
+    phase_a: &PhaseAParams,
+    events_tx: &Sender<C1Event>,
+) -> (C1State, PlateKinematics) {
     let _ = events_tx.send(C1Event::Started {
         spec: spec.clone(),
         kind: C1RunKind::Workflow {
@@ -552,18 +576,63 @@ fn run_workflow(spec: &C1RunSpec, phase_a: &PhaseAParams, events_tx: &Sender<C1E
     // caveat as the gallery path; Viz-0-bis item 1).
     let initial_velocities: Vec<(f64, f64)> = kinematics.velocities.clone();
 
-    let n_cycles = phase_a.n_cycles;
-    let k_cycle = phase_a.k_cycle;
-    let iso_config = IsostasyConfig::default();
-
     // Cycle-0 pre-run snapshot (step 0).
     let _ = events_tx.send(C1Event::StepCompleted {
         snapshot: C1Snapshot::from_state(0, &state, &initial_velocities),
     });
 
     let t0 = Instant::now();
+    let final_step = run_workflow_cycles(
+        &mut state,
+        &mut kinematics,
+        spec,
+        phase_a,
+        &initial_velocities,
+        events_tx,
+        0,
+    );
+    let elapsed = t0.elapsed();
 
-    for cycle in 0..n_cycles {
+    let final_snapshot =
+        C1Snapshot::from_state(final_step, &state, &initial_velocities);
+    let _ = events_tx.send(C1Event::Completed {
+        spec: spec.clone(),
+        final_snapshot,
+        elapsed,
+    });
+
+    // Hand the post-run state back so the worker can retain it for a
+    // future continuation (Issue #139 Stage E4).
+    (state, kinematics)
+}
+
+/// Continuation-ready core (Issue #139 Stage E4): run `phase_a.
+/// n_cycles` Phase A cycles on an **existing** `state` + `kinematics`,
+/// emitting per-step + per-cycle snapshots. `base_step` is the global
+/// tectonic step already elapsed (0 for a fresh run; `> 0` when
+/// resuming a retained state). Returns the global tectonic step after
+/// the last cycle.
+///
+/// Factored out of [`run_workflow`] so a future
+/// `C1Command::ContinueRun { additional_cycles, new_kinematics }`
+/// could call it again on the worker's retained `(state, kinematics)`
+/// with `base_step = prior total` — resuming the simulation instead
+/// of re-initialising. No command consumes it yet (Stage E4 ships the
+/// capability only; the command + UI are deferred).
+fn run_workflow_cycles(
+    state: &mut C1State,
+    kinematics: &mut PlateKinematics,
+    spec: &C1RunSpec,
+    phase_a: &PhaseAParams,
+    initial_velocities: &[(f64, f64)],
+    events_tx: &Sender<C1Event>,
+    base_step: usize,
+) -> usize {
+    let k_cycle = phase_a.k_cycle;
+    let iso_config = IsostasyConfig::default();
+    let mut last_step = base_step;
+
+    for cycle in 0..phase_a.n_cycles {
         let cfg = C1TimeLoopConfig {
             n_steps: k_cycle,
             dx: 1.0 / spec.grid_size as f64,
@@ -571,21 +640,21 @@ fn run_workflow(spec: &C1RunSpec, phase_a: &PhaseAParams, events_tx: &Sender<C1E
             iso_config: iso_config.clone(),
             drainage_max_distance: spec.drainage_max_distance,
         };
-        let base = cycle * k_cycle;
+        let cyc_base = base_step + cycle * k_cycle;
 
         // Per-step tectonic loop (animation hook). The closure
-        // captures only `events_tx`, `initial_velocities`, `base` by
-        // reference / copy — none alias `state` / `kinematics`, so no
-        // borrow conflict with `run_with_closures`'s `&mut` args.
+        // captures only `events_tx`, `initial_velocities`, `cyc_base`
+        // by reference / copy — none alias `state` / `kinematics`, so
+        // no borrow conflict with `run_with_closures`'s `&mut` args.
         run_with_closures(
-            &mut state,
-            &mut kinematics,
+            state,
+            kinematics,
             &cfg,
             &spec.closures,
             |s_in_c, st| {
-                let step = base + s_in_c + 1;
+                let step = cyc_base + s_in_c + 1;
                 let _ = events_tx.send(C1Event::StepCompleted {
-                    snapshot: C1Snapshot::from_state(step, st, &initial_velocities),
+                    snapshot: C1Snapshot::from_state(step, st, initial_velocities),
                 });
             },
         );
@@ -605,19 +674,12 @@ fn run_workflow(spec: &C1RunSpec, phase_a: &PhaseAParams, events_tx: &Sender<C1E
 
         // Post-cycle snapshot — coast reclassified. Reuses the
         // boundary tectonic step index.
-        let boundary_step = base + k_cycle;
+        let boundary_step = cyc_base + k_cycle;
         let _ = events_tx.send(C1Event::StepCompleted {
-            snapshot: C1Snapshot::from_state(boundary_step, &state, &initial_velocities),
+            snapshot: C1Snapshot::from_state(boundary_step, state, initial_velocities),
         });
+        last_step = boundary_step;
     }
 
-    let elapsed = t0.elapsed();
-    let final_step = n_cycles * k_cycle;
-    let final_snapshot =
-        C1Snapshot::from_state(final_step, &state, &initial_velocities);
-    let _ = events_tx.send(C1Event::Completed {
-        spec: spec.clone(),
-        final_snapshot,
-        elapsed,
-    });
+    last_step
 }

--- a/crates/ymir-viz/src/visualization/c1_plugin.rs
+++ b/crates/ymir-viz/src/visualization/c1_plugin.rs
@@ -35,10 +35,14 @@ use bevy::asset::RenderAssetUsages;
 use bevy::image::ImageSampler;
 use bevy::prelude::*;
 use bevy::render::render_resource::{Extent3d, TextureDimension, TextureFormat};
+use bevy_egui::input::EguiWantsInput;
 use bevy_egui::{egui, EguiContexts, EguiPrimaryContextPass};
 
+use ymir_core::grid::GridF32;
+
 use crate::bridge::c1::{C1CumulativeStats, C1RunSpec, C1RunState, C1SolverBridge};
-use crate::visualization::c1_viz::{field_to_rgba, C1Field};
+use crate::camera::CursorWorldPos;
+use crate::visualization::c1_viz::{derive_altitude_field, field_to_rgba, C1Field};
 use crate::visualization::overlay::{draw_velocity_vectors, draw_voronoi_boundaries};
 
 const C1_SPRITE_BASE_SIZE: f32 = 600.0;
@@ -54,6 +58,19 @@ pub enum ActiveEngine {
 
 #[derive(Component)]
 pub struct C1VizSprite;
+
+/// Per-cell hover readout (Issue #139 Stage E1). `altitude_nondim`
+/// is the verification value (W3 global: non-dim = truth, meters =
+/// cosmetic). Meters are added by the Stage E3 hypsometric lens and
+/// rendered SECOND, below the non-dim row.
+#[derive(Clone, Copy, Debug)]
+pub struct HoverReadout {
+    pub i: usize,
+    pub j: usize,
+    pub s: f64,
+    pub age: f64,
+    pub altitude_nondim: f32,
+}
 
 /// Run-locked UI state — editable spec the user is composing,
 /// plus current field selection and overlay toggles.
@@ -77,6 +94,18 @@ pub struct C1VizState {
     pub arrow_scale: f64,
     /// `(nx, ny, step, field_idx, overlay_bits)` for change detection.
     pub last_signature: Option<(usize, usize, usize, u8, u8)>,
+    /// Lazily-derived Architecture C altitude field for the hover
+    /// inspector, keyed by `snapshot.step`. Recomputed only when a
+    /// newer snapshot arrives (W2: invalidate on snapshot change);
+    /// cursor movement within the same step is a cache hit. Makes
+    /// per-cell altitude available in ALL views (W4), not just the
+    /// Altitude view.
+    pub altitude_cache: Option<(usize, GridF32)>,
+    /// Current per-cell hover readout, or `None` when the cursor is
+    /// off the map / over an egui panel / a different engine is
+    /// active. Written by `update_c1_hover`, read by
+    /// `c1_hover_panel`.
+    pub hover: Option<HoverReadout>,
 }
 
 impl Default for C1VizState {
@@ -91,8 +120,38 @@ impl Default for C1VizState {
             // above MIN_ARROW_CELLS = 1. See arrow_scale docstring.
             arrow_scale: 500.0,
             last_signature: None,
+            altitude_cache: None,
+            hover: None,
         }
     }
+}
+
+/// Invert the C1 sprite transform to map a world-space cursor
+/// position to a cell `(i, j)`. Returns `None` when the cursor is
+/// outside the sprite bounds.
+///
+/// The sprite is centred at the world origin (`Transform::from_xyz(
+/// 0, 0, C1_SPRITE_Z)`) with `custom_size = sprite_size(nx, ny)` and
+/// a nearest sampler over the `nx × ny` texel image, so
+/// `sprite_local == world`. Bevy sprite texel row 0 renders at the
+/// top and world `+Y` points up, hence `v = (half.y − world.y)` for
+/// the vertical axis (NOT `world.y + half.y`). Mirrors the
+/// `sprite_size` formula used by `update_c1_texture` so the mapping
+/// stays correct across grid resizes (W1).
+fn world_to_cell(world: Vec2, nx: usize, ny: usize) -> Option<(usize, usize)> {
+    if nx == 0 || ny == 0 {
+        return None;
+    }
+    let size = sprite_size(nx, ny);
+    let half = size / 2.0;
+    let u = (world.x + half.x) / size.x;
+    let v = (half.y - world.y) / size.y;
+    if !(0.0..1.0).contains(&u) || !(0.0..1.0).contains(&v) {
+        return None;
+    }
+    let i = ((u * nx as f32) as usize).min(nx - 1);
+    let j = ((v * ny as f32) as usize).min(ny - 1);
+    Some((i, j))
 }
 
 fn sprite_size(nx: usize, ny: usize) -> Vec2 {
@@ -226,6 +285,111 @@ fn update_engine_visibility(
             *v = target;
         }
     }
+}
+
+/// Hover-to-inspect (Issue #139 Stage E1). Maps the world-space
+/// cursor to a cell, refreshes the lazily-derived altitude cache
+/// when the snapshot step changes, and writes the per-cell readout
+/// into `C1VizState.hover`. Suppressed (`hover = None`) when:
+/// - a non-C1 engine is active,
+/// - the pointer is over an egui panel (not the map),
+/// - the cursor is off the sprite, or
+/// - there is no snapshot yet.
+fn update_c1_hover(
+    active: Res<ActiveEngine>,
+    egui_input: Res<EguiWantsInput>,
+    cursor: Res<CursorWorldPos>,
+    bridge: Res<C1SolverBridge>,
+    mut viz: ResMut<C1VizState>,
+) {
+    if *active != ActiveEngine::C1 || egui_input.is_pointer_over_area() {
+        viz.hover = None;
+        return;
+    }
+    let Some(world) = cursor.pos else {
+        viz.hover = None;
+        return;
+    };
+    let Some(snapshot) = bridge.state.latest_snapshot() else {
+        viz.hover = None;
+        return;
+    };
+    let nx = snapshot.nx;
+    let ny = snapshot.ny;
+    let Some((i, j)) = world_to_cell(world, nx, ny) else {
+        viz.hover = None;
+        return;
+    };
+
+    // Refresh the altitude cache if the snapshot step changed (W2).
+    let step = snapshot.step;
+    let stale = match &viz.altitude_cache {
+        Some((cached_step, _)) => *cached_step != step,
+        None => true,
+    };
+    if stale {
+        let altitude = derive_altitude_field(snapshot);
+        viz.altitude_cache = Some((step, altitude));
+    }
+
+    let altitude_nondim = viz
+        .altitude_cache
+        .as_ref()
+        .map(|(_, grid)| grid.get(i as i32, j as i32))
+        .unwrap_or(0.0);
+    let s = snapshot.s[j * nx + i];
+    let age = snapshot.age[j * nx + i];
+
+    viz.hover = Some(HoverReadout {
+        i,
+        j,
+        s,
+        age,
+        altitude_nondim,
+    });
+}
+
+/// Fixed corner panel rendering the hover readout (Issue #139 Stage
+/// E1, anchored bottom-right). Non-dim altitude is shown FIRST as
+/// the verification value (W3 global). Meters (Stage E3 hypsometric
+/// lens) will be added below, labelled "(after hypsometric curve)".
+fn c1_hover_panel(
+    mut contexts: EguiContexts,
+    viz: Res<C1VizState>,
+    active: Res<ActiveEngine>,
+) {
+    if *active != ActiveEngine::C1 {
+        return;
+    }
+    let Ok(ctx) = contexts.ctx_mut() else {
+        return;
+    };
+    egui::Window::new("C1 Cell Inspector")
+        .anchor(egui::Align2::RIGHT_BOTTOM, [-16.0, -16.0])
+        .resizable(false)
+        .collapsible(false)
+        .show(ctx, |ui| match viz.hover {
+            Some(h) => {
+                egui::Grid::new("c1_hover_grid").show(ui, |ui| {
+                    ui.label("cell (i, j)");
+                    ui.label(format!("({}, {})", h.i, h.j));
+                    ui.end_row();
+                    ui.label("S̃");
+                    ui.label(format!("{:.4}", h.s));
+                    ui.end_row();
+                    ui.label("age");
+                    ui.label(format!("{:.4}", h.age));
+                    ui.end_row();
+                    ui.label("altitude (non-dim)");
+                    ui.label(format!("{:+.4}", h.altitude_nondim));
+                    ui.end_row();
+                });
+                ui.weak("non-dim = verification value (meters: Stage E3)");
+            }
+            None => {
+                ui.weak("Hover over the map…");
+            }
+        });
 }
 
 /// egui control panel — init params, closure toggles, Run/Cancel,
@@ -531,7 +695,64 @@ impl Plugin for C1VisualizationPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ActiveEngine>()
             .add_systems(Startup, setup_c1_sprite)
-            .add_systems(Update, (update_c1_texture, update_engine_visibility))
-            .add_systems(EguiPrimaryContextPass, c1_control_panel);
+            .add_systems(
+                Update,
+                (update_c1_texture, update_engine_visibility, update_c1_hover),
+            )
+            .add_systems(EguiPrimaryContextPass, (c1_control_panel, c1_hover_panel));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Default 64² grid → square sprite 600×600, half = 300.
+    const N: usize = 64;
+
+    #[test]
+    fn world_to_cell_centre_is_mid_grid() {
+        // World origin = sprite centre → centre cell.
+        assert_eq!(world_to_cell(Vec2::new(0.0, 0.0), N, N), Some((32, 32)));
+    }
+
+    #[test]
+    fn world_to_cell_y_axis_is_top_down() {
+        // W1 Y-flip guard: an OFF-CENTRE, non-symmetric point. World
+        // +Y is up; texel row 0 is the TOP. A point in the upper
+        // half (world.y > 0) must map to a SMALL j (near the top),
+        // not a large one. size = 600, half = 300.
+        //   world.y = +150 → v = (300 - 150)/600 = 0.25 → j = 16.
+        //   world.x = -150 → u = (-150 + 300)/600 = 0.25 → i = 16.
+        // If the vertical term were (world.y + half)/size (the wrong
+        // sign), v would be 0.75 → j = 48, failing this assert.
+        assert_eq!(
+            world_to_cell(Vec2::new(-150.0, 150.0), N, N),
+            Some((16, 16))
+        );
+        // Symmetric lower-right point → large i and j.
+        assert_eq!(
+            world_to_cell(Vec2::new(150.0, -150.0), N, N),
+            Some((48, 48))
+        );
+    }
+
+    #[test]
+    fn world_to_cell_outside_is_none() {
+        // Beyond the +x edge (half = 300).
+        assert_eq!(world_to_cell(Vec2::new(400.0, 0.0), N, N), None);
+        // Beyond the -y edge.
+        assert_eq!(world_to_cell(Vec2::new(0.0, -400.0), N, N), None);
+    }
+
+    #[test]
+    fn world_to_cell_respects_non_square_resize() {
+        // W1 resize correctness: nx=4, ny=8 → longer=8,
+        // size = (600·4/8, 600·8/8) = (300, 600), half = (150, 300).
+        // World origin → centre cell (nx/2, ny/2) = (2, 4).
+        assert_eq!(world_to_cell(Vec2::new(0.0, 0.0), 4, 8), Some((2, 4)));
+        // A point at x = +75 (u = 0.75 → i = 3), y = +150
+        // (v = (300-150)/600 = 0.25 → j = 2).
+        assert_eq!(world_to_cell(Vec2::new(75.0, 150.0), 4, 8), Some((3, 2)));
     }
 }

--- a/crates/ymir-viz/src/visualization/c1_plugin.rs
+++ b/crates/ymir-viz/src/visualization/c1_plugin.rs
@@ -39,8 +39,9 @@ use bevy_egui::input::EguiWantsInput;
 use bevy_egui::{egui, EguiContexts, EguiPrimaryContextPass};
 
 use ymir_core::grid::GridF32;
+use ymir_core::tectonics_v2::workflow::PhaseAParams;
 
-use crate::bridge::c1::{C1CumulativeStats, C1RunSpec, C1RunState, C1SolverBridge};
+use crate::bridge::c1::{C1CumulativeStats, C1RunKind, C1RunSpec, C1RunState, C1SolverBridge};
 use crate::camera::CursorWorldPos;
 use crate::visualization::c1_viz::{derive_altitude_field, field_to_rgba, C1Field};
 use crate::visualization::overlay::{draw_velocity_vectors, draw_voronoi_boundaries};
@@ -54,6 +55,59 @@ pub enum ActiveEngine {
     V2,
     #[default]
     C1,
+}
+
+/// Which C1 pipeline the panel will submit on Run (Issue #139 Stage
+/// E3). Default `Gallery` (the Issue #137 contract). Run-locked: set
+/// at Run submit, displayed but not editable during a run.
+#[derive(Resource, Clone, Copy, Default, PartialEq, Eq, Debug)]
+pub enum ActivePipeline {
+    #[default]
+    Gallery,
+    Workflow,
+}
+
+/// Hypsometric lens (Issue #139 Stage E3). Maps the **non-dim**
+/// altitude (the verification value) to display **meters** — a
+/// cosmetic curve that NEVER touches the model or the non-dim value
+/// (W3 global). Land side is a free tunable lens; ocean side is
+/// anchored to the Stein-Stein `depth_scale_m = 5000` so meters
+/// invert the bathymetry back to physical depth.
+#[derive(Resource, Clone, Copy, Debug)]
+pub struct HypsometricScale {
+    /// Land elevation scale (m) — tunable cosmetic lens.
+    pub land_scale_m: f32,
+    /// Land gamma (curve shape) — tunable.
+    pub land_gamma: f32,
+    /// Ocean depth scale (m) — anchored to Stein-Stein
+    /// `depth_scale_m`; shown, not tuned.
+    pub ocean_scale_m: f32,
+    /// Ocean gamma — anchored at 1.0 (linear inverse of the
+    /// non-dim bathymetry).
+    pub ocean_gamma: f32,
+}
+
+impl Default for HypsometricScale {
+    fn default() -> Self {
+        Self {
+            land_scale_m: 8000.0,
+            land_gamma: 1.0,
+            ocean_scale_m: 5000.0,
+            ocean_gamma: 1.0,
+        }
+    }
+}
+
+/// Map a non-dim altitude to display meters via the hypsometric lens.
+/// Land (`alt ≥ 0`) and ocean (`alt < 0`) use independent
+/// scale/gamma. **Cosmetic only** — the non-dim altitude remains the
+/// verification value (Issue #139 W3 global).
+fn hypsometric_meters(alt_nondim: f32, scale: &HypsometricScale) -> f32 {
+    if alt_nondim >= 0.0 {
+        scale.land_scale_m * alt_nondim.powf(scale.land_gamma)
+    } else {
+        -(scale.ocean_scale_m * (-alt_nondim).powf(scale.ocean_gamma))
+    }
 }
 
 #[derive(Component)]
@@ -80,6 +134,11 @@ pub struct C1VizState {
     pub field: C1Field,
     /// User-editable spec; submitted on Run button.
     pub pending_spec: C1RunSpec,
+    /// User-editable Phase A cadence for workflow mode (Issue #139
+    /// Stage E3). Defaults to `PhaseAParams::default()` (the
+    /// calibrated 5×20). Only the gallery vs workflow dispatch reads
+    /// it; ignored in gallery mode.
+    pub pending_phase_a: PhaseAParams,
     /// Toggle Voronoi boundary overlay (cardinality-agnostic;
     /// Track D dynamic plate_id handled natively by `draw_voronoi_boundaries`).
     pub show_voronoi_boundaries: bool,
@@ -114,6 +173,7 @@ impl Default for C1VizState {
             texture_handle: None,
             field: C1Field::default(),
             pending_spec: C1RunSpec::default(),
+            pending_phase_a: PhaseAParams::default(),
             show_voronoi_boundaries: false,
             show_velocity_vectors: false,
             // C1-tuned default: 0.01 × 500 = 5 cells, comfortably
@@ -357,6 +417,7 @@ fn c1_hover_panel(
     mut contexts: EguiContexts,
     viz: Res<C1VizState>,
     active: Res<ActiveEngine>,
+    hypso: Res<HypsometricScale>,
 ) {
     if *active != ActiveEngine::C1 {
         return;
@@ -380,11 +441,17 @@ fn c1_hover_panel(
                     ui.label("age");
                     ui.label(format!("{:.4}", h.age));
                     ui.end_row();
+                    // Non-dim altitude FIRST — the verification value.
                     ui.label("altitude (non-dim)");
                     ui.label(format!("{:+.4}", h.altitude_nondim));
                     ui.end_row();
+                    // Meters SECOND — cosmetic hypsometric lens.
+                    ui.label("altitude (m)");
+                    let meters = hypsometric_meters(h.altitude_nondim, &hypso);
+                    ui.label(format!("{meters:+.0}"));
+                    ui.end_row();
                 });
-                ui.weak("non-dim = verification value (meters: Stage E3)");
+                ui.weak("non-dim = verification; m = after hypsometric curve");
             }
             None => {
                 ui.weak("Hover over the map…");
@@ -399,6 +466,8 @@ fn c1_control_panel(
     bridge: Res<C1SolverBridge>,
     mut viz: ResMut<C1VizState>,
     mut active_engine: ResMut<ActiveEngine>,
+    mut active_pipeline: ResMut<ActivePipeline>,
+    mut hypso: ResMut<HypsometricScale>,
 ) {
     let Ok(ctx) = contexts.ctx_mut() else {
         return;
@@ -434,6 +503,39 @@ fn c1_control_panel(
                 return;
             }
 
+            // Pipeline toggle (run-locked, Issue #139 Stage E3).
+            ui.horizontal(|ui| {
+                ui.label("Pipeline:");
+                ui.add_enabled_ui(!is_running, |ui| {
+                    let mut pipe = *active_pipeline;
+                    if ui
+                        .selectable_value(&mut pipe, ActivePipeline::Gallery, "Gallery")
+                        .on_hover_text(
+                            "Standalone run_with_closures (Issue #137 contract). \
+                             Static plate_type / coast; total = n_steps.",
+                        )
+                        .clicked()
+                    {
+                        *active_pipeline = pipe;
+                    }
+                    if ui
+                        .selectable_value(&mut pipe, ActivePipeline::Workflow, "Workflow")
+                        .on_hover_text(
+                            "Calibrated Phase A loop (per-cycle post-tectonic: \
+                             sea-level + macro-redistribution + reclassify). \
+                             Coast migrates per cycle; total = n_cycles × k_cycle.",
+                        )
+                        .clicked()
+                    {
+                        *active_pipeline = pipe;
+                    }
+                });
+            });
+            if is_running {
+                ui.weak("(pipeline run-locked during a run)");
+            }
+            ui.separator();
+
             // Init parameters (run-locked).
             ui.collapsing("Init parameters", |ui| {
                 ui.add_enabled_ui(!is_running, |ui| {
@@ -451,15 +553,68 @@ fn c1_control_panel(
                         ui.end_row();
 
                         ui.label("n_steps");
-                        ui.add(
+                        ui.add_enabled(
+                            *active_pipeline == ActivePipeline::Gallery,
                             egui::DragValue::new(&mut viz.pending_spec.n_steps)
                                 .range(10..=3000)
                                 .speed(10),
-                        );
+                        )
+                        .on_hover_text("Gallery only. Workflow uses n_cycles × k_cycle.");
                         ui.end_row();
                     });
                 });
             });
+
+            // Workflow cadence (workflow mode only, run-locked).
+            if *active_pipeline == ActivePipeline::Workflow {
+                ui.collapsing("Workflow cadence", |ui| {
+                    ui.add_enabled_ui(!is_running, |ui| {
+                        egui::Grid::new("c1_workflow_cadence").show(ui, |ui| {
+                            ui.label("n_cycles");
+                            ui.add(
+                                egui::Slider::new(
+                                    &mut viz.pending_phase_a.n_cycles,
+                                    1..=20,
+                                )
+                                .text("(default 5)"),
+                            );
+                            ui.end_row();
+
+                            ui.label("k_cycle");
+                            ui.add(
+                                egui::Slider::new(
+                                    &mut viz.pending_phase_a.k_cycle,
+                                    1..=100,
+                                )
+                                .text("(default 20)"),
+                            );
+                            ui.end_row();
+                        });
+                        let total = viz.pending_phase_a.n_cycles
+                            * viz.pending_phase_a.k_cycle;
+                        ui.weak(format!(
+                            "total tectonic steps = {} × {} = {}",
+                            viz.pending_phase_a.n_cycles,
+                            viz.pending_phase_a.k_cycle,
+                            total
+                        ));
+                        // Calibration warning — the A1-c lesson.
+                        let off_calibration = viz.pending_phase_a.k_cycle != 20
+                            || viz.pending_phase_a.n_cycles != 5;
+                        if off_calibration {
+                            ui.colored_label(
+                                egui::Color32::from_rgb(220, 160, 40),
+                                format!(
+                                    "⚠ alpha = {:.3} is calibrated for k_cycle = 20, \
+                                     n_cycles = 5. Raising the cadence without lowering \
+                                     alpha over-erodes the continent (A1-c lesson).",
+                                    viz.pending_phase_a.alpha
+                                ),
+                            );
+                        }
+                    });
+                });
+            }
 
             // Closure toggles (run-locked, Q-E4.2).
             ui.collapsing("Closures", |ui| {
@@ -507,7 +662,18 @@ fn c1_control_panel(
                     .add_enabled(!is_running, egui::Button::new("▶ Run"))
                     .clicked()
                 {
-                    let _ = bridge.submit_run(viz.pending_spec.clone());
+                    // Dispatch by pipeline (set at submit; run-locked).
+                    match *active_pipeline {
+                        ActivePipeline::Gallery => {
+                            let _ = bridge.submit_run(viz.pending_spec.clone());
+                        }
+                        ActivePipeline::Workflow => {
+                            let _ = bridge.submit_workflow(
+                                viz.pending_spec.clone(),
+                                viz.pending_phase_a.clone(),
+                            );
+                        }
+                    }
                 }
                 if ui
                     .add_enabled(is_running, egui::Button::new("■ Cancel"))
@@ -558,6 +724,37 @@ fn c1_control_panel(
                 }
             });
 
+            // Hypsometric lens (Issue #139 Stage E3). Drives ONLY the
+            // hover meters readout — never the non-dim value or the
+            // model (W3 global). Editable any time (cosmetic).
+            ui.separator();
+            ui.collapsing("Hypsometric (hover meters)", |ui| {
+                egui::Grid::new("c1_hypso").show(ui, |ui| {
+                    ui.label("land scale (m)");
+                    ui.add(
+                        egui::Slider::new(&mut hypso.land_scale_m, 1000.0..=12000.0)
+                            .text("tunable"),
+                    );
+                    ui.end_row();
+
+                    ui.label("land gamma");
+                    ui.add(
+                        egui::Slider::new(&mut hypso.land_gamma, 0.3..=3.0)
+                            .text("tunable"),
+                    );
+                    ui.end_row();
+
+                    ui.label("ocean scale (m)");
+                    ui.label(format!("{:.0}", hypso.ocean_scale_m));
+                    ui.end_row();
+
+                    ui.label("ocean gamma");
+                    ui.label(format!("{:.1}", hypso.ocean_gamma));
+                    ui.end_row();
+                });
+                ui.weak("ocean anchored to Stein-Stein depth_scale_m; non-dim untouched");
+            });
+
             // Live stats — Stage A bug fix: cumulative totals
             // accumulated across the StepCompleted stream, NOT
             // per-step (per-step reads 0 for rare events like
@@ -573,13 +770,30 @@ fn c1_control_panel(
                         ui.label("Idle. Press ▶ Run to start.");
                     }
                     C1RunState::Running {
+                        kind,
                         step,
                         total,
                         latest_snapshot,
                         cumulative,
                         ..
                     } => {
-                        ui.label(format!("Step {}/{}", step + 1, total,));
+                        // Workflow shows a per-cycle counter; gallery
+                        // shows the flat step counter.
+                        match kind {
+                            C1RunKind::Workflow { phase_a } => {
+                                let k = phase_a.k_cycle.max(1);
+                                // step is the tectonic step (1-based
+                                // after +1); cycle index = ceil(step/k).
+                                let cycle = (*step).div_ceil(k).min(phase_a.n_cycles);
+                                ui.label(format!(
+                                    "Step {}/{}  ·  cycle {}/{}",
+                                    step, total, cycle, phase_a.n_cycles
+                                ));
+                            }
+                            C1RunKind::Gallery => {
+                                ui.label(format!("Step {}/{}", step + 1, total));
+                            }
+                        }
                         if let Some(snap) = latest_snapshot {
                             render_live_stats_grid(
                                 ui,
@@ -694,6 +908,8 @@ pub struct C1VisualizationPlugin;
 impl Plugin for C1VisualizationPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<ActiveEngine>()
+            .init_resource::<ActivePipeline>()
+            .init_resource::<HypsometricScale>()
             .add_systems(Startup, setup_c1_sprite)
             .add_systems(
                 Update,
@@ -743,6 +959,30 @@ mod tests {
         assert_eq!(world_to_cell(Vec2::new(400.0, 0.0), N, N), None);
         // Beyond the -y edge.
         assert_eq!(world_to_cell(Vec2::new(0.0, -400.0), N, N), None);
+    }
+
+    #[test]
+    fn hypsometric_meters_land_ocean_split() {
+        let s = HypsometricScale::default(); // land 8000/γ1, ocean 5000/γ1
+        // Land: linear at γ=1 → land_scale × alt.
+        assert!((hypsometric_meters(1.0, &s) - 8000.0).abs() < 1e-3);
+        assert!((hypsometric_meters(0.5, &s) - 4000.0).abs() < 1e-3);
+        // Sea level maps to 0.
+        assert!(hypsometric_meters(0.0, &s).abs() < 1e-3);
+        // Ocean: negative, anchored to depth_scale_m = 5000.
+        assert!((hypsometric_meters(-0.5, &s) + 2500.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn hypsometric_meters_land_gamma_curves() {
+        // γ = 2 compresses low elevations: alt 0.5 → 8000·0.25 = 2000.
+        let s = HypsometricScale {
+            land_gamma: 2.0,
+            ..HypsometricScale::default()
+        };
+        assert!((hypsometric_meters(0.5, &s) - 2000.0).abs() < 1e-3);
+        // Ocean side is independent of land gamma.
+        assert!((hypsometric_meters(-0.5, &s) + 2500.0).abs() < 1e-3);
     }
 
     #[test]

--- a/crates/ymir-viz/src/visualization/c1_viz.rs
+++ b/crates/ymir-viz/src/visualization/c1_viz.rs
@@ -19,6 +19,7 @@
 //!   showing S̃** (gallery-anchored derivation lands at Stage E4).
 //! - `Cratonic` — binary grayscale (0/1) MVP standalone view.
 
+use ymir_core::grid::GridF32;
 use ymir_core::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
 use ymir_core::tectonics_c1::closures::oceanic_bathymetry::{
     apply_stein_stein_bathymetry, SteinSteinParams,
@@ -224,10 +225,27 @@ fn render_plate_type(snapshot: &C1Snapshot, rgba: &mut [u8]) {
 /// `IsostasyConfig::default()` and `SteinSteinParams::default()`
 /// are the same defaults the galleries use (no per-spec overrides
 /// in Viz-0; Q-V.3 Option A palette continuity preserved).
-fn render_altitude(snapshot: &C1Snapshot, rgba: &mut [u8]) {
+/// Architecture C live altitude derivation, returning the raw
+/// non-dimensional altitude `GridF32` (steps 1–3 of the gallery
+/// code path). Factored out of [`render_altitude`] so the hover
+/// inspector (Issue #139 Stage E1) can read per-cell altitude in
+/// **any** view, not just the Altitude view — the cache reuses
+/// this single source of truth.
+///
+///   1. Reconstruct `Field2D` for `s` + `age` from snapshot vecs.
+///   2. Reconstruct `PlateTypeField` from `snapshot.plate_type:
+///      Vec<u8>` via the `0 = Oceanic / 1 = Continental` decoder.
+///   3. `compute_isostasy(&s_field, &IsostasyConfig::default())` →
+///      `heightmap: GridF32`, then `apply_stein_stein_bathymetry`
+///      (Architecture C post-isostasy overwrite on oceanic cells).
+///
+/// The returned grid carries non-dim altitude per cell
+/// (`grid.get(i, j)`), the verification value surfaced first by
+/// the hover readout (Issue #139 W3 global: non-dim = verification,
+/// meters = cosmetic).
+pub fn derive_altitude_field(snapshot: &C1Snapshot) -> GridF32 {
     let nx = snapshot.nx;
     let ny = snapshot.ny;
-    debug_assert_eq!(rgba.len(), nx * ny * 4);
 
     // 1. Reconstruct Field2D from snapshot raw vecs.
     let s_field = Field2D::from_vec(nx, ny, snapshot.s.clone());
@@ -257,6 +275,16 @@ fn render_altitude(snapshot: &C1Snapshot, rgba: &mut [u8]) {
         &plate_type_field,
         &SteinSteinParams::default(),
     );
+    altitude
+}
+
+fn render_altitude(snapshot: &C1Snapshot, rgba: &mut [u8]) {
+    let nx = snapshot.nx;
+    let ny = snapshot.ny;
+    debug_assert_eq!(rgba.len(), nx * ny * 4);
+
+    // Steps 1–3 (shared with the hover inspector cache).
+    let altitude = derive_altitude_field(snapshot);
 
     // 4. Map [-half_range, +half_range] → [0, 1] → RGBA via
     //    hypsometric_bipolar (same colormap as gallery).

--- a/docs/reports/viz_0_5/README.md
+++ b/docs/reports/viz_0_5/README.md
@@ -1,0 +1,69 @@
+# Issue #139 — Viz-0.5: hover-to-inspect + workflow mode + hypsometric lens + continuation-ready
+
+Builds on Viz-0 (Issue #137). Adds per-cell inspection, the calibrated Phase A **workflow** pipeline alongside the gallery path, a hypsometric meters lens, and continuation-ready worker structure. **Viz-only** — `tectonics_c1` untouched (9th bit-identical preserved).
+
+## What ships
+
+| Surface | Detail |
+|---|---|
+| **Hover-to-inspect** | Bottom-right "C1 Cell Inspector": `(i,j)`, S̃, age, altitude. Reads `CursorWorldPos` (world-space, camera-corrected), inverts the C1 sprite transform (`world_to_cell`, Y-flip-correct, resize-correct). Altitude derived lazily (`derive_altitude_field`, cached by snapshot step) → works in **all** views. |
+| **Non-dim first, meters second** | Non-dim altitude is the verification value (shown first); meters are the cosmetic hypsometric lens (shown second, "after hypsometric curve"). |
+| **Workflow pipeline** | `ActivePipeline::Workflow` → `C1Command::RunWorkflow`. The calibrated Phase A loop: `n_cycles` cycles of `run_with_closures(k_cycle)` + per-cycle `apply_post_tectonic` (sea-level → macro-redistribution → reclassify). Coast migrates per cycle. Gallery `RunBaseline` path left untouched. |
+| **Calibrated cadence** | `PhaseAParams::default()` = `n_cycles 5 × k_cycle 20` = 100 tectonic steps, 5 macro passes. Total = `n_cycles × k_cycle`, **never** `n_steps` (the A1-c over-erosion guard). |
+| **Hypsometric lens** | `HypsometricScale` resource: land scale/gamma tunable, ocean anchored to Stein-Stein `depth_scale_m = 5000`. Drives ONLY the hover meters — never the non-dim value or the model. |
+| **Continuation-ready** | Worker retains the last completed run's `(C1State, PlateKinematics)`. `run_workflow_cycles` is the reusable continuation core (accepts `base_step`). A future `ContinueRun` would resume from the retained state. Capability only — no command/UI yet. |
+| **9th bit-identical** | Preserved (viz-only; zero `tectonics_c1` changes). |
+
+## Hover: non-dim = verification, meters = cosmetic
+
+The non-dimensional altitude is the value to verify against — it comes straight from the Architecture C derivation (`compute_isostasy` + `apply_stein_stein_bathymetry`). The meters readout is a presentation lens (`hypsometric_meters`): land `= land_scale·alt^γ`, ocean `= −(ocean_scale·|alt|^γ)`. Tuning the lens never touches the non-dim value or the simulation. This separation is load-bearing — meters are for human intuition, non-dim is for validation.
+
+## Workflow mode = the A1-c fix, calibrated
+
+Viz-0 (Issue #137) reverted the A1-c worker (which ran `apply_post_tectonic` 6× the calibrated cadence — 50/300 — and over-eroded the continent) and shipped the static-coast gallery path, documenting that a *calibrated* workflow was a Viz-0-bis follow-up. Viz-0.5 ships it: the workflow worker reproduces `run_phase_a_cycle_c1(Enabled)` at the calibrated `PhaseAParams::default()` cadence, inlining `run_with_closures` only for the per-step animation hook. The cadence is `n_cycles × k_cycle`, with a UI calibration warning when the user moves off the default (raising the cadence without lowering `alpha` over-erodes — the A1-c mechanism).
+
+## The continental-fraction finding (Stage V diagnostic)
+
+The calibrated workflow converges to a continental/emergent fraction of **~0.058** at seed 42 (64²), not the ~0.20–0.45 originally estimated. The Stage V diagnostic established this is **correct**, on evidence:
+
+1. **The ~0.27 init "continent" is a geometric LABEL, not emergent land.** Init `plate_type` = Voronoï continental seeds (0.27). The above-sea-level land (`compute_isostasy(s).land_ratio`, S̃-only) is ~0.045 even in the pure-tectonic gallery. The [0.20,0.45] target compared the geometric label to a final emergent fraction — apples/oranges.
+2. **Not macro erosion.** `macro_redistribution` is mass-conserving (`Δmass ≈ 0`/cycle, `isostatic_rebound_ratio = 0.80`). The continental loss is **declassification**, not mass transport.
+3. **Adaptive `sea_level_ref` drift is the mechanism.** `sea_level_ref = s_min + 0.4·(s_max − s_min)` jumps 0.52 → 0.98 in cycle 1 as `s_max` doubles (1.0 → 2.18) via Davis-Suppe orographic peaks — declassifying 753 cells by threshold rise. The workflow converges (last-cycle Δ 0.0007) and sits ABOVE the gallery isostatic floor (0.0588 > 0.0449).
+4. **Pre-existing C1 debt, revealed not created.** The `min/max`-based `sea_level_ref` is fragile to peak outliers. A robust **percentile** sea level is a Phase 1.5 follow-up (core change, out of viz-only scope). This also explains "little emergent land at 256²" from the Viz-0 thread: C1 intrinsically produces little emergent land at seed 42 under the current sea-level formula — model behavior, not a viz bug. **For Phase 3 validation**: "little emergent land" is the normal seed-42 state.
+
+## The A1-c regression guard (qualitative signature)
+
+`workflow_mode_continent_preserved` does not assert a magic band; it asserts the signature that distinguishes the calibrated-converged workflow from the A1-c runaway:
+
+1. mass-conserving — `|Δmass|/mass < 1e-3` per cycle;
+2. converges — last-cycle `|Δfrac| < 0.01`;
+3. above the isostatic floor — workflow `iso_land ≥ 0.9 × gallery iso_land` at the same 100 steps (apples-to-apples on the S̃-only emergent land, NOT the plate_type-gated rendered land).
+
+## Stage outcomes
+
+| Stage | Deliverable | Commit |
+|---|---|---|
+| S | Exploration (cursor→cell, split-borrow, calibration anchor, altitude cache) | `6ba2a73` |
+| E1 | Hover-to-inspect per-cell readout | `a2c1a46` |
+| E2 | Workflow-mode worker (calibrated PhaseAParams, per-cycle post-tectonic) | `7127e72` |
+| E3 | Pipeline toggle + cadence sliders + hypsometric scale | `a0b6065` |
+| E4 | Continuation-ready worker state retention (capability only) | `58e3902` |
+| V | Workflow worker tests + A1-c regression guard | `097a35b` |
+| A | Acceptance (migrating-coast product test + manual checklist) | `2b21cb6` |
+| Final | This README + memory + PR | — |
+
+## Tests
+
+8 `bridge::c1::thread` tests PASS (4 gallery + 4 workflow) + 1 `#[ignore]` diagnostic; 6 `c1_plugin` tests (4 `world_to_cell` incl. Y-flip + resize, 2 `hypsometric_meters`); 7 `c1_viz` render tests (behavior-preserving after `derive_altitude_field` extraction). 9th bit-identical PASS (viz-only).
+
+## Viz-0-bis / Phase 1.5 follow-ups
+
+- **Percentile `sea_level_ref`** (Phase 1.5, core): robust to Davis-Suppe `s_max` outliers; would raise the emergent-land fraction. The reason emergent land is so low at seed 42.
+- **`ContinueRun` command + UI**: resume from the retained state via `run_workflow_cycles` (structure already in place).
+- Carried from Viz-0: `last_plate_velocities` (live mid-run kinematics), JSON presets, Track C kinematics, custom `IsostasyConfig`, true mid-run cancel.
+
+## Files
+
+- `crates/ymir-viz/src/bridge/c1/{commands,events,mod,plugin,thread}.rs`
+- `crates/ymir-viz/src/visualization/{c1_plugin,c1_viz}.rs`
+- `docs/reports/viz_0_5/{README,stage_s_exploration,acceptance_checklist}.md`

--- a/docs/reports/viz_0_5/acceptance_checklist.md
+++ b/docs/reports/viz_0_5/acceptance_checklist.md
@@ -1,0 +1,69 @@
+# Viz-0.5 — Issue #139 Acceptance Checklist
+
+Hover-to-inspect + workflow-mode pipeline + hypsometric lens + continuation-ready structure. Manual UI/visual checklist (the headless part is automated; see bottom). Viz-only — `tectonics_c1` untouched (9th bit-identical guard at Final).
+
+## How to run
+
+```bash
+cargo run --release -p ymir-viz --features v2_legacy
+```
+
+C1 engine selected by default; "C1 Engine Controls" panel top-left; "C1 Cell Inspector" panel bottom-right.
+
+## Checklist
+
+### 1. Hover-to-inspect (all views)
+
+- [ ] Hover the map in **each** field view (S̃, Age, PlateId, PlateType, Altitude, Cratonic). The bottom-right "C1 Cell Inspector" updates with `cell (i,j)`, `S̃`, `age`, `altitude (non-dim)`, `altitude (m)`.
+- [ ] **Non-dim altitude is shown FIRST** (the verification value); meters SECOND, labelled "after hypsometric curve".
+- [ ] Cross-check a known cell: hover the **centre** of the map → `(i,j)` ≈ `(nx/2, ny/2)`. Hover an **off-centre** cell (e.g. upper-left) → small `i`, small `j` (Y-axis is top-down).
+- [ ] Hover works in views OTHER than Altitude (the altitude cache derives independent of the active field).
+- [ ] Moving off the map / over a panel clears the readout ("Hover over the map…").
+
+### 2. Workflow mode — continent + migrating coast
+
+- [ ] Switch **Pipeline → Workflow**. Press ▶ Run (default 64² seed 42, 5×20).
+- [ ] The continent does NOT vanish — a stable landmass remains (Altitude / PlateType views). See the finding below: emergent land at seed 42 is ~5–6%, the honest above-sea fraction (NOT collapsed).
+- [ ] The coast **migrates in discrete jumps** at each cycle boundary (every k_cycle steps) as `apply_post_tectonic` reclassifies — visible in PlateType / Altitude.
+
+### 3. Gallery ↔ Workflow toggle (same seed)
+
+- [ ] Run **Gallery** then **Workflow** at the same seed (64² seed 42). In Gallery the PlateType coast is static (Issue #137 contract); in Workflow it migrates per cycle. The difference should be visible.
+
+### 4. Cadence sliders + calibration warning
+
+- [ ] In Workflow mode, open "Workflow cadence". `n_cycles` (default 5) and `k_cycle` (default 20) sliders show, with the live "total = N×K" readout.
+- [ ] Move a slider off the default → an **amber calibration warning** appears ("alpha=0.01 calibrated for k_cycle=20, n_cycles=5; raising without lowering alpha over-erodes"). Running off-default visibly over-erodes (expected — the A1-c lesson).
+
+### 5. Hypsometric lens (meters only)
+
+- [ ] Open "Hypsometric (hover meters)". Adjust **land scale** / **land gamma** → the hover **meters** value changes; the **non-dim** value does NOT (W3: cosmetic lens, never the verification value or the model).
+- [ ] Ocean scale/gamma are shown read-only ("anchored Stein-Stein").
+
+### 6. Gallery + v2 unchanged
+
+- [ ] Gallery mode behaves exactly as Issue #137 (static coast, per-step animation, 6 fields, overlays).
+- [ ] Switch Engine → v2 (legacy): v2 works unchanged; C1 controls gray out.
+
+## Headless acceptance (automated)
+
+```bash
+cargo test --release -p ymir-viz --features v2_legacy --bin ymir-viz \
+  bridge::c1::thread -- --nocapture
+```
+
+- `workflow_mode_produces_calibrated_cycle_count` — cycle-0 + n_cycles×(k_cycle per-step + 1 post-cycle) snapshots, monotone indices, total = n_cycles×k_cycle.
+- `workflow_mode_coast_reclassifies` — `apply_post_tectonic` reclassify changes `plate_type` at a cycle boundary.
+- `worker_retains_state_for_continuation` — `run_workflow_cycles` resumes a carried state (Stage E4 continuation core).
+- `workflow_mode_continent_preserved` — **the A1-c regression guard** (qualitative signature): mass-conserving (`|Δmass|/mass < 1e-3`/cycle), converged (`|Δfrac| < 0.01` last cycle), and workflow `iso_land ≥ 0.9 × gallery iso_land` at the same 100 steps.
+- `workflow_acceptance_continent_preserved_seed_42` — **product acceptance**: coast migrated substantially vs init (> 500 cells reclassified; measured 1205) AND emergent land nonzero (> 0.02; measured 0.0588).
+- `workflow_continent_diagnostic` (`#[ignore]`) — per-cycle evidence trajectory.
+
+## Stage V diagnostic findings (the ~0.058 continental fraction)
+
+The calibrated workflow converges to a continental/emergent fraction of **~0.058** at seed 42 (NOT the ~0.20–0.45 originally estimated). The Stage V diagnostic established this is **correct**, not a regression:
+
+1. **The ~0.27 init "continent" is a geometric LABEL, not emergent land.** Init `plate_type` is assigned by Voronoï continental seeds (0.27 of cells). The *above-sea-level* land (`compute_isostasy(s).land_ratio`, S̃-only) is ~0.05 even in the pure-tectonic gallery (0.0449 at 100 steps). The [0.20,0.45] target compared the geometric label to a final emergent fraction — apples/oranges, confirmed on evidence.
+2. **Not macro erosion.** `macro_redistribution` is mass-conserving (`Δmass ≈ 0` every cycle, `isostatic_rebound_ratio = 0.80`). The continental loss is **declassification**, not mass transport.
+3. **Adaptive `sea_level_ref` drift is the mechanism.** `sea_level_ref = s_min + 0.4·(s_max − s_min)` jumps 0.52 → 0.98 in cycle 1 as `s_max` doubles (1.0 → 2.18) from Davis-Suppe orographic peaks — declassifying 753 continental cells by threshold rise. The workflow then converges (last-cycle Δ 0.0007) and sits ABOVE the gallery isostatic floor (0.0588 > 0.0449).
+4. **Pre-existing C1 debt, revealed not created.** The `min/max`-based `sea_level_ref` is fragile to Davis-Suppe peak outliers. A robust **percentile** sea level is a Phase 1.5 follow-up (core change, out of viz-only scope). This also explains "little emergent land at 256²" from the Viz-0 thread: C1 intrinsically produces little emergent land at seed 42 under the current sea-level formula — model behavior, not a viz bug. **Relevant for Phase 3 validation**: "little emergent land" is the normal seed-42 state; an arc on a thin band is consistent.

--- a/docs/reports/viz_0_5/stage_s_exploration.md
+++ b/docs/reports/viz_0_5/stage_s_exploration.md
@@ -1,0 +1,100 @@
+# Issue #139 — Viz-0.5 Stage S exploration
+
+Hover-to-inspect + workflow-mode pipeline + hypsometric lens + continuation-ready structure. Viz-only (no `tectonics_c1` changes; 9th bit-identical guard at Final). Branch `139-viz-05-hover-to-inspect-workflow-mode-pipeline-phase-3-validation-instruments` off `milestone/c1-lightweight-dynamic-tectonics` (Issue #137 merged via PR #138).
+
+This document records the four Stage S confirmations the workflow requires before any code lands.
+
+## 1. Cursor → cell transform
+
+**Finding**: the world-space cursor already exists. [`camera.rs`](../../../crates/ymir-viz/src/camera.rs) defines `CursorWorldPos { pos: Option<Vec2> }` (a `Resource`), recomputed every frame in `update_cursor_world_pos` via `camera.viewport_to_world_2d(camera_transform, cursor)`. This is **world space, already camera-corrected** (pan + zoom folded in). The hover system reads this resource — no new cursor plumbing needed.
+
+**Inversion math**: the C1 sprite ([`c1_plugin.rs`](../../../crates/ymir-viz/src/visualization/c1_plugin.rs)) is spawned at `Transform::from_xyz(0.0, 0.0, C1_SPRITE_Z=12.0)` — **centred at the world origin**. Its `custom_size = sprite_size(nx, ny)`:
+
+```rust
+let longer = nx.max(ny) as f32;
+Vec2::new(BASE*nx/longer, BASE*ny/longer)   // BASE = C1_SPRITE_BASE_SIZE = 600.0
+```
+
+with a **nearest** sampler over the `nx × ny` texel image. Because the sprite is at the origin, `sprite_local = world` directly. Mapping world → cell:
+
+```text
+half = size / 2
+u = (world.x + half.x) / size.x        // [0,1] left→right
+v = (half.y - world.y) / size.y        // [0,1] top→bottom  (Bevy world +Y up; texel row 0 = top)
+i = floor(u * nx)
+j = floor(v * ny)
+hover valid iff 0 ≤ u,v < 1  → else None (cursor outside sprite)
+```
+
+**W1 (cursor→cell at grid resize)**: `size` is recomputed from the *current* snapshot `nx/ny`, so the transform is resize-correct as long as the hover system reads `snapshot.nx/ny` (not a cached grid size). The `update_c1_texture` resize path already keys the sprite `custom_size` off `sprite_size(nx, ny)`, so the hover system must mirror that exact formula. Verification: cross-check a known cell (e.g. cursor at world origin → centre cell `(nx/2, ny/2)`).
+
+**Y-axis caveat**: Bevy sprite texel row 0 renders at the **top**; world +Y points up. Hence `v = (half.y − world.y)/size.y` (NOT `(world.y + half.y)`). The render path writes `rgba[(j*nx+i)*4]` row-major with j=0 first → top row, consistent with this inversion. To verify, the W1 known-cell check must use an **off-centre, non-symmetric** cell to catch a Y-flip (a centre-cell check passes under either convention).
+
+## 2. Split-borrow for the workflow worker
+
+**Finding**: confirmed already compiling in [`phase_a_c1.rs:152`](../../../crates/ymir-core/src/tectonics_v2/workflow/phase_a_c1.rs). `apply_post_tectonic` takes:
+
+```rust
+pub struct PostTectonicInput<'a> {
+    pub s_field: &'a mut Field2D,                 // &mut state.s
+    pub plate_id: Option<&'a PlateIdField>,       // Some(&state.plate_id)
+    pub plate_type: Option<&'a mut PlateTypeField>,// Some(&mut state.plate_type)
+    ...
+    pub params: &'a PhaseAParams,                 // ← NOTE: PhaseAParams, not WorkflowParams
+    pub iso_cfg: &'a IsostasyConfig,
+    pub cratonic_cfg: Option<&'a CratonicConfigEnabled>,
+}
+```
+
+The struct-literal holds three **disjoint** borrows of `state` (`&mut s`, `&plate_id`, `&mut plate_type`) — the borrow checker accepts this under the splitting-borrow rule. The existing `run_phase_a_cycle_c1` does exactly this, so the worker can replicate it verbatim.
+
+**W3 correction to the issue sketch**: `PostTectonicInput.params` is `&PhaseAParams`, NOT `&WorkflowParams`. The worker's `workflow_params` field must therefore be a **`PhaseAParams`** (the issue text says "workflow_params defaults to `PhaseAParams::default()`" — consistent; just be precise about the type). `WorkflowParams` wraps `{ phase_a: PhaseAParams, phase_b: PhaseBParams }`; we only need `phase_a` (Phase B is HD finalization, out of scope).
+
+## 3. Calibration anchor (the A1-c guard)
+
+**Finding**: [`PhaseAParams::default()`](../../../crates/ymir-core/src/tectonics_v2/workflow/mod.rs#L152) in `workflow/mod.rs`:
+
+```rust
+n_cycles = 5
+k_cycle  = 20
+alpha    = 0.01
+isostatic_rebound_ratio = 0.80
+max_drainage_distance   = 10
+```
+
+**Total tectonic steps = `n_cycles × k_cycle` = 100**, with **5** `macro_redistribution` passes (one per cycle). This is the calibrated cadence. A1-c failed by running `apply_post_tectonic` 6× over 300 steps (`steps_per_cycle=50`) — `macro_redistribution`'s `alpha=0.01` is calibrated for `k_cycle=20`; raising the per-pass step count (or pass frequency) without lowering `alpha` over-erodes. The workflow worker MUST use these defaults and compute total as `n_cycles × k_cycle`, **never** `n_steps`.
+
+## 4. Altitude-field cache (reuse of Viz-0 E4 derivation)
+
+**Finding**: [`render_altitude` in `c1_viz.rs`](../../../crates/ymir-viz/src/visualization/c1_viz.rs#L227) already performs the Architecture C derivation but **discards the raw altitude `GridF32`** (it only emits RGBA). Steps 1–3 of that function:
+
+```rust
+let s_field   = Field2D::from_vec(nx, ny, snapshot.s.clone());
+let age_field = Field2D::from_vec(nx, ny, snapshot.age.clone());
+let plate_type_field = /* decode snapshot.plate_type Vec<u8> → PlateTypeField */;
+let iso = compute_isostasy(&s_field, &IsostasyConfig::default());
+let mut altitude = iso.heightmap;                       // GridF32, non-dim
+apply_stein_stein_bathymetry(&mut altitude, &age_field, &plate_type_field,
+                             &SteinSteinParams::default());
+// altitude.get(i as i32, j as i32) → f32 non-dim altitude per cell
+```
+
+**E1 refactor**: extract `derive_altitude_field(snapshot) -> GridF32` (steps 1–3) so both `render_altitude` (RGBA path) and the hover cache (raw value path) share one source of truth. The hover readout reads `altitude.get(i, j)` — the **non-dim** value (verification value, W3 global). The cache is keyed by `snapshot.step`; invalidated when a newer snapshot arrives (W2). Because the cache derives altitude independent of the active field view, **hover works in ALL views** (W4), not just Altitude.
+
+## Extension points for later stages
+
+- **`C1VizState`** ([`c1_plugin.rs`](../../../crates/ymir-viz/src/visualization/c1_plugin.rs)) currently: `texture_handle, field, pending_spec, show_voronoi_boundaries, show_velocity_vectors, arrow_scale, last_signature`. E1 adds an altitude cache (`Option<(usize, GridF32)>`) + hover readout state; E3 adds the pipeline toggle + cadence sliders surface. Hypsometric scale and `ActivePipeline` are proposed as **separate resources** (cleaner than overloading `C1VizState`).
+- **Worker / command shape (E2)**: gallery `RunBaseline` must stay untouched (W4). Cleanest is a **new** `C1Command::RunWorkflow { spec, phase_a_params: PhaseAParams }` parallel entry (matches the `init-re-architecture-pattern` memory: ship re-architectured flow as a new parallel entry, preserve the old verbatim). The worker `Completed`-time state retention (E4) is a passive add — keep `Option<(C1State, PlateKinematics)>` after the run instead of dropping it.
+- **`Started`/`total` counter (E2/E3)**: `poll_c1_events` currently sets `total = spec.n_steps`. Workflow per-step total is `n_cycles × k_cycle` (= 100 default), with `n_cycles` extra post-cycle snapshots. The counter must read the workflow total, not `n_steps`. Surfaced for E2 design (likely the `Started` event carries the resolved total, or the poll computes it from the pipeline + params).
+
+## Open design choices to confirm before E1
+
+1. **Hover readout placement** — fixed corner egui panel vs cursor-following tooltip. The sprite is a Bevy world entity (not an egui widget), so a cursor-following egui tooltip over the sprite is awkward (egui tooltips anchor to egui widgets; the pointer is *not* over an egui area when hovering the sprite). **Recommendation: fixed corner panel** (stable, no occlusion, trivial to implement). Confirm.
+2. **E2 command shape** — new `RunWorkflow` command (recommended, preserves `RunBaseline` verbatim per init-re-architecture pattern) vs a `pipeline` field on a unified run command. Confirm.
+
+## W7 surfaces resolved this stage
+
+- Cursor→cell: existing `CursorWorldPos` (world space) + sprite-origin-centred inversion; Y-flip caveat noted; resize-correct via per-snapshot nx/ny.
+- Split-borrow: confirmed compiling in `phase_a_c1.rs`; `params` is `&PhaseAParams` (issue-sketch type correction).
+- Calibration anchor: `PhaseAParams::default()` = 5×20, alpha 0.01; total = n_cycles×k_cycle = 100.
+- Altitude cache: factor `derive_altitude_field` out of `render_altitude`; key by step; available in all views.


### PR DESCRIPTION
Closes #139. Builds on Viz-0 (#137). **Viz-only** — `tectonics_c1` untouched, 9th bit-identical preserved.

## What ships
- **Hover-to-inspect**: bottom-right cell inspector (`(i,j)`, S̃, age, altitude) in ALL views. Reads `CursorWorldPos`, inverts the sprite transform (`world_to_cell`, Y-flip + resize correct), altitude lazily derived + cached by step. Non-dim FIRST (verification), meters SECOND (cosmetic).
- **Workflow pipeline**: `ActivePipeline::Workflow` + `RunWorkflow` — the calibrated Phase A loop (`run_workflow_cycles`), gallery `RunBaseline` untouched. Cadence = `PhaseAParams::default()` 5×20 (total = n_cycles×k_cycle, never n_steps — the A1-c guard). UI calibration warning off-default.
- **Hypsometric lens**: drives ONLY hover meters; non-dim + model untouched.
- **Continuation-ready**: worker retains `(C1State, PlateKinematics)`; `run_workflow_cycles` takes `base_step`. No `ContinueRun` command yet (capability only).

## Workflow = the A1-c fix, calibrated
Reproduces `run_phase_a_cycle_c1(Enabled)` at the calibrated 5×20 cadence (inlines `run_with_closures` only for the per-step animation hook; `cratonic_cfg=None` ⇒ `initial_per_plate_type=None` is bit-identical). A1-c's failure was 6 passes over 300 steps (50/300) = outside the envelope.

## Continental-fraction finding (Stage V diagnostic)
Calibrated workflow converges to ~0.058 emergent land at seed 42 — **correct, not over-erosion**:
1. ~0.27 init is a geometric LABEL, not emergent land (gallery isostatic land ~0.045 even with no erosion); [0.20,0.45] was apples/oranges.
2. `macro_redistribution` mass-conserving (Δ≈0/cycle).
3. Adaptive `sea_level_ref` drifts 0.52→0.98 (s_max doubles via Davis-Suppe) → declassification, not mass loss.
4. Pre-existing C1 debt (min/max sea level fragile to peaks) → Phase 1.5 percentile follow-up. "Little emergent land" is normal seed-42 behavior (relevant for Phase 3).

## A1-c regression guard (qualitative signature, not a band)
`workflow_mode_continent_preserved`: mass-conserving (|Δmass|/mass<1e-3), converges (last-cycle |Δfrac|<0.01), and workflow `iso_land ≥ 0.9× gallery iso_land` at the same 100 steps (apples-to-apples on S̃-only emergent land, not plate_type-gated rendered land).

## Tests
8 `bridge::c1::thread` (4 gallery + 4 workflow) + 1 `#[ignore]` diagnostic; 6 `c1_plugin`; 7 `c1_viz`. Viz-only: zero ymir-core changes; 9th bit-identical PASS.

## Test plan (manual)
See `docs/reports/viz_0_5/acceptance_checklist.md` — 6-item UI/visual checklist (hover all views, workflow continent+migrating coast, gallery↔workflow toggle, cadence sliders+warning, hypsometric meters-only, gallery+v2 unchanged).

## Follow-ups
- Phase 1.5: percentile `sea_level_ref` (robust to Davis-Suppe s_max) — why emergent land is low.
- `ContinueRun` command + UI (structure in place).
- Carried Viz-0-bis: live plate velocities, JSON presets, Track C kinematics, custom IsostasyConfig, mid-run cancel.
