### PR TITLE
FIX : Issue #47 root cause - PlateConfig serde(default) for legacy-me…

### DIFF
--- a/crates/ymir-core/src/tectonics/plates.rs
+++ b/crates/ymir-core/src/tectonics/plates.rs
@@ -90,7 +90,14 @@ impl Plate {
 pub const BASE_CONTINENTAL_RATIO: f64 = 0.6;
 
 /// Configuration for plate generation.
+///
+/// `#[serde(default)]` (struct-level): metadata saved before a field
+/// was added still deserializes — missing fields fall back to
+/// [`PlateConfig::default`]. Guards against the #47-class legacy-
+/// compat break (e.g. `continental_area_factor` added later without a
+/// default broke `deserialize_legacy_metadata_without_upscale`).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
 pub struct PlateConfig {
     /// Number of tectonic plates (5–15).
     pub num_plates: usize,


### PR DESCRIPTION
…tadata compat [#47]

deserialize_legacy_metadata_without_upscale failed with "missing field continental_area_factor": the field was added to PlateConfig (part of PipelineMetadata) without a serde default, so metadata JSON saved before the field breaks deserialization (the #47-class legacy-compat break).

Fix: struct-level #[serde(default)] on PlateConfig (it already has a Default impl) -> missing fields fall back to Default; robust to future field additions. Deserialization-only; no serialization change, no compute-path change, no v2 behavior change.

Surfaced while running Issue #141's v2-byte-identical guard; relocated to its own branch/commit (one PR = one subject; a deserialization fix should live in a commit that speaks about deserialization, for a clean bisect). Orthogonal to #141 (zero export/PlateConfig changes there).

Verified: deserialize_legacy_metadata_without_upscale PASSES.