### PR TITLE
C1 upscale robustness

### DIFF
--- a/crates/ymir-core/src/tectonics_c1/mod.rs
+++ b/crates/ymir-core/src/tectonics_c1/mod.rs
@@ -81,6 +81,7 @@ pub mod distance_field;
 pub mod init;
 pub mod init_r7;
 pub mod kinematics;
+pub mod production_upscale;
 pub mod state;
 pub mod stats;
 pub mod time_loop;

--- a/crates/ymir-core/src/tectonics_c1/production_upscale.rs
+++ b/crates/ymir-core/src/tectonics_c1/production_upscale.rs
@@ -1,0 +1,109 @@
+//! Production C1 → anisotropic-FBM upscale wiring (Issue #147
+//! FOLLOWUPS-#6 outcome).
+//!
+//! ## The robustness contract (enforced by the type, not just documented)
+//!
+//! The S̃ thickness field is mesh-NON-convergent in production
+//! (downsample-correlation r~0.51 across 64²/128²/256²/512² — Issue
+//! #147). The upscale is nonetheless ROBUST to this — 64²+upscale and
+//! 256²+upscale produce the SAME world (structure r~0.90, measured in
+//! `stage_upscale_robustness.md`) — **only because it reads the
+//! laundered production ALTITUDE** (isostasy + Stein-Stein, which
+//! converges at alt r~0.88), NOT the raw S̃ gradient (r~0.51). The
+//! non-convergence is washed out by isostasy + Stein-Stein before the
+//! FBM orientation ever sees it (same absorption that hides the
+//! Davis-Suppe mass swing in production).
+//!
+//! Feeding raw S̃ to the upscale would silently break this: the FBM
+//! would orient on a non-convergent gradient, 64²+FBM and 256²+FBM
+//! would DIVERGE (invisible at a single resolution; only a 2-resolution
+//! comparison reveals it), and it would reopen FOLLOWUPS #6 (the
+//! deferred advection-scheme milestone).
+//!
+//! [`upscale_from_c1`] makes that illegal state **unrepresentable**: it
+//! takes a [`C1State`] and builds the altitude INTERNALLY. There is no
+//! S̃/heightmap parameter a caller could substitute. The contract is
+//! enforced by the signature; the inline comment is belt-and-braces.
+//!
+//! The regression test
+//! `c1_closure_morphology::upscale_from_c1_structure_converges`
+//! asserts the precondition (64²/256² structure convergence) so a
+//! future change that breaks it is caught, not just warned against.
+
+use crate::seed::WorldSeed;
+use crate::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
+use crate::terrain::upscale::{upscale_with_fbm, FbmUpscaleConfig, UpscaleResult};
+
+use super::closures::oceanic_bathymetry::params::SteinSteinParams;
+use super::closures::oceanic_bathymetry::source_term::apply_stein_stein_bathymetry;
+use super::state::C1State;
+
+/// Fixed altitude→`[0,1]` normalisation half-range (sea level 0.0 maps
+/// to 0.5). This MUST be a constant, NOT a per-call data range:
+/// normalising 64² and 256² by their own min/max would make them
+/// incomparable and break the measured cross-resolution robustness.
+/// Value matches the production gallery palette half-range.
+const ALTITUDE_NORM_HALF_RANGE: f32 = 1.13;
+
+/// Upscale a C1 simulation state to a detailed heightmap via the
+/// anisotropic-FBM upscale, **through the robustness-preserving
+/// altitude path** (Issue #147 FOLLOWUPS-#6 — see module docs).
+///
+/// Takes the [`C1State`] (not an S̃ field, not a heightmap) BY DESIGN:
+/// the altitude is built internally so no caller can feed the
+/// non-convergent raw S̃ to the FBM orientation.
+///
+/// Pipeline (identical to the measured-robust `stage_upscale_robustness`
+/// path): `compute_isostasy(iso)` → `apply_stein_stein_bathymetry(ss)`
+/// → fixed `[0,1]` normalisation (sea→0.5) → `upscale_with_fbm`.
+pub fn upscale_from_c1(
+    state: &C1State,
+    iso: &IsostasyConfig,
+    ss: &SteinSteinParams,
+    seed: &WorldSeed,
+    cfg: &FbmUpscaleConfig,
+) -> UpscaleResult {
+    // CONTRACT (Issue #147 #6): the upscale reads the laundered
+    // ALTITUDE (isostasy + Stein-Stein, convergent r~0.88), NOT raw S̃
+    // (non-convergent r~0.51). This is what makes the upscale robust to
+    // S̃ mesh non-convergence. Do NOT replace this with `&state.s` or a
+    // raw-S̃ heightmap — it reopens FOLLOWUPS #6 and silently diverges
+    // across resolutions.
+    let isostasy = compute_isostasy(&state.s, iso);
+    let mut altitude = isostasy.heightmap;
+    apply_stein_stein_bathymetry(&mut altitude, &state.age, &state.plate_type, ss);
+
+    // Fixed normalisation to [0,1] (sea 0.0 → 0.5), resolution-independent.
+    let half = ALTITUDE_NORM_HALF_RANGE;
+    let mut coarse = altitude;
+    for v in coarse.data.iter_mut() {
+        *v = ((*v + half) / (2.0 * half)).clamp(0.0, 1.0);
+    }
+    let sea_level_normalized = 0.5_f32;
+
+    upscale_with_fbm(&coarse, sea_level_normalized, seed, cfg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tectonics_c1::init_r7::{init_c1_state_phase_2_r7, Phase2InitParams};
+
+    /// Smoke: the contract path runs and produces a target-sized
+    /// heightmap with finite values (no NaN/Inf), at a small target.
+    #[test]
+    fn upscale_from_c1_smoke() {
+        let state = init_c1_state_phase_2_r7(64, 42, &Phase2InitParams::default());
+        let cfg = FbmUpscaleConfig { target_size: 128, ..Default::default() };
+        let out = upscale_from_c1(
+            &state,
+            &IsostasyConfig::c1_default(),
+            &SteinSteinParams::default(),
+            &WorldSeed::new(42),
+            &cfg,
+        );
+        assert_eq!(out.heightmap.width, 128);
+        assert_eq!(out.heightmap.height, 128);
+        assert!(out.heightmap.data.iter().all(|v| v.is_finite()));
+    }
+}

--- a/crates/ymir-core/src/tectonics_c1/production_upscale.rs
+++ b/crates/ymir-core/src/tectonics_c1/production_upscale.rs
@@ -30,13 +30,41 @@
 //! asserts the precondition (64²/256² structure convergence) so a
 //! future change that breaks it is caught, not just warned against.
 
+use crate::grid::GridF32;
 use crate::seed::WorldSeed;
 use crate::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
+use crate::tectonics_v2::boundaries::plate_type::PlateTypeField;
+use crate::tectonics_v2::field::Field2D;
 use crate::terrain::upscale::{upscale_with_fbm, FbmUpscaleConfig, UpscaleResult};
 
 use super::closures::oceanic_bathymetry::params::SteinSteinParams;
 use super::closures::oceanic_bathymetry::source_term::apply_stein_stein_bathymetry;
 use super::state::C1State;
+
+/// The C1 PRODUCTION altitude (Architecture C): `compute_isostasy`
+/// followed by the Stein-Stein bathymetry re-apply on oceanic cells.
+///
+/// **SINGLE SOURCE OF TRUTH** for the production altitude, shared by
+/// the viz render (`bridge::c1` / `c1_viz::derive_altitude_field`, which
+/// reconstructs these fields from a snapshot and calls this) AND the
+/// upscale input ([`upscale_from_c1`]). Factoring it here (Issue #147
+/// #6) prevents the upscaled HD terrain from silently diverging from
+/// the rendered production altitude: the two agree BY CONSTRUCTION, not
+/// by two copies of the same `isostasy + Stein-Stein` sequence drifting
+/// apart. The regression test guards robustness; this shared function
+/// guards render/upscale equality.
+pub fn c1_production_altitude(
+    s: &Field2D,
+    age: &Field2D,
+    plate_type: &PlateTypeField,
+    iso: &IsostasyConfig,
+    ss: &SteinSteinParams,
+) -> GridF32 {
+    let isostasy = compute_isostasy(s, iso);
+    let mut altitude = isostasy.heightmap;
+    apply_stein_stein_bathymetry(&mut altitude, age, plate_type, ss);
+    altitude
+}
 
 /// Fixed altitude→`[0,1]` normalisation half-range (sea level 0.0 maps
 /// to 0.5). This MUST be a constant, NOT a per-call data range:
@@ -66,16 +94,13 @@ pub fn upscale_from_c1(
     // CONTRACT (Issue #147 #6): the upscale reads the laundered
     // ALTITUDE (isostasy + Stein-Stein, convergent r~0.88), NOT raw S̃
     // (non-convergent r~0.51). This is what makes the upscale robust to
-    // S̃ mesh non-convergence. Do NOT replace this with `&state.s` or a
-    // raw-S̃ heightmap — it reopens FOLLOWUPS #6 and silently diverges
-    // across resolutions.
-    let isostasy = compute_isostasy(&state.s, iso);
-    let mut altitude = isostasy.heightmap;
-    apply_stein_stein_bathymetry(&mut altitude, &state.age, &state.plate_type, ss);
+    // S̃ mesh non-convergence. Built via the SHARED `c1_production_altitude`
+    // (same source of truth as the viz render) — do NOT inline a raw-S̃
+    // path here; it reopens FOLLOWUPS #6 and silently diverges.
+    let mut coarse = c1_production_altitude(&state.s, &state.age, &state.plate_type, iso, ss);
 
     // Fixed normalisation to [0,1] (sea 0.0 → 0.5), resolution-independent.
     let half = ALTITUDE_NORM_HALF_RANGE;
-    let mut coarse = altitude;
     for v in coarse.data.iter_mut() {
         *v = ((*v + half) / (2.0 * half)).clamp(0.0, 1.0);
     }

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -52,6 +52,8 @@ use ymir_core::tectonics_c1::state::C1State;
 use ymir_core::tectonics_c1::time_loop::{run_with_closures, C1Closures, C1TimeLoopConfig};
 use ymir_core::tectonics_v2::boundaries::plate_type::PlateType;
 use ymir_core::tectonics_v2::field::Field2D;
+use ymir_core::seed::WorldSeed;
+use ymir_core::terrain::upscale::{upscale_with_fbm, FbmUpscaleConfig};
 
 const GRID_SIZE: usize = 64;
 const N_STEPS: usize = 300;
@@ -691,6 +693,111 @@ fn contrast_counterfactual_gamma() {
     eprintln!();
     eprintln!("  λ=0 row = pure curtain (variant C, expect ~0.045).");
     eprintln!("  r→~1 with λ ⇒ scheme FEASIBLE (curtain cedes) → go (α). r stuck ⇒ scheme floor.");
+}
+
+/// #147 FOLLOWUPS-#6 GATING measurement — is the upscale ROBUST to the
+/// S̃ field non-convergence (production r~0.51), or does it diverge?
+/// Wires C1→upscale on a throwaway: run production (rigid, full
+/// closures) at 64² and 256² (same seed), build the gallery altitude,
+/// normalise with the SAME fixed map (sea=0.5) so both are comparable,
+/// upscale both to 1024² anisotropic FBM, and compare STRUCTURE
+/// (NOT identity — FBM fills more from 256² by design, "different
+/// paths" accepted). Criterion = structure convergence: same
+/// continents/chains/bathymetry in the same places, detail differing.
+///
+/// Metrics: (1) coarse-altitude cross-grid r (the field the upscale's
+/// slope orientation reads); (2) upscaled-result structure r (both
+/// 1024² block-meaned to 64², correlated — FBM averages out, large
+/// structure remains); (3) land morphology of each upscaled result
+/// (sea_level threshold) — same n_components/largest/area? (4) visual
+/// side-by-side PNGs (the judge).
+#[test]
+#[ignore]
+fn upscale_robustness_64_vs_256() {
+    let dir = output_dir().join("upscale_robustness");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let seed = 42u64;
+    const HALF: f32 = ALT_HALF; // fixed normalisation half-range (sea at 0.0 → 0.5)
+    let cfg = FbmUpscaleConfig { target_size: 1024, ..Default::default() };
+
+    eprintln!("#147 FOLLOWUPS-#6 gating — upscale robustness to S̃ r~0.51 (seed {seed})");
+    eprintln!("  structure-convergence (NOT identity); coarse normalised sea=0.5, target 1024²");
+
+    let mut coarse_ds: Vec<Vec<f64>> = Vec::new(); // coarse-altitude →64
+    let mut up_ds: Vec<Vec<f64>> = Vec::new();      // upscaled →64
+    let grids = [64usize, 256];
+    for &grid in &grids {
+        let n_steps = 300 * grid / 64;
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true,
+            n_steps,
+            dx: 1.0 / grid as f64,
+            dy: 1.0 / grid as f64,
+            iso_config: iso_config.clone(),
+            drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+        // Gallery altitude → fixed [0,1] normalisation (sea 0.0 → 0.5).
+        let altitude = render_altitude(&state, &iso_config, &closures);
+        let mut coarse = altitude.clone();
+        for v in coarse.data.iter_mut() {
+            *v = ((*v + HALF) / (2.0 * HALF)).clamp(0.0, 1.0);
+        }
+        coarse_ds.push(block_mean_to_64(&|i, j| coarse.get(i as i32, j as i32) as f64, grid));
+
+        let up = upscale_with_fbm(&coarse, 0.5, &WorldSeed::new(seed), &cfg);
+        let up_grid = up.heightmap.width;
+        up_ds.push(block_mean_to_64_dim(
+            &|i, j| up.heightmap.get(i as i32, j as i32) as f64,
+            up_grid,
+        ));
+
+        // Land morphology of the upscaled result (land = h > sea 0.5).
+        let mask: Vec<bool> = up.heightmap.data.iter().map(|&v| v > 0.5).collect();
+        let m = land_morphology(&mask, up.heightmap.width, up.heightmap.height);
+        eprintln!(
+            "  grid {grid}²→{}²: upscaled land%={:.1} perim/A={:.3} n_comp={} largest={:.3}",
+            up_grid, 100.0 * m.area_fraction, m.perimeter_over_area, m.n_components,
+            m.largest_component_fraction
+        );
+
+        save_heightmap01(&up.heightmap, &dir.join(format!("upscaled_from{grid:04}.png")));
+    }
+
+    let coarse_r = pearson(&coarse_ds[0], &coarse_ds[1]);
+    let up_r = pearson(&up_ds[0], &up_ds[1]);
+    eprintln!();
+    eprintln!("  coarse-altitude structure r (64 vs 256, →64) = {coarse_r:.4}");
+    eprintln!("  UPSCALED structure r       (64 vs 256, →64) = {up_r:.4}");
+    eprintln!();
+    eprintln!("  ROBUST if upscaled structure r ≈ coarse r (upscale preserves the convergent");
+    eprintln!("  large structure; FBM detail differs) → scheme milestone DEFERRABLE.");
+    eprintln!("  DIVERGES if upscaled structure r << coarse r → scheme milestone NECESSARY.");
+    eprintln!("  Visual: {}", dir.display());
+}
+
+/// Block-mean an arbitrary square `grid` (multiple of 64) field to 64².
+fn block_mean_to_64_dim(get: &dyn Fn(usize, usize) -> f64, grid: usize) -> Vec<f64> {
+    block_mean_to_64(get, grid)
+}
+
+/// Render a normalised `[0,1]` heightmap (sea at 0.5) with the
+/// hypsometric palette, 1:1 (no upscale).
+fn save_heightmap01(h: &GridF32, path: &Path) {
+    let (nx, ny) = (h.width, h.height);
+    let mut img = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(nx as u32, ny as u32);
+    for j in 0..ny {
+        for i in 0..nx {
+            let v = h.get(i as i32, j as i32).clamp(0.0, 1.0);
+            img.put_pixel(i as u32, (ny - 1 - j) as u32, Rgb(hypsometric(v, 0.5)));
+        }
+    }
+    img.save(path).expect("save heightmap01 PNG");
 }
 
 /// #147 (C) — visual characterisation of the advection-only

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -53,7 +53,8 @@ use ymir_core::tectonics_c1::time_loop::{run_with_closures, C1Closures, C1TimeLo
 use ymir_core::tectonics_v2::boundaries::plate_type::PlateType;
 use ymir_core::tectonics_v2::field::Field2D;
 use ymir_core::seed::WorldSeed;
-use ymir_core::terrain::upscale::{upscale_with_fbm, FbmUpscaleConfig};
+use ymir_core::terrain::upscale::FbmUpscaleConfig;
+use ymir_core::tectonics_c1::production_upscale::upscale_from_c1;
 
 const GRID_SIZE: usize = 64;
 const N_STEPS: usize = 300;
@@ -713,7 +714,7 @@ fn contrast_counterfactual_gamma() {
 /// side-by-side PNGs (the judge).
 #[test]
 #[ignore]
-fn upscale_robustness_64_vs_256() {
+fn upscale_from_c1_structure_converges() {
     let dir = output_dir().join("upscale_robustness");
     std::fs::create_dir_all(&dir).expect("create dir");
     let iso_config = IsostasyConfig::c1_default();
@@ -721,11 +722,13 @@ fn upscale_robustness_64_vs_256() {
     const HALF: f32 = ALT_HALF; // fixed normalisation half-range (sea at 0.0 → 0.5)
     let cfg = FbmUpscaleConfig { target_size: 1024, ..Default::default() };
 
-    eprintln!("#147 FOLLOWUPS-#6 gating — upscale robustness to S̃ r~0.51 (seed {seed})");
+    eprintln!("#147 FOLLOWUPS-#6 contract regression — upscale_from_c1 structure convergence (seed {seed})");
     eprintln!("  structure-convergence (NOT identity); coarse normalised sea=0.5, target 1024²");
 
     let mut coarse_ds: Vec<Vec<f64>> = Vec::new(); // coarse-altitude →64
     let mut up_ds: Vec<Vec<f64>> = Vec::new();      // upscaled →64
+    let mut up_land: Vec<f64> = Vec::new();
+    let mut up_largest: Vec<f64> = Vec::new();
     let grids = [64usize, 256];
     for &grid in &grids {
         let n_steps = 300 * grid / 64;
@@ -750,7 +753,16 @@ fn upscale_robustness_64_vs_256() {
         }
         coarse_ds.push(block_mean_to_64(&|i, j| coarse.get(i as i32, j as i32) as f64, grid));
 
-        let up = upscale_with_fbm(&coarse, 0.5, &WorldSeed::new(seed), &cfg);
+        // Upscale through the CONTRACT path (upscale_from_c1 builds the
+        // laundered altitude internally — never raw S̃). This is what the
+        // regression guards: production uses exactly this entry.
+        let up = upscale_from_c1(
+            &state,
+            &iso_config,
+            &closures.oceanic_bathymetry,
+            &WorldSeed::new(seed),
+            &cfg,
+        );
         let up_grid = up.heightmap.width;
         up_ds.push(block_mean_to_64_dim(
             &|i, j| up.heightmap.get(i as i32, j as i32) as f64,
@@ -765,6 +777,8 @@ fn upscale_robustness_64_vs_256() {
             up_grid, 100.0 * m.area_fraction, m.perimeter_over_area, m.n_components,
             m.largest_component_fraction
         );
+        up_land.push(m.area_fraction);
+        up_largest.push(m.largest_component_fraction);
 
         save_heightmap01(&up.heightmap, &dir.join(format!("upscaled_from{grid:04}.png")));
     }
@@ -774,11 +788,28 @@ fn upscale_robustness_64_vs_256() {
     eprintln!();
     eprintln!("  coarse-altitude structure r (64 vs 256, →64) = {coarse_r:.4}");
     eprintln!("  UPSCALED structure r       (64 vs 256, →64) = {up_r:.4}");
-    eprintln!();
-    eprintln!("  ROBUST if upscaled structure r ≈ coarse r (upscale preserves the convergent");
-    eprintln!("  large structure; FBM detail differs) → scheme milestone DEFERRABLE.");
-    eprintln!("  DIVERGES if upscaled structure r << coarse r → scheme milestone NECESSARY.");
     eprintln!("  Visual: {}", dir.display());
+
+    // REGRESSION (Issue #147 #6 contract): the upscale, fed via
+    // `upscale_from_c1` (laundered altitude), must stay STRUCTURE-
+    // convergent across resolutions. If a future change feeds raw S̃
+    // instead, up_r collapses toward the S̃ field r (~0.51) and this
+    // fails — the precondition is TESTED, not merely documented.
+    assert!(
+        up_r >= 0.85,
+        "upscaled structure r {up_r:.3} < 0.85 — robustness contract broken \
+         (is the upscale reading raw S̃ instead of the laundered altitude? reopens #6)"
+    );
+    // Same world: one dominant landmass at BOTH resolutions, comparable
+    // land fraction (FBM detail differs; large structure must not).
+    assert!(
+        up_largest[0] > 0.8 && up_largest[1] > 0.8,
+        "upscaled largest-component {up_largest:?} — not one dominant landmass at both res"
+    );
+    assert!(
+        (up_land[0] - up_land[1]).abs() < 0.05,
+        "upscaled land fractions {up_land:?} diverge > 5 pts across resolution"
+    );
 }
 
 /// Block-mean an arbitrary square `grid` (multiple of 64) field to 64².

--- a/crates/ymir-viz/src/visualization/c1_viz.rs
+++ b/crates/ymir-viz/src/visualization/c1_viz.rs
@@ -20,10 +20,8 @@
 //! - `Cratonic` — binary grayscale (0/1) MVP standalone view.
 
 use ymir_core::grid::GridF32;
-use ymir_core::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
-use ymir_core::tectonics_c1::closures::oceanic_bathymetry::{
-    apply_stein_stein_bathymetry, SteinSteinParams,
-};
+use ymir_core::tectonics::isostasy::IsostasyConfig;
+use ymir_core::tectonics_c1::closures::oceanic_bathymetry::SteinSteinParams;
 use ymir_core::tectonics_c1::stats::C1StepStats;
 use ymir_core::tectonics_v2::boundaries::plate_type::{PlateType, PlateTypeField};
 use ymir_core::tectonics_v2::field::Field2D;
@@ -266,20 +264,20 @@ pub fn derive_altitude_field(snapshot: &C1Snapshot) -> GridF32 {
         }
     }
 
-    // 3. Architecture C: compute_isostasy + Stein-Stein re-apply.
+    // 3. Architecture C: compute_isostasy + Stein-Stein re-apply, via
+    // the SHARED core source of truth (Issue #147 #6) so this render
+    // altitude and the upscale input (`upscale_from_c1`) cannot diverge.
     // Issue #141: c1_default (P95-capped) so the rendered altitude=0
     // coast matches the reclassify (plate_type) coast — both use the
     // same robust sea level (W2 coherence; prevents the Viz-0 Stage A
     // plate_type-vs-altitude divergence).
-    let iso = compute_isostasy(&s_field, &IsostasyConfig::c1_default());
-    let mut altitude = iso.heightmap;
-    apply_stein_stein_bathymetry(
-        &mut altitude,
+    ymir_core::tectonics_c1::production_upscale::c1_production_altitude(
+        &s_field,
         &age_field,
         &plate_type_field,
+        &IsostasyConfig::c1_default(),
         &SteinSteinParams::default(),
-    );
-    altitude
+    )
 }
 
 fn render_altitude(snapshot: &C1Snapshot, rgba: &mut [u8]) {

--- a/docs/reports/c1_continental_buoyancy/FOLLOWUPS.md
+++ b/docs/reports/c1_continental_buoyancy/FOLLOWUPS.md
@@ -32,7 +32,18 @@ Out of #145 scope (scope kept healthy: core buoyancy fix proven/implemented/flip
 **Diagnosis (acquired, measured):** S̃ does not converge with mesh resolution because the **upwind advection scheme itself** is bulk mesh-dependent (numerical diffusion ∝ dx; init→64 r 0.90 collapses to advection-only r 0.045 over a run). Anchored by an init-convergence CONTROL (init IS convergent → advection destroys it), the contrast counterfactual γ (boundary-contrast smoothing does NOT help → not a boundary issue), and split B (subduction innocent; accretion couples via velocity-averaging, not a parameter). NO closure-PARAMETER fix works: DS physical-width (Fix #1, real units bug, kept, partial) and accretion step→time (degraded 128/256, reverted) are units-hygiene, not the lever. Equilibrium-height MASKS it (full-system r~0.51) but does not cure it. Production S̃ r ~0.51; geography converges (alt r ~0.87).
 **Lead:** a higher-order / less-diffusive / flux-limited (or semi-Lagrangian) advection scheme for S̃ + age. **FOUNDATION defect** of the transport scheme — same depth class as continental-buoyancy, surfaced by the same measure-don't-assume method. Out of #147, which REDEFINED the problem from "closure calibration" to "advection scheme".
 
-**GATING QUESTION before opening the scheme issue (do NOT open it yet):** do we actually NEED r→1? The reason to want S̃-field invariance is the upscale (consumes the S̃ gradient). But we have NOT measured whether r~0.51 actually perturbs the upscale downstream. Precedent: the mass swing LOOKED like a problem; Stein-Stein absorbed it (invisible in production). The upscale may be similarly robust to r~0.51 (stochastic FBM merely ORIENTED by the gradient — perhaps no need for a perfectly convergent gradient). **MEASURE FIRST** (next session): 64²+upscale vs 256²+upscale — coherent detail (upscale robust to r~0.51 → scheme milestone DEFERRABLE) or different worlds (upscale diverges → milestone NECESSARY)? Same "is the effect visible downstream?" logic that (correctly) avoided over-fixing DS. The scheme issue's urgency/necessity is decided by that measurement, not assumed.
+**GATING ANSWERED → DEFERRABLE (do NOT open the scheme issue).** Measured
+(`stage_upscale_robustness.md`): 64²+upscale vs 256²+upscale = SAME world
+(upscaled structure r 0.90 ≈ coarse-altitude r 0.88; ~26% land + largest
+~0.96 both; visual = same continents/orogen/bathymetry, different fineness).
+The upscale orients FBM by the coarse ALTITUDE slope (convergent, r~0.88),
+NOT raw S̃ (r~0.51) — the non-convergence is laundered through isostasy +
+Stein-Stein, invisible downstream (same as the DS mass swing). So the
+advection-scheme milestone is NOT urgent; #6 stays registered but deferred.
+**Precondition:** holds because the upscale reads altitude; revisit only if a
+consumer reads the raw S̃ gradient. Original reasoning retained below.
+
+**GATING QUESTION (now answered above — kept for the record):** do we actually NEED r→1? The reason to want S̃-field invariance is the upscale (consumes the S̃ gradient). But we have NOT measured whether r~0.51 actually perturbs the upscale downstream. Precedent: the mass swing LOOKED like a problem; Stein-Stein absorbed it (invisible in production). The upscale may be similarly robust to r~0.51 (stochastic FBM merely ORIENTED by the gradient — perhaps no need for a perfectly convergent gradient). **MEASURE FIRST** (next session): 64²+upscale vs 256²+upscale — coherent detail (upscale robust to r~0.51 → scheme milestone DEFERRABLE) or different worlds (upscale diverges → milestone NECESSARY)? Same "is the effect visible downstream?" logic that (correctly) avoided over-fixing DS. The scheme issue's urgency/necessity is decided by that measurement, not assumed.
 
 ---
 

--- a/docs/reports/c1_continental_buoyancy/stage_upscale_robustness.md
+++ b/docs/reports/c1_continental_buoyancy/stage_upscale_robustness.md
@@ -1,0 +1,62 @@
+# Upscale robustness to S̃ mesh non-convergence (#147 FOLLOWUPS-#6 gating)
+
+**Question (the gate before opening the advection-scheme milestone):** the
+S̃ field is mesh-non-convergent in production (r~0.51, #147). The reason to
+care is the upscale (it adds the fine terrain). But does r~0.51 actually
+perturb the upscale downstream — or is the upscale robust to it (as
+Stein-Stein absorbed the mass swing, invisible in production)? **Measure
+before opening a foundation milestone.**
+
+**Method (throwaway C1→upscale):** run C1 production (rigid, full closures)
+at 64² and 256², same seed 42; build the gallery altitude (isostasy +
+Stein-Stein); normalise with the SAME fixed map (sea 0.0→0.5) so both are
+comparable; `upscale_with_fbm` both to 1024² anisotropic FBM. Criterion =
+**structure convergence, NOT identity** (FBM fills more from 256² by design;
+"different paths" accepted). Harness: `c1_closure_morphology::upscale_robustness_64_vs_256`.
+
+## Result
+
+```
+ coarse-altitude structure r (64 vs 256, block-meaned →64) = 0.8825
+ UPSCALED structure r        (64 vs 256, block-meaned →64) = 0.9027
+ upscaled land%  : 25.8 (from 64²)  vs  26.2 (from 256²)
+ largest comp    : 0.951            vs  0.969
+```
+
+- **Upscaled structure r (0.90) ≈ coarse-altitude r (0.88)** — the upscale
+  does NOT amplify the divergence; it PRESERVES the coarse structure
+  convergence. The S̃ non-convergence (r~0.51) does NOT propagate.
+- **Land morphology matches:** ~26% land both, one dominant landmass
+  (largest ~0.96) in both → same continents.
+- **Visual (the judge):** both renders show the SAME seed-42 world — same
+  continent (upper-left mass + diagonal arm + left-edge island), same brown
+  orogenic highland in the same place, same bathymetry/coasts. The 64²-based
+  is blockier (coarse stairstep coast); the 256²-based smoother. **Same world,
+  different fineness** — structure-convergence criterion MET.
+
+## Why robust (mechanism)
+
+`upscale_with_fbm` orients its anisotropic FBM by the slope of the **coarse
+ALTITUDE** it is given (`compute_terrain_analysis(coarse)`), NOT the raw S̃
+gradient. We feed it the production altitude (isostasy + Stein-Stein), which
+converges at **alt r ~0.88** — the non-convergent S̃ (r~0.51) is "laundered"
+through isostasy + Stein-Stein into a convergent altitude BEFORE the upscale
+reads it. Same absorption mechanism as the DS mass swing absorbed by
+Stein-Stein (invisible in production). The FBM then merely adds detail at the
+coarse-cell scale (different fineness per base resolution — the accepted
+"different paths"), averaging out under downsampling.
+
+## VERDICT — advection-scheme milestone is DEFERRABLE
+
+The S̃ mesh non-convergence is **invisible downstream**: the upscale produces
+the same world at 64² and 256² base. C1 can proceed to upscale wiring /
+Phase 3 / piste 4 **without** changing the advection scheme. The foundation
+follow-up (FOLLOWUPS #6) stays REGISTERED but is **not urgent / deferrable** —
+the gating measurement answered "robust", so the milestone is not opened.
+
+**Caveat (the robustness precondition):** this holds because the upscale
+consumes the **altitude** (laundered, convergent), not the raw S̃ gradient.
+If a future wiring fed the raw S̃ gradient to the FBM orientation, robustness
+would NOT hold (it would read r~0.51 directly). Keep the upscale on the
+altitude path; revisit #6 only if that contract changes or a downstream
+consumer reads raw S̃.


### PR DESCRIPTION
Two deliverables in one coherent unit (the wiring follows from the measurement):

## 1. Gating measurement — is the upscale robust to S̃ mesh non-convergence?
Issue #147 left S̃ field mesh-convergence at r~0.51 (production), redefining
the problem as an advection-SCHEME defect (FOLLOWUPS #6) and gating the
decision to open that foundation milestone on a downstream measurement: does
r~0.51 actually perturb the upscale, or is it absorbed (like the DS mass
swing via Stein-Stein)?

**Measured (`stage_upscale_robustness.md`, `upscale_from_c1_structure_converges`):**
64²+upscale vs 256²+upscale → **same world** (structure r 0.90 ≈ coarse-altitude
r 0.88; ~26% land + largest ~0.96 both; visual = same continents/orogen/
bathymetry, different fineness). **ROBUST.** Mechanism: the upscale orients its
FBM by the coarse **altitude** slope (convergent r~0.88), NOT the raw S̃ gradient
(r~0.51) — the non-convergence is laundered through isostasy + Stein-Stein.

→ **The advection-scheme milestone (#6) is DEFERRABLE**, NOT opened. C1 can
proceed to upscale / Phase 3 / piste 4 without a new advection scheme.

## 2. Altitude-contract wiring — `upscale_from_c1`
The robustness holds ONLY because the upscale reads the laundered altitude,
not raw S̃. A "clean" integration could tempt passing `snapshot.s` (richer)
and silently break it (invisible at one resolution; reopens #6). The wiring
makes that **unrepresentable**:

- **`tectonics_c1::production_upscale::upscale_from_c1(state, iso, ss, seed, cfg)`**
  takes a `C1State` ONLY — builds the altitude internally, no S̃/heightmap
  param a caller could substitute. Contract enforced by the **type**, not just
  a comment (belt: guard comment too).
- **`c1_production_altitude`** factored as the SINGLE SOURCE OF TRUTH for the
  isostasy→Stein-Stein composition; both the viz render (`derive_altitude_field`)
  and the upscale input call it → render and HD upscale agree **by construction**
  (was duplicated; dedup'd here).
- **Regression** `upscale_from_c1_structure_converges` (`#[ignore]`): asserts
  64²/256² structure r ≥ 0.85 + same-world (largest > 0.8 both, land Δ < 5 pts).
  Precondition TESTED, not just documented (defence in depth: type forbids +
  test catches).

## Deferred (open UI decisions — NOT in this PR)
Bridge `C1Event::Upscaled` + HD render/export: deferred until piste 4 / Living
Landz specifies how the HD is consumed (gallery vs file export, target
resolution, output interface). This PR ships the capability + contract, not the
exposure.

## Notes
- No production behaviour change (the contract fn reproduces the measured path;
  the dedup is behaviour-preserving — regression r unchanged 0.9027).
- Build clean (core + viz). Diagnostic harness `c1_closure_morphology` (`#[ignore]`).
- FOLLOWUPS.md #6 marked DEFERRABLE (gating answered); precondition: holds while
  the upscale reads altitude — revisit only if a consumer reads raw S̃.
