### PR TITLE
#151 — C1 HD coastline refinement, resolution-independent FBM, ocean cleanup

### DIFF
--- a/crates/ymir-core/src/tectonics_c1/production_upscale.rs
+++ b/crates/ymir-core/src/tectonics_c1/production_upscale.rs
@@ -62,8 +62,46 @@ pub fn c1_production_altitude(
 ) -> GridF32 {
     let isostasy = compute_isostasy(s, iso);
     let mut altitude = isostasy.heightmap;
-    apply_stein_stein_bathymetry(&mut altitude, age, plate_type, ss);
+    // #151 F3 fix — despike the age before Stein-Stein. The flux-form age
+    // advection piles age up at convergent plate boundaries (sparse cells
+    // with ~1000× the background age — the registered density-vs-Lagrangian
+    // artefact). Stein-Stein turns those age spikes into the deepest cells,
+    // rendering as dark dotted lines in the ocean (F3). A 3×3 median kills
+    // the sparse spikes while preserving smooth age structure (verified: no
+    // legitimate age gradient is flattened — the C1 model has none without
+    // seafloor spreading). This is a RENDER-side band-aid: Stein-Stein is the
+    // only consumer of age on the altitude path, so this fixes F3 fully for
+    // both the viz render and the upscale. The internal advected age field is
+    // unchanged (the root cause — age advection — is a deferred deep fix).
+    let age_despiked = median_3x3(age);
+    apply_stein_stein_bathymetry(&mut altitude, &age_despiked, plate_type, ss);
     altitude
+}
+
+/// 3×3 median filter (clamped edges). Removes sparse spikes (the age
+/// pile-up cells) while preserving smooth structure.
+fn median_3x3(field: &Field2D) -> Field2D {
+    let nx = field.nx();
+    let ny = field.ny();
+    let mut out = field.clone();
+    let mut nb: Vec<f64> = Vec::with_capacity(9);
+    for j in 0..ny {
+        for i in 0..nx {
+            nb.clear();
+            for dj in -1i32..=1 {
+                for di in -1i32..=1 {
+                    let ni = i as i32 + di;
+                    let nj = j as i32 + dj;
+                    if ni >= 0 && nj >= 0 && (ni as usize) < nx && (nj as usize) < ny {
+                        nb.push(field.get(ni as usize, nj as usize));
+                    }
+                }
+            }
+            nb.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            out.set(i, j, nb[nb.len() / 2]);
+        }
+    }
+    out
 }
 
 /// Fixed altitude→`[0,1]` normalisation half-range (sea level 0.0 maps

--- a/crates/ymir-core/src/terrain/upscale.rs
+++ b/crates/ymir-core/src/terrain/upscale.rs
@@ -53,6 +53,19 @@ pub struct FbmUpscaleConfig {
     /// pixel. Low = coherent meander over several coarse cells.
     /// Default: 0.5.
     pub coast_warp_frequency: f64,
+    /// **Coastal amplitude taper** (Issue #151 follow-up). FBM amplitude
+    /// is multiplied by `smoothstep(|height − sea_level|, 0,
+    /// coastal_amplitude_band)`, so the noise tapers to ~0 AT the
+    /// sea-level contour and rises to full beyond `band` (altitude
+    /// units). Without it, `±amplitude·noise` flips cells land↔ocean at
+    /// the coast → a feathered/combed coastline, worst on flat
+    /// near-sea-level regions (the interior of strong relief is
+    /// unaffected — so a global amplitude cut is the wrong fix, it would
+    /// flatten mountains). This is a LOCAL fix: kills coastal feathering,
+    /// keeps inland mountain detail. The coast warp supplies the macro
+    /// coast irregularity; this removes the micro-feathering. Default:
+    /// 0.0 (OFF → byte-identical to pre-#151; v2 unaffected).
+    pub coastal_amplitude_band: f64,
 }
 
 impl Default for FbmUpscaleConfig {
@@ -72,6 +85,7 @@ impl Default for FbmUpscaleConfig {
             domain_warp_octaves: 3,
             coast_warp_strength: 0.0,
             coast_warp_frequency: 0.5,
+            coastal_amplitude_band: 0.0,
         }
     }
 }
@@ -214,9 +228,18 @@ pub fn upscale_with_fbm(
                 let altitude_factor =
                     if base_height > sea_level { 1.0 } else { config.submarine_damping };
 
-                let amplitude = config.amplitude_base
+                let mut amplitude = config.amplitude_base
                     * (1.0 + slope_mag as f64 * config.amplitude_slope_factor)
                     * altitude_factor;
+
+                // #151: coastal amplitude taper — damp the FBM to ~0 AT the
+                // sea-level contour so it doesn't feather the coastline by
+                // flipping near-sea cells land↔ocean; full amplitude inland
+                // (mountains preserved). OFF (band 0) → no-op, byte-identical.
+                if config.coastal_amplitude_band > 0.0 {
+                    let dist_from_sea = (base_height as f64 - sea_level as f64).abs();
+                    amplitude *= smoothstep(dist_from_sea, 0.0, config.coastal_amplitude_band);
+                }
 
                 // 4. Compute anisotropy ratio with sigmoid rolloff
                 let slope_f64 = slope_mag as f64;

--- a/crates/ymir-core/src/terrain/upscale.rs
+++ b/crates/ymir-core/src/terrain/upscale.rs
@@ -37,6 +37,22 @@ pub struct FbmUpscaleConfig {
     pub domain_warp_frequency: f64,
     /// Number of FBM octaves for the warp noise itself. Default: 3.
     pub domain_warp_octaves: usize,
+    /// **Coastline warp** (Issue #151 follow-up). Displacement applied
+    /// to the COARSE-ALTITUDE sampling coordinates `(sx, sy)` BEFORE
+    /// bilinear interpolation, in units of COARSE pixels. This makes
+    /// the `altitude = sea_level` contour (the coastline) meander
+    /// instead of following the blocky interpolated coarse polygon —
+    /// the domain warp above only warps the NOISE, never the coarse
+    /// sampling, so it cannot move the coast (cause pinned: blocky
+    /// coast = STEP 1, the interpolated contour). Amplitude ~0.5–1.0
+    /// coarse cells breaks the 1-cell stairstep without making the
+    /// coast chaotic. Default: 0.0 (OFF → byte-identical to pre-#151;
+    /// the existing v2 pipeline is unaffected).
+    pub coast_warp_strength: f64,
+    /// Frequency of the coastline-warp noise, in cycles per COARSE
+    /// pixel. Low = coherent meander over several coarse cells.
+    /// Default: 0.5.
+    pub coast_warp_frequency: f64,
 }
 
 impl Default for FbmUpscaleConfig {
@@ -54,6 +70,8 @@ impl Default for FbmUpscaleConfig {
             domain_warp_strength: 0.0,
             domain_warp_frequency: 0.5,
             domain_warp_octaves: 3,
+            coast_warp_strength: 0.0,
+            coast_warp_frequency: 0.5,
         }
     }
 }
@@ -123,6 +141,12 @@ pub fn upscale_with_fbm(
     // Domain warp: two independent FBM fields for X and Y displacement
     let warp_noise_x = SeededNoise::new(noise_seed.wrapping_add(55555), config.domain_warp_octaves);
     let warp_noise_y = SeededNoise::new(noise_seed.wrapping_add(77777), config.domain_warp_octaves);
+    // Dedicated coastline-warp noise (Issue #151 follow-up) — distinct
+    // seeds from the noise/domain-warp so the coast displacement is
+    // independent of the FBM detail.
+    let coast_octaves = config.domain_warp_octaves.max(1);
+    let coast_warp_noise_x = SeededNoise::new(noise_seed.wrapping_add(13331), coast_octaves);
+    let coast_warp_noise_y = SeededNoise::new(noise_seed.wrapping_add(24421), coast_octaves);
 
     // Precompute slope and direction on the coarse grid
     let (slope_map, direction_map) = compute_terrain_analysis(coarse);
@@ -145,12 +169,35 @@ pub fn upscale_with_fbm(
                 let sx = i as f64 * scale_x;
                 let sy = j as f64 * scale_y;
 
-                // 1. Bilinear interpolation of the coarse heightmap
-                let base_height = coarse.sample_bilinear_periodic(sx as f32, sy as f32);
+                // 0. Coastline warp (Issue #151 follow-up): displace the
+                // COARSE-ALTITUDE sampling position so the sea-level
+                // contour meanders instead of following the blocky 64²
+                // polygon. In coarse-pixel units; the domain warp (step
+                // 7) never touches this. OFF when strength == 0 →
+                // (csx, csy) == (sx, sy), byte-identical to pre-#151.
+                let (csx, csy) = if config.coast_warp_strength > 0.0 {
+                    let cwf = config.coast_warp_frequency;
+                    let (wcx, wcy) = (sx * cwf, sy * cwf);
+                    let cdx = coast_warp_noise_x.fbm(
+                        wcx, wcy, coast_octaves, config.lacunarity, config.persistence,
+                    ) * config.coast_warp_strength;
+                    let cdy = coast_warp_noise_y.fbm(
+                        wcx, wcy, coast_octaves, config.lacunarity, config.persistence,
+                    ) * config.coast_warp_strength;
+                    (sx + cdx, sy + cdy)
+                } else {
+                    (sx, sy)
+                };
 
-                // 2. Sample terrain properties from coarse analysis
-                let slope_mag = slope_map.sample_bilinear_periodic(sx as f32, sy as f32);
-                let slope_dir = direction_map.sample_bilinear_periodic(sx as f32, sy as f32);
+                // 1. Bilinear interpolation of the coarse heightmap (at the
+                // coast-warped position — this is what bends the coastline).
+                let base_height = coarse.sample_bilinear_periodic(csx as f32, csy as f32);
+
+                // 2. Sample terrain properties from coarse analysis (same
+                // warped position so amplitude/orientation follow the
+                // displaced coarse terrain coherently).
+                let slope_mag = slope_map.sample_bilinear_periodic(csx as f32, csy as f32);
+                let slope_dir = direction_map.sample_bilinear_periodic(csx as f32, csy as f32);
 
                 // 3. Compute amplitude modulation
                 let altitude_factor =

--- a/crates/ymir-core/src/terrain/upscale.rs
+++ b/crates/ymir-core/src/terrain/upscale.rs
@@ -151,11 +151,22 @@ pub fn upscale_with_fbm(
     // Precompute slope and direction on the coarse grid
     let (slope_map, direction_map) = compute_terrain_analysis(coarse);
 
-    // Base frequency: one cycle per source cell, calibrated against the
-    // longer source axis so the noise wavelength in physical units is
-    // identical on both axes regardless of orientation (on a square grid
-    // this is unchanged since src_w == src_h).
-    let freq = config.base_frequency / (src_w.max(src_h) as f64);
+    // #151: RESOLUTION-INDEPENDENT noise frequency. The FBM is sampled in
+    // COARSE-CELL coordinate space (`sx, sy`), NOT target-pixel space, so
+    // the noise feature size is fixed relative to the terrain regardless of
+    // `target_size`. (Previously `freq = base/src_w` applied to the TARGET
+    // pixel index → the feature count scaled with the upscale ratio, e.g.
+    // 4× finer at 4096² than 1024² for the same config — see #151.)
+    //
+    // The coefficients reference the prior 1024² calibration
+    // (`NOISE_REF_TARGET`) so that a 1024² render is BYTE-IDENTICAL to
+    // pre-#151 (old `i·base/src` ≡ `sx·nscale` when `target == 1024`); all
+    // other target sizes now match the 1024² feature size instead of
+    // diverging.
+    const NOISE_REF_TARGET: f64 = 1024.0;
+    let src_max = src_w.max(src_h) as f64;
+    let nscale = config.base_frequency * NOISE_REF_TARGET / (src_max * src_max);
+    let ascale = ANGLE_PERTURBATION_FREQ * NOISE_REF_TARGET / src_max;
 
     // Process each output row in parallel
     let row_data: Vec<(Vec<f32>, Vec<f32>)> = (0..dst_h)
@@ -215,23 +226,26 @@ pub fn upscale_with_fbm(
                 // 5. Blend factor: isotropic at low slopes, anisotropic at high slopes
                 let aniso_blend = smoothstep(slope_f64, ISOTROPY_LOW, ISOTROPY_HIGH);
 
-                // 6. Angular perturbation to break long-range parallelism
+                // 6. Angular perturbation to break long-range parallelism.
+                // #151: sampled in coarse-cell space (sx·ascale) →
+                // resolution-independent, byte-identical at 1024².
                 let angle_offset = angle_noise.sample(
                     0,
-                    i as f64 * ANGLE_PERTURBATION_FREQ,
-                    j as f64 * ANGLE_PERTURBATION_FREQ,
+                    sx * ascale,
+                    sy * ascale,
                 ) * ANGLE_PERTURBATION_MAX;
                 let perturbed_dir = slope_dir as f64 + angle_offset;
 
-                // 7. Domain warping: distort noise coordinates to break regular patterns
-                let raw_nx = i as f64 * freq;
-                let raw_ny = j as f64 * freq;
+                // 7. Domain warping: distort noise coordinates to break regular
+                // patterns. #151: all in coarse-cell space (sx·nscale).
+                let raw_nx = sx * nscale;
+                let raw_ny = sy * nscale;
 
                 let (nx, ny) = if config.domain_warp_strength > 0.0 {
-                    let warp_freq = freq * config.domain_warp_frequency;
-                    let wx = i as f64 * warp_freq;
-                    let wy = j as f64 * warp_freq;
-                    let inv_freq = config.domain_warp_strength / freq;
+                    let warp_freq = nscale * config.domain_warp_frequency;
+                    let wx = sx * warp_freq;
+                    let wy = sy * warp_freq;
+                    let inv_freq = config.domain_warp_strength / nscale;
                     let warp_dx = warp_noise_x.fbm(
                         wx,
                         wy,

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -817,6 +817,43 @@ fn block_mean_to_64_dim(get: &dyn Fn(usize, usize) -> f64, grid: usize) -> Vec<f
     block_mean_to_64(get, grid)
 }
 
+/// #151 PRODUCTION combined export — coast warp + coastal amplitude taper
+/// + mountain amplitude, the full recommended HD config, on the seed set.
+#[test]
+#[ignore]
+fn export_hd_production() {
+    let dir = output_dir().join("hd_production");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let seeds: [u64; 7] = [2, 42, 99, 1337, 1988, 2026, 4138];
+    let cfg = FbmUpscaleConfig {
+        target_size: 2048,
+        coast_warp_strength: 0.8,
+        coast_warp_frequency: 0.5,
+        coastal_amplitude_band: 0.06,
+        amplitude_base: 0.16,
+        ..Default::default()
+    };
+    eprintln!("#151 HD production export — warp 0.8 + band 0.06 + amp 0.16, 2048²");
+    for &seed in &seeds {
+        let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300,
+            dx: 1.0 / 64.0, dy: 1.0 / 64.0,
+            iso_config: iso_config.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let up = upscale_from_c1(
+            &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &cfg,
+        );
+        save_heightmap01(&up.heightmap, &dir.join(format!("hd_seed{seed:05}.png")));
+        eprintln!("  seed {seed:>5} done");
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
 /// #151 border-FBM artefact PIN — the FBM streaks the interior near the
 /// coast (directional ridges shooting inland). Hypothesis: the coast's
 /// extreme coarse-step slope drives FULL anisotropy + slope-amplified

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -817,6 +817,56 @@ fn block_mean_to_64_dim(get: &dyn Fn(usize, usize) -> f64, grid: usize) -> Vec<f
     block_mean_to_64(get, grid)
 }
 
+/// #151 coastline-warp variants — does displacing the coarse-altitude
+/// sampling (`coast_warp_strength`, in coarse cells) break the blocky
+/// 64² coastline (STEP-1 fix)? Eye-judged: credible meander vs
+/// procedural-fake regular ripples. All via the contract `upscale_from_c1`.
+#[test]
+#[ignore]
+fn export_coast_warp() {
+    let dir = output_dir().join("coast_warp");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let seeds: [u64; 2] = [42, 1988];
+    // Isolate the coast warp: amplitude/damping at defaults; vary only
+    // coast_warp_strength (coarse cells). 0.0 = baseline (blocky).
+    let strengths: [(&str, f64); 4] = [
+        ("off", 0.0),
+        ("c05", 0.5),
+        ("c08", 0.8),
+        ("c12", 1.2),
+    ];
+    eprintln!("#151 coastline warp — seeds {seeds:?}, coast_warp_strength sweep (coarse cells)");
+    for &seed in &seeds {
+        let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true,
+            n_steps: 300,
+            dx: 1.0 / 64.0,
+            dy: 1.0 / 64.0,
+            iso_config: iso_config.clone(),
+            drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        for (tag, strength) in &strengths {
+            let cfg = FbmUpscaleConfig {
+                target_size: 1024,
+                coast_warp_strength: *strength,
+                ..Default::default()
+            };
+            let up = upscale_from_c1(
+                &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &cfg,
+            );
+            save_heightmap01(&up.heightmap, &dir.join(format!("coast_seed{seed:05}_{tag}.png")));
+        }
+        eprintln!("  seed {seed} done");
+    }
+    eprintln!("  out = {}", dir.display());
+    eprintln!("  EYE: coast meanders credibly (real-coast irregular) vs procedural-fake ripples?");
+}
+
 /// Quick HD EXPORT — see the final product (no UI). Runs C1 production
 /// (64², rigid, full closures) then `upscale_from_c1` (THE contract
 /// function — laundered altitude, NOT raw S̃) → 1024² HD heightmap PNG,

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -817,6 +817,54 @@ fn block_mean_to_64_dim(get: &dyn Fn(usize, usize) -> f64, grid: usize) -> Vec<f
     block_mean_to_64(get, grid)
 }
 
+/// #151 coastline warp at the TARGET resolution (4096²) — see the
+/// product the eye will actually judge. Seed 1988, off / 0.8 / 1.2 coast
+/// warp (isolated), plus 0.8 + raised amplitude (full-product look).
+#[test]
+#[ignore]
+fn export_coast_warp_4096() {
+    let dir = output_dir().join("coast_warp_4096");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let seed = 1988u64;
+    let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
+    let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+    let closures = C1Closures::default();
+    let config = C1TimeLoopConfig {
+        rigid_continental_crust: true,
+        n_steps: 300,
+        dx: 1.0 / 64.0,
+        dy: 1.0 / 64.0,
+        iso_config: iso_config.clone(),
+        drainage_max_distance: 30,
+    };
+    run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+    let variants: [(&str, f64, f64); 4] = [
+        // tag, coast_warp_strength, amplitude_base
+        ("off", 0.0, 0.08),
+        ("c08", 0.8, 0.08),
+        ("c12", 1.2, 0.08),
+        ("c08_amp", 0.8, 0.16),
+    ];
+    eprintln!("#151 coast warp @ 4096² (seed {seed}) — 0.8 coarse cell ≈ 51 px at this res");
+    for (tag, strength, amp) in &variants {
+        let cfg = FbmUpscaleConfig {
+            target_size: 4096,
+            coast_warp_strength: *strength,
+            amplitude_base: *amp,
+            ..Default::default()
+        };
+        let t0 = std::time::Instant::now();
+        let up = upscale_from_c1(
+            &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &cfg,
+        );
+        save_heightmap01(&up.heightmap, &dir.join(format!("coast4096_{tag}.png")));
+        eprintln!("  [{tag:>7}] {}² in {:.2?}", up.heightmap.width, t0.elapsed());
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
 /// #151 coastline-warp variants — does displacing the coarse-altitude
 /// sampling (`coast_warp_strength`, in coarse cells) break the blocky
 /// 64² coastline (STEP-1 fix)? Eye-judged: credible meander vs

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -920,6 +920,43 @@ fn coast_palette_check() {
     eprintln!("  out = {}", dir.display());
 }
 
+/// #151 coast-warp strength sweep — with FBM removed from the coast
+/// (band 0.30) the warp carries the coastline irregularity alone, so it
+/// reads lighter; sweep stronger warp to restore an irregular coast
+/// (watch for fragmentation). Production-ish config, 2048².
+#[test]
+#[ignore]
+fn export_warp_sweep() {
+    let dir = output_dir().join("warp_sweep");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    for &seed in &[1988u64, 2] {
+        let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300,
+            dx: 1.0 / 64.0, dy: 1.0 / 64.0,
+            iso_config: iso_config.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        for warp in [0.8_f64, 1.2, 1.6, 2.0] {
+            let cfg = FbmUpscaleConfig {
+                target_size: 2048, coast_warp_strength: warp, coast_warp_frequency: 0.5,
+                coastal_amplitude_band: 0.30, amplitude_base: 0.16, submarine_damping: 0.0,
+                ..Default::default()
+            };
+            let up = upscale_from_c1(
+                &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &cfg,
+            );
+            save_heightmap01(&up.heightmap,
+                &dir.join(format!("warp_seed{seed:05}_{:02}.png", (warp * 10.0) as i32)));
+        }
+        eprintln!("  seed {seed} done");
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
 /// #151 PRODUCTION combined export — coast warp + coastal amplitude taper
 /// + mountain amplitude, the full recommended HD config, on the seed set.
 #[test]
@@ -931,7 +968,7 @@ fn export_hd_production() {
     let seeds: [u64; 7] = [2, 42, 99, 1337, 1988, 2026, 4138];
     let cfg = FbmUpscaleConfig {
         target_size: 2048,
-        coast_warp_strength: 0.8,
+        coast_warp_strength: 1.5, // stronger: FBM no longer roughens the coast (band 0.30)
         coast_warp_frequency: 0.5,
         coastal_amplitude_band: 0.30, // FBM only in highland; all lowland smooth
         amplitude_base: 0.16,

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -946,6 +946,10 @@ fn pin_f3_ocean_lines() {
         };
         run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
 
+        let mut amin = f64::INFINITY; let mut amax = f64::NEG_INFINITY;
+        for &v in state.age.data() { amin = amin.min(v); amax = amax.max(v); }
+        let arange = (amax - amin).max(1e-9);
+
         // (1) Coarse production altitude (Stein-Stein), 64² scaled ×8.
         let alt = c1_production_altitude(&state.s, &state.age, &state.plate_type, &iso_config, &ss);
         save_altitude_scaled(&alt, &dir.join(format!("f3_seed{seed:05}_altitude.png")), 8);
@@ -967,10 +971,16 @@ fn pin_f3_ocean_lines() {
         let alt_med = c1_production_altitude(&state.s, &age_med, &state.plate_type, &iso_config, &ss);
         save_altitude_scaled(&alt_med, &dir.join(format!("f3_seed{seed:05}_altitude_median.png")), 8);
 
+        // Despiked age, SAME normalisation as the before-age, to verify the
+        // median kills ONLY spikes and preserves any legitimate age gradient.
+        let mut aimg2 = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(grid as u32 * 8, grid as u32 * 8);
+        for j in 0..grid { for i in 0..grid {
+            let g = (((age_med.get(i, j) - amin) / arange).clamp(0.0, 1.0) * 255.0) as u8;
+            put_block(&mut aimg2, i, grid - 1 - j, 8, [g, g, g]);
+        }}
+        aimg2.save(dir.join(format!("f3_seed{seed:05}_age_median.png"))).unwrap();
+
         // (2a) Age field, grayscale normalised to its range.
-        let mut amin = f64::INFINITY; let mut amax = f64::NEG_INFINITY;
-        for &v in state.age.data() { amin = amin.min(v); amax = amax.max(v); }
-        let arange = (amax - amin).max(1e-9);
         let mut aimg = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(grid as u32 * 8, grid as u32 * 8);
         for j in 0..grid { for i in 0..grid {
             let g = (((state.age.get(i, j) - amin) / arange) * 255.0) as u8;

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -817,6 +817,77 @@ fn block_mean_to_64_dim(get: &dyn Fn(usize, usize) -> f64, grid: usize) -> Vec<f
     block_mean_to_64(get, grid)
 }
 
+/// Save a native crop with a CONTINUOUS grayscale palette (no
+/// hypsometric color bands), so palette-banding can be told apart from
+/// real height (FBM) variation.
+fn save_gray01_crop(h: &GridF32, x0: usize, y0: usize, size: usize, path: &Path) {
+    let w = (x0 + size).min(h.width) - x0;
+    let ht = (y0 + size).min(h.height) - y0;
+    let mut img = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(w as u32, ht as u32);
+    for jj in 0..ht {
+        for ii in 0..w {
+            let v = h.get((x0 + ii) as i32, (y0 + jj) as i32).clamp(0.0, 1.0);
+            let g = (v * 255.0) as u8;
+            img.put_pixel(ii as u32, (ht - 1 - jj) as u32, Rgb([g, g, g]));
+        }
+    }
+    img.save(path).expect("save gray crop PNG");
+}
+
+/// #151 coastal contour-line PIN — are the faint lines near the coast on
+/// land real FBM height, or hypsometric-PALETTE banding? Render the same
+/// coastal crop in hypsometric vs continuous grayscale. If the lines
+/// vanish in grayscale → palette artefact (cosmetic, not terrain).
+#[test]
+#[ignore]
+fn coast_palette_check() {
+    let dir = output_dir().join("coast_palette");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let seed = 1988u64;
+    let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
+    let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+    let closures = C1Closures::default();
+    let config = C1TimeLoopConfig {
+        rigid_continental_crust: true, n_steps: 300,
+        dx: 1.0 / 64.0, dy: 1.0 / 64.0,
+        iso_config: iso_config.clone(), drainage_max_distance: 30,
+    };
+    run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+    let cfg = FbmUpscaleConfig {
+        target_size: 2048, coast_warp_strength: 0.8, coast_warp_frequency: 0.5,
+        coastal_amplitude_band: 0.06, amplitude_base: 0.16, submarine_damping: 0.0,
+        ..Default::default()
+    };
+    let up = upscale_from_c1(
+        &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &cfg,
+    );
+    // Current config: hypso + gray crops (palette-vs-real check).
+    for (cname, x0, y0) in [("a", 900usize, 1050usize), ("b", 1150, 850), ("c", 600, 1500)] {
+        save_heightmap01_crop(&up.heightmap, x0, y0, 460, &dir.join(format!("coast_{cname}_hypso.png")));
+        save_gray01_crop(&up.heightmap, x0, y0, 460, &dir.join(format!("coast_{cname}_gray.png")));
+    }
+    // Band-width sweep (grayscale crop "a") — does a WIDER coastal taper
+    // suppress the near-coast FBM ripples?
+    for band in [0.06_f64, 0.15, 0.30] {
+        let c2 = FbmUpscaleConfig { coastal_amplitude_band: band, ..cfg.clone() };
+        let u2 = upscale_from_c1(
+            &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &c2,
+        );
+        save_gray01_crop(&u2.heightmap, 900, 1050, 460,
+            &dir.join(format!("band_{:03}_gray.png", (band * 100.0) as i32)));
+    }
+    // Full continents at a few band widths (hypsometric) for the look call.
+    for band in [0.06_f64, 0.20, 0.35] {
+        let c2 = FbmUpscaleConfig { coastal_amplitude_band: band, ..cfg.clone() };
+        let u2 = upscale_from_c1(
+            &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &c2,
+        );
+        save_heightmap01(&u2.heightmap, &dir.join(format!("full_band_{:03}.png", (band * 100.0) as i32)));
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
 /// #151 PRODUCTION combined export — coast warp + coastal amplitude taper
 /// + mountain amplitude, the full recommended HD config, on the seed set.
 #[test]
@@ -830,12 +901,12 @@ fn export_hd_production() {
         target_size: 2048,
         coast_warp_strength: 0.8,
         coast_warp_frequency: 0.5,
-        coastal_amplitude_band: 0.06,
+        coastal_amplitude_band: 0.20, // smooth coastal plains; FBM only inland (mountains)
         amplitude_base: 0.16,
         submarine_damping: 0.0, // no FBM in the ocean (smooth bathymetry)
         ..Default::default()
     };
-    eprintln!("#151 HD production export — warp 0.8 + band 0.06 + amp 0.16 + subdamp 0.0, 2048²");
+    eprintln!("#151 HD production export — warp 0.8 + band 0.20 + amp 0.16 + subdamp 0.0, 2048²");
     for &seed in &seeds {
         let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
         let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -895,9 +895,10 @@ fn export_fbm_2048_isolate() {
     let aniso = std::env::var("FBM_ANISO").ok().and_then(|s| s.parse().ok()).unwrap_or(3.0);
     let sfac = std::env::var("FBM_SLOPEFAC").ok().and_then(|s| s.parse().ok()).unwrap_or(3.0);
     let amp = std::env::var("FBM_AMP").ok().and_then(|s| s.parse().ok()).unwrap_or(0.08);
+    let band = std::env::var("FBM_BAND").ok().and_then(|s| s.parse().ok()).unwrap_or(0.0);
     let cfg = FbmUpscaleConfig {
         target_size: 2048, max_anisotropy: aniso, amplitude_slope_factor: sfac,
-        amplitude_base: amp, ..Default::default()
+        amplitude_base: amp, coastal_amplitude_band: band, ..Default::default()
     };
     let up = upscale_from_c1(
         &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &cfg,

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -832,9 +832,10 @@ fn export_hd_production() {
         coast_warp_frequency: 0.5,
         coastal_amplitude_band: 0.06,
         amplitude_base: 0.16,
+        submarine_damping: 0.0, // no FBM in the ocean (smooth bathymetry)
         ..Default::default()
     };
-    eprintln!("#151 HD production export — warp 0.8 + band 0.06 + amp 0.16, 2048²");
+    eprintln!("#151 HD production export — warp 0.8 + band 0.06 + amp 0.16 + subdamp 0.0, 2048²");
     for &seed in &seeds {
         let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
         let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
@@ -933,9 +934,11 @@ fn export_fbm_2048_isolate() {
     let sfac = std::env::var("FBM_SLOPEFAC").ok().and_then(|s| s.parse().ok()).unwrap_or(3.0);
     let amp = std::env::var("FBM_AMP").ok().and_then(|s| s.parse().ok()).unwrap_or(0.08);
     let band = std::env::var("FBM_BAND").ok().and_then(|s| s.parse().ok()).unwrap_or(0.0);
+    let subdamp = std::env::var("FBM_SUBDAMP").ok().and_then(|s| s.parse().ok()).unwrap_or(0.3);
     let cfg = FbmUpscaleConfig {
         target_size: 2048, max_anisotropy: aniso, amplitude_slope_factor: sfac,
-        amplitude_base: amp, coastal_amplitude_band: band, ..Default::default()
+        amplitude_base: amp, coastal_amplitude_band: band, submarine_damping: subdamp,
+        ..Default::default()
     };
     let up = upscale_from_c1(
         &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &cfg,

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -834,6 +834,34 @@ fn save_gray01_crop(h: &GridF32, x0: usize, y0: usize, size: usize, path: &Path)
     img.save(path).expect("save gray crop PNG");
 }
 
+/// Hillshade crop (Lambert, light from NW) — shows REAL relief without
+/// any palette colour-band artefact. Flat land → uniform mid-gray;
+/// FBM ripples → visible shading. dz exaggerated for visibility.
+fn save_hillshade_crop(h: &GridF32, x0: usize, y0: usize, size: usize, path: &Path) {
+    let w = (x0 + size).min(h.width) - x0;
+    let ht = (y0 + size).min(h.height) - y0;
+    let mut img = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(w as u32, ht as u32);
+    let z = 60.0_f64; // vertical exaggeration
+    let (lx, ly, lz) = {
+        let (a, b, c) = (1.0_f64, 1.0, 2.0);
+        let n = (a * a + b * b + c * c).sqrt();
+        (a / n, b / n, c / n)
+    };
+    for jj in 0..ht {
+        for ii in 0..w {
+            let gx = (x0 + ii) as i32;
+            let gy = (y0 + jj) as i32;
+            let dzdx = (h.get(gx + 1, gy) - h.get(gx - 1, gy)) as f64 * z;
+            let dzdy = (h.get(gx, gy + 1) - h.get(gx, gy - 1)) as f64 * z;
+            let nn = (dzdx * dzdx + dzdy * dzdy + 1.0).sqrt();
+            let shade = ((-dzdx * lx - dzdy * ly + lz) / nn).clamp(0.0, 1.0);
+            let g = (shade * 255.0) as u8;
+            img.put_pixel(ii as u32, (ht - 1 - jj) as u32, Rgb([g, g, g]));
+        }
+    }
+    img.save(path).expect("save hillshade crop PNG");
+}
+
 /// #151 coastal contour-line PIN — are the faint lines near the coast on
 /// land real FBM height, or hypsometric-PALETTE banding? Render the same
 /// coastal crop in hypsometric vs continuous grayscale. If the lines
@@ -844,7 +872,7 @@ fn coast_palette_check() {
     let dir = output_dir().join("coast_palette");
     std::fs::create_dir_all(&dir).expect("create dir");
     let iso_config = IsostasyConfig::c1_default();
-    let seed = 1988u64;
+    let seed = std::env::var("SEED").ok().and_then(|s| s.parse().ok()).unwrap_or(1988u64);
     let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
     let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
     let closures = C1Closures::default();
@@ -854,19 +882,23 @@ fn coast_palette_check() {
         iso_config: iso_config.clone(), drainage_max_distance: 30,
     };
     run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+    let band = std::env::var("FBM_BAND").ok().and_then(|s| s.parse().ok()).unwrap_or(0.20);
     let cfg = FbmUpscaleConfig {
         target_size: 2048, coast_warp_strength: 0.8, coast_warp_frequency: 0.5,
-        coastal_amplitude_band: 0.06, amplitude_base: 0.16, submarine_damping: 0.0,
+        coastal_amplitude_band: band, amplitude_base: 0.16, submarine_damping: 0.0,
         ..Default::default()
     };
     let up = upscale_from_c1(
         &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &cfg,
     );
-    // Current config: hypso + gray crops (palette-vs-real check).
+    // 3-way render of coastal crops: hypso (user's view) vs gray (real
+    // height) vs hillshade (relief, no palette bands).
     for (cname, x0, y0) in [("a", 900usize, 1050usize), ("b", 1150, 850), ("c", 600, 1500)] {
         save_heightmap01_crop(&up.heightmap, x0, y0, 460, &dir.join(format!("coast_{cname}_hypso.png")));
         save_gray01_crop(&up.heightmap, x0, y0, 460, &dir.join(format!("coast_{cname}_gray.png")));
+        save_hillshade_crop(&up.heightmap, x0, y0, 460, &dir.join(format!("coast_{cname}_hill.png")));
     }
+    save_heightmap01(&up.heightmap, &dir.join("full_hypso.png"));
     // Band-width sweep (grayscale crop "a") — does a WIDER coastal taper
     // suppress the near-coast FBM ripples?
     for band in [0.06_f64, 0.15, 0.30] {
@@ -901,12 +933,12 @@ fn export_hd_production() {
         target_size: 2048,
         coast_warp_strength: 0.8,
         coast_warp_frequency: 0.5,
-        coastal_amplitude_band: 0.20, // smooth coastal plains; FBM only inland (mountains)
+        coastal_amplitude_band: 0.30, // FBM only in highland; all lowland smooth
         amplitude_base: 0.16,
         submarine_damping: 0.0, // no FBM in the ocean (smooth bathymetry)
         ..Default::default()
     };
-    eprintln!("#151 HD production export — warp 0.8 + band 0.20 + amp 0.16 + subdamp 0.0, 2048²");
+    eprintln!("#151 HD production export — warp 0.8 + band 0.30 + amp 0.16 + subdamp 0.0, 2048²");
     for &seed in &seeds {
         let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
         let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -817,6 +817,56 @@ fn block_mean_to_64_dim(get: &dyn Fn(usize, usize) -> f64, grid: usize) -> Vec<f
     block_mean_to_64(get, grid)
 }
 
+/// #151 border-FBM artefact PIN — the FBM streaks the interior near the
+/// coast (directional ridges shooting inland). Hypothesis: the coast's
+/// extreme coarse-step slope drives FULL anisotropy + slope-amplified
+/// amplitude → long ridges along the coast-normal. Counterfactual:
+/// disable anisotropy (max_anisotropy=1) and/or the slope amplitude
+/// boost (amplitude_slope_factor=0) — does the border streaking vanish?
+#[test]
+#[ignore]
+fn export_border_fbm_pin() {
+    let dir = output_dir().join("border_fbm");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let seed = 1988u64;
+    let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
+    let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+    let closures = C1Closures::default();
+    let config = C1TimeLoopConfig {
+        rigid_continental_crust: true, n_steps: 300,
+        dx: 1.0 / 64.0, dy: 1.0 / 64.0,
+        iso_config: iso_config.clone(), drainage_max_distance: 30,
+    };
+    run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+    // Match the fbm2048 case the artefact was reported in (no coast warp,
+    // default amplitude); vary only the slope-driven FBM terms. 1024² for
+    // viewability.
+    let base = FbmUpscaleConfig {
+        target_size: 1024, coast_warp_strength: 0.0, amplitude_base: 0.08,
+        ..Default::default()
+    };
+    let variants: [(&str, f64, f64); 4] = [
+        // tag, max_anisotropy, amplitude_slope_factor
+        ("default", 3.0, 3.0),
+        ("aniso1", 1.0, 3.0),     // isotropic → streaks gone?
+        ("slopefac0", 3.0, 0.0),  // no slope amplitude boost
+        ("both", 1.0, 0.0),       // both off
+    ];
+    eprintln!("#151 border-FBM pin (seed {seed}) — aniso/slope-boost counterfactual");
+    for (tag, aniso, sfac) in &variants {
+        let cfg = FbmUpscaleConfig {
+            max_anisotropy: *aniso, amplitude_slope_factor: *sfac, ..base.clone()
+        };
+        let up = upscale_from_c1(
+            &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &cfg,
+        );
+        save_heightmap01(&up.heightmap, &dir.join(format!("border_{tag}.png")));
+        eprintln!("  {tag}: aniso={aniso} slope_factor={sfac}");
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
 /// #151 v2 re-validation — render the upscale at v2's DEFAULT workflow
 /// target (2048²) with DEFAULT config (no coast warp) to isolate the FBM
 /// frequency change. Run before vs after the FBM recalibration (swap
@@ -841,14 +891,26 @@ fn export_fbm_2048_isolate() {
     };
     run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
     // Default config (coast_warp off) at v2's default target 2048².
-    let cfg = FbmUpscaleConfig { target_size: 2048, ..Default::default() };
+    // FBM_ANISO env overrides max_anisotropy (counterfactual: 1 = isotropic).
+    let aniso = std::env::var("FBM_ANISO").ok().and_then(|s| s.parse().ok()).unwrap_or(3.0);
+    let sfac = std::env::var("FBM_SLOPEFAC").ok().and_then(|s| s.parse().ok()).unwrap_or(3.0);
+    let amp = std::env::var("FBM_AMP").ok().and_then(|s| s.parse().ok()).unwrap_or(0.08);
+    let cfg = FbmUpscaleConfig {
+        target_size: 2048, max_anisotropy: aniso, amplitude_slope_factor: sfac,
+        amplitude_base: amp, ..Default::default()
+    };
     let up = upscale_from_c1(
         &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &cfg,
     );
     // Filename tag from an env var so before/after runs don't clobber.
     let tag = std::env::var("FBM_TAG").unwrap_or_else(|_| "x".into());
     save_heightmap01(&up.heightmap, &dir.join(format!("fbm2048_{tag}.png")));
-    eprintln!("  fbm2048_{tag}: {}²", up.heightmap.width);
+    // Native-resolution crops (no downscale) so fine anisotropic streaks
+    // are visible. 384² windows over the bridge/peninsula + lower interior.
+    for (cname, x0, y0) in [("bridge", 820usize, 760usize), ("lower", 520, 1180), ("lowedge", 640, 1560)] {
+        save_heightmap01_crop(&up.heightmap, x0, y0, 384, &dir.join(format!("crop_{cname}_{tag}.png")));
+    }
+    eprintln!("  fbm2048_{tag}: {}² (+3 native crops)", up.heightmap.width);
 }
 
 /// #151 coastline warp at the TARGET resolution (4096²) — see the
@@ -1025,6 +1087,22 @@ fn export_hd_upscaled() {
         }
     }
     eprintln!("  out = {} (cost note: 1024² ~per above; 4096² ≈ 16× the FBM)", dir.display());
+}
+
+/// Save a native-resolution `size×size` crop of a `[0,1]` heightmap at
+/// `(x0,y0)` (1:1, no scaling) so fine detail (anisotropic streaks) is
+/// visible without Read's downscaling.
+fn save_heightmap01_crop(h: &GridF32, x0: usize, y0: usize, size: usize, path: &Path) {
+    let w = (x0 + size).min(h.width) - x0;
+    let ht = (y0 + size).min(h.height) - y0;
+    let mut img = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(w as u32, ht as u32);
+    for jj in 0..ht {
+        for ii in 0..w {
+            let v = h.get((x0 + ii) as i32, (y0 + jj) as i32).clamp(0.0, 1.0);
+            img.put_pixel(ii as u32, (ht - 1 - jj) as u32, Rgb(hypsometric(v, 0.5)));
+        }
+    }
+    img.save(path).expect("save crop PNG");
 }
 
 /// Render a normalised `[0,1]` heightmap (sea at 0.5) with the

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -54,7 +54,8 @@ use ymir_core::tectonics_v2::boundaries::plate_type::PlateType;
 use ymir_core::tectonics_v2::field::Field2D;
 use ymir_core::seed::WorldSeed;
 use ymir_core::terrain::upscale::FbmUpscaleConfig;
-use ymir_core::tectonics_c1::production_upscale::upscale_from_c1;
+use ymir_core::tectonics_c1::production_upscale::{c1_production_altitude, upscale_from_c1};
+use ymir_core::tectonics_c1::closures::oceanic_bathymetry::SteinSteinParams;
 
 const GRID_SIZE: usize = 64;
 const N_STEPS: usize = 300;
@@ -916,6 +917,83 @@ fn coast_palette_check() {
             &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &c2,
         );
         save_heightmap01(&u2.heightmap, &dir.join(format!("full_band_{:03}.png", (band * 100.0) as i32)));
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
+/// F3 PIN — the dark dotted lines in the OCEAN. Render, at the COARSE
+/// 64² resolution (pre-upscale), the production altitude (Stein-Stein
+/// bathymetry), the age field, and the plate boundaries, to test:
+/// (1) are the dark lines already in the coarse altitude (→ Stein-Stein,
+/// not the upscale)? (2) do they coincide with age discontinuities /
+/// plate boundaries (→ age-jump → depth-jump)?
+#[test]
+#[ignore]
+fn pin_f3_ocean_lines() {
+    let dir = output_dir().join("f3_pin");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    for &seed in &[4138u64, 2] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300,
+            dx: 1.0 / grid as f64, dy: 1.0 / grid as f64,
+            iso_config: iso_config.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+        // (1) Coarse production altitude (Stein-Stein), 64² scaled ×8.
+        let alt = c1_production_altitude(&state.s, &state.age, &state.plate_type, &iso_config, &ss);
+        save_altitude_scaled(&alt, &dir.join(format!("f3_seed{seed:05}_altitude.png")), 8);
+
+        // Counterfactual: 3×3 MEDIAN-filtered age → despikes the
+        // pile-up cells, then Stein-Stein. Do the dark dots vanish?
+        let mut age_med = state.age.clone();
+        for j in 0..grid { for i in 0..grid {
+            let mut nb: Vec<f64> = Vec::with_capacity(9);
+            for dj in -1i32..=1 { for di in -1i32..=1 {
+                let (ni, nj) = (i as i32 + di, j as i32 + dj);
+                if ni>=0 && nj>=0 && (ni as usize)<grid && (nj as usize)<grid {
+                    nb.push(state.age.get(ni as usize, nj as usize));
+                }
+            }}
+            nb.sort_by(|a,b| a.partial_cmp(b).unwrap());
+            age_med.set(i, j, nb[nb.len()/2]);
+        }}
+        let alt_med = c1_production_altitude(&state.s, &age_med, &state.plate_type, &iso_config, &ss);
+        save_altitude_scaled(&alt_med, &dir.join(format!("f3_seed{seed:05}_altitude_median.png")), 8);
+
+        // (2a) Age field, grayscale normalised to its range.
+        let mut amin = f64::INFINITY; let mut amax = f64::NEG_INFINITY;
+        for &v in state.age.data() { amin = amin.min(v); amax = amax.max(v); }
+        let arange = (amax - amin).max(1e-9);
+        let mut aimg = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(grid as u32 * 8, grid as u32 * 8);
+        for j in 0..grid { for i in 0..grid {
+            let g = (((state.age.get(i, j) - amin) / arange) * 255.0) as u8;
+            put_block(&mut aimg, i, grid - 1 - j, 8, [g, g, g]);
+        }}
+        aimg.save(dir.join(format!("f3_seed{seed:05}_age.png"))).unwrap();
+
+        // (2b) Plate boundaries (cell 4-adjacent to a different plate_id) in red over ocean.
+        let idx = |i: usize, j: usize| state.plate_id.get(i, j);
+        let mut bimg = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(grid as u32 * 8, grid as u32 * 8);
+        for j in 0..grid { for i in 0..grid {
+            let mut bnd = false;
+            for (di, dj) in [(-1i32,0i32),(1,0),(0,-1),(0,1)] {
+                let (ni, nj) = (i as i32 + di, j as i32 + dj);
+                if ni>=0 && nj>=0 && (ni as usize)<grid && (nj as usize)<grid
+                    && idx(ni as usize, nj as usize) != idx(i, j) { bnd = true; }
+            }
+            let oceanic = matches!(state.plate_type.get(i,j), PlateType::Oceanic);
+            let col = if bnd { [255,0,0] } else if oceanic { [40,80,160] } else { [60,130,60] };
+            put_block(&mut bimg, i, grid - 1 - j, 8, col);
+        }}
+        bimg.save(dir.join(format!("f3_seed{seed:05}_bounds.png"))).unwrap();
+        eprintln!("  seed {seed}: age range [{amin:.3},{amax:.3}]");
     }
     eprintln!("  out = {}", dir.display());
 }

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -817,6 +817,40 @@ fn block_mean_to_64_dim(get: &dyn Fn(usize, usize) -> f64, grid: usize) -> Vec<f
     block_mean_to_64(get, grid)
 }
 
+/// #151 v2 re-validation — render the upscale at v2's DEFAULT workflow
+/// target (2048²) with DEFAULT config (no coast warp) to isolate the FBM
+/// frequency change. Run before vs after the FBM recalibration (swap
+/// upscale.rs) to judge v2's calibration at its real target.
+#[test]
+#[ignore]
+fn export_fbm_2048_isolate() {
+    let dir = output_dir().join("fbm_2048");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let seed = 1988u64;
+    let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
+    let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+    let closures = C1Closures::default();
+    let config = C1TimeLoopConfig {
+        rigid_continental_crust: true,
+        n_steps: 300,
+        dx: 1.0 / 64.0,
+        dy: 1.0 / 64.0,
+        iso_config: iso_config.clone(),
+        drainage_max_distance: 30,
+    };
+    run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+    // Default config (coast_warp off) at v2's default target 2048².
+    let cfg = FbmUpscaleConfig { target_size: 2048, ..Default::default() };
+    let up = upscale_from_c1(
+        &state, &iso_config, &closures.oceanic_bathymetry, &WorldSeed::new(seed), &cfg,
+    );
+    // Filename tag from an env var so before/after runs don't clobber.
+    let tag = std::env::var("FBM_TAG").unwrap_or_else(|_| "x".into());
+    save_heightmap01(&up.heightmap, &dir.join(format!("fbm2048_{tag}.png")));
+    eprintln!("  fbm2048_{tag}: {}²", up.heightmap.width);
+}
+
 /// #151 coastline warp at the TARGET resolution (4096²) — see the
 /// product the eye will actually judge. Seed 1988, off / 0.8 / 1.2 coast
 /// warp (isolated), plus 0.8 + raised amplitude (full-product look).

--- a/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
+++ b/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
@@ -137,9 +137,18 @@ bends the contour (macro irregularity), the taper stops the FBM
 micro-feathering at it.
 
 ## Recommended production setting
-`coast_warp_strength ≈ 0.8`, `coast_warp_frequency = 0.5`,
+`coast_warp_strength ≈ 1.5`, `coast_warp_frequency = 0.5`,
 `coastal_amplitude_band ≈ 0.30`, `amplitude_base ≈ 0.16`,
 **`submarine_damping = 0.0`** for the C1 HD export.
+
+(`coast_warp_strength` 0.8 → **1.5**: with FBM removed from the coast (band 0.30),
+the warp carries the coastline irregularity ALONE → 0.8 read too light/smooth.
+Sweep {0.8, 1.2, 1.6, 2.0}: 1.2–1.6 give a natural irregular coast, 2.0 gets
+busy/spiky; **1.5** chosen. Verified across geometries — seeds 1988, 2
+(high-relief), 42 (modest), 4138 (islands): irregular natural coasts, NO
+fragmentation, smooth coastal plains, rugged mountains preserved. The two coast
+levers are now correctly balanced: the warp does the macro irregularity, the
+band keeps the plains smooth.)
 
 (`coastal_amplitude_band` 0.20 → **0.30**: a 3rd reported pass showed faint
 reddish contour lines on the near-coast land. **Decisive attribution** — a

--- a/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
+++ b/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
@@ -74,6 +74,29 @@ visibly finer. Upscale lib tests green (default-off / 1024-identical).
 corrected) → re-validate v2 visually before relying on it; no v2 test asserts
 exact pixels.
 
+## v2 re-validation (the FBM fix touches shared code)
+
+v2 consumers of `upscale_with_fbm`: v2 viz (target = actual heightmap dims,
+dropdown) and v2 workflow `phase_b` (`hd_grid_size`, **default 2048**,
+workflow/mod.rs:211). So v2's default target is **2048²**, not 1024² — the fix
+DOES change v2's default output (the pre-existing resolution-dependence bug
+affected v2 too). `export_fbm_2048_isolate`, seed 1988, default config (coast
+warp off, to isolate the FBM), rendered before vs after by swapping `upscale.rs`:
+
+- **before (pre-fix) @2048²:** interior FBM slightly finer/granular (2× the
+  1024 cycle count — the bug).
+- **after (fixed) @2048²:** interior slightly smoother/broader = the
+  1024-referenced feature size; **well-formed, well-calibrated continent**
+  (amplitude/aniso/gradient read correctly).
+
+**Verdict: v2 IMPROVED / NEUTRAL.** The fix gives resolution-consistency; at
+the 2048² default it is a subtle, benign coarsening (2×), NOT a calibration
+derangement. v2's calibration was not critically relying on the
+resolution-dependent fineness. Residual (non-blocking): this isolation used a
+C1 coarse + default params (the FBM feature-size change is source/param-
+independent); a v2-NATIVE before/after at 2048² would be the gold-standard
+confirmation before relying on v2 at non-1024 targets in production.
+
 ## Recommended production setting
 `coast_warp_strength ≈ 0.8`, `coast_warp_frequency = 0.5` for the C1 HD export.
 Kept OFF by default in `FbmUpscaleConfig` (byte-identical / v2-safe); the C1

--- a/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
+++ b/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
@@ -124,10 +124,21 @@ LOCAL near-sea-level amplitude taper — `amplitude *= smoothstep(|base_height �
 sea_level|, 0, coastal_band)` → FBM ≈ 0 at the coast (no feathering), full
 inland (mountains preserved). The coast warp supplies the macro coast
 irregularity; this removes the micro-feathering. `coastal_band` ~0.05–0.1
-altitude, to scope/measure. (Surface W7 before coding.)
+altitude.
+
+**FIX DONE + validated** (`coastal_amplitude_band`, opt-in, default 0.0 =
+byte-identical / v2-safe; upscale lib tests green). Native-res crops, band
+sweep {0, 0.06, 0.12}: **band 0.06 removes the coastal feathering** (coastline
+back to a clean contour) while the interior mountain texture is **fully
+preserved** (local taper — `smoothstep(|h−sea|,0,band)` = 1 beyond the band, so
+inland relief is untouched). band 0.12 also clean (slightly wider flat coastal
+strip). Recommend **~0.06** (gentler). Complements the coast warp: the warp
+bends the contour (macro irregularity), the taper stops the FBM
+micro-feathering at it.
 
 ## Recommended production setting
-`coast_warp_strength ≈ 0.8`, `coast_warp_frequency = 0.5` for the C1 HD export.
-Kept OFF by default in `FbmUpscaleConfig` (byte-identical / v2-safe); the C1
-production HD path opts in. Wiring the default into the C1 production upscale
-config is a product decision (deferred with the rest of the HD/UI wiring).
+`coast_warp_strength ≈ 0.8`, `coast_warp_frequency = 0.5`,
+`coastal_amplitude_band ≈ 0.06` for the C1 HD export. All kept OFF/0 by default
+in `FbmUpscaleConfig` (byte-identical / v2-safe); the C1 production HD path opts
+in. Wiring these defaults into the C1 production upscale config is a product
+decision (deferred with the rest of the HD/UI wiring).

--- a/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
+++ b/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
@@ -97,6 +97,35 @@ C1 coarse + default params (the FBM feature-size change is source/param-
 independent); a v2-NATIVE before/after at 2048² would be the gold-standard
 confirmation before relying on v2 at non-1024 targets in production.
 
+## Border-feathering artefact (#151) — cause PINNED
+
+User report: the FBM "deforms the interior near the border" (directional
+combing at the coast); macro border + coast warp OK, mountains OK. Native-res
+crops (`export_fbm_2048_isolate` + `save_heightmap01_crop`, the artefact is
+invisible under Read's downscaling) confirm: a feathered/combed coastline,
+worst on the thin near-sea-level bridge/peninsula.
+
+Counterfactual pinning (2048², seed 1988, env-driven):
+- `max_anisotropy = 1` (isotropic): **still feathered** → NOT anisotropy.
+- `amplitude_slope_factor = 0` (no slope boost): **still feathered** → NOT the
+  slope-amplified amplitude.
+- `amplitude_base 0.08 → 0.02`: **feathering nearly gone** → the **base FBM
+  amplitude crossing the sea-level contour** is the cause.
+
+Mechanism: `final = base_height + amplitude·noise`; near the sea-level contour
+`±amplitude·noise` flips cells land↔ocean → a feathered coast. Worst where the
+coarse altitude is FLAT and near sea level (the bridge): no relief to anchor
+against, so the whole low region is FBM-dominated. Strong-relief interior
+(mountains) is barely perturbed → "mountains OK". `submarine_damping` only
+damps BELOW sea level, not the near-sea-level band on the land side.
+
+**Fix direction (NOT global amplitude — that flattens mountains too):** a
+LOCAL near-sea-level amplitude taper — `amplitude *= smoothstep(|base_height −
+sea_level|, 0, coastal_band)` → FBM ≈ 0 at the coast (no feathering), full
+inland (mountains preserved). The coast warp supplies the macro coast
+irregularity; this removes the micro-feathering. `coastal_band` ~0.05–0.1
+altitude, to scope/measure. (Surface W7 before coding.)
+
 ## Recommended production setting
 `coast_warp_strength ≈ 0.8`, `coast_warp_frequency = 0.5` for the C1 HD export.
 Kept OFF by default in `FbmUpscaleConfig` (byte-identical / v2-safe); the C1

--- a/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
+++ b/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
@@ -1,0 +1,39 @@
+# Coastline warp (#151 follow-up) — STEP-1 fix, eye-validated
+
+Cause was pinned to STEP 1 (`stage_hd_export.md`): the sea-level contour
+follows the bilinear-interpolated 64² altitude; the domain warp only warps the
+NOISE, never the coarse sampling. **Fix (piste 1):** displace the
+COARSE-ALTITUDE sampling coords `(sx,sy)` before `sample_bilinear_periodic`,
+in coarse-pixel units, so the contour meanders.
+
+## Implementation (minimal, reuse, opt-in)
+`FbmUpscaleConfig.coast_warp_strength` (coarse cells) + `coast_warp_frequency`
+(cycles/coarse pixel). Dedicated coast-warp FBM (distinct seeds from the
+noise/domain-warp). Applied to the sampling position of `base_height` + slope +
+direction (coherent). **Default 0.0 = OFF = byte-identical** (the v2 pipeline
+is unaffected). The domain warp (noise) is untouched.
+
+## Eye verdict (the judge — credible meander vs procedural-fake)
+`export_coast_warp`, seeds 42 + 1988, strength sweep {0, 0.5, 0.8, 1.2} coarse
+cells, 1024²:
+
+- **off (0.0):** the blocky 64² stairstep coast (axis-aligned 90° steps).
+- **0.8 (sweet spot):** the stairstep is broken into an **irregular,
+  credibly-meandering coast** on BOTH seeds — FBM-irregular, NOT regular
+  procedural ripples (passes the "not fake" bar; real coasts are irregular).
+  No fragmentation; continents stay connected.
+- **1.2:** more meander but starts to **over-warp** — a few coastal cells
+  detach into pixel-scale fragments. Past the useful range.
+
+**Verdict: piste 1 works.** A coast warp of ~0.8 coarse cells dissolves the
+64² stairstep into a credible irregular coastline, eye-confirmed on two seeds,
+without fragmentation. The displacement is ~0.8 coarse cells ≈ 13 px at 1024²,
+which breaks the ~16 px stairstep. Honest bound: this fixes the PLATE-SCALE
+coast geometry; sub-~13 px coastal filigree would need finer warp octaves or a
+finer base — but the blocky-coast complaint (the #1 HD flaw) is resolved.
+
+## Recommended production setting
+`coast_warp_strength ≈ 0.8`, `coast_warp_frequency = 0.5` for the C1 HD export.
+Kept OFF by default in `FbmUpscaleConfig` (byte-identical / v2-safe); the C1
+production HD path opts in. Wiring the default into the C1 production upscale
+config is a product decision (deferred with the rest of the HD/UI wiring).

--- a/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
+++ b/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
@@ -50,6 +50,30 @@ finer base — but the blocky-coast complaint (the #1 HD flaw) is resolved.
   **resolution-dependent**: 1.2 fragments at 1024² but is clean + more natural
   at 4096².
 
+## FBM resolution-calibration fix (#151) — the FBM was target-pixel-based
+
+Surfaced by the 4096² render: the SAME config gave a **4× finer** interior FBM
+at 4096² than 1024². Cause (pre-existing, NOT the coast warp): the noise was
+sampled in TARGET-pixel space — `freq = base/src_w; nx = i·freq` (i = target
+pixel) → the FBM cycle count across the image = `(dst/src)·base`, scaling with
+`target_size`. The coast warp was already coarse-cell-based (resolution-OK);
+only the interior FBM was miscalibrated.
+
+**Fix:** sample ALL noise (base FBM, domain warp, angle perturbation) in
+COARSE-CELL space (`sx·nscale`, `nscale = base·NOISE_REF_TARGET/src²`,
+`NOISE_REF_TARGET = 1024`). The feature size is now fixed relative to the
+terrain, independent of `target_size`. Coefficients reference the prior 1024²
+calibration so **1024² is byte-identical to pre-#151** (`sx·nscale ≡ i·freq`
+when `target == 1024`; warp off by default) — v2@1024 unaffected; other target
+sizes now MATCH the 1024² feature size instead of diverging.
+
+**Verified:** post-fix, c08 at 1024² and 4096² show the same world at the same
+relative feature size (broad mottled interior at both); pre-fix 4096² was
+visibly finer. Upscale lib tests green (default-off / 1024-identical).
+**v2 impact:** v2 renders at a non-1024 target would change (resolution-
+corrected) → re-validate v2 visually before relying on it; no v2 test asserts
+exact pixels.
+
 ## Recommended production setting
 `coast_warp_strength ≈ 0.8`, `coast_warp_frequency = 0.5` for the C1 HD export.
 Kept OFF by default in `FbmUpscaleConfig` (byte-identical / v2-safe); the C1

--- a/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
+++ b/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
@@ -32,6 +32,24 @@ which breaks the ~16 px stairstep. Honest bound: this fixes the PLATE-SCALE
 coast geometry; sub-~13 px coastal filigree would need finer warp octaves or a
 finer base — but the blocky-coast complaint (the #1 HD flaw) is resolved.
 
+## At the TARGET resolution (4096², seed 1988 — `export_coast_warp_4096`)
+
+~1.7 s per 4096² render. 0.8 coarse cells ≈ 51 px here.
+
+- **off:** even MORE glaring than at 1024² — clean ~64 px axis-aligned
+  stairstep blocks. Unacceptable at target res. Confirms the fix is necessary,
+  not cosmetic.
+- **c08 (+ amplitude 0.16):** credible continent — irregular meandering coast
+  (no axis-aligned steps) + rugged mountain interior. Residual: some
+  large-scale 64²-polygon straightness remains (the warp wobbles the broad
+  shape rather than redrawing it). Plate-scale-acceptable; reads as a real
+  coast at this zoom.
+- **c12:** stronger meander, breaks the residual large-scale straightness MORE,
+  and — unlike at 1024² — shows **no fragmentation** at 4096² (finer pixels
+  render the displaced coastal cells smoothly). So warp tolerance is
+  **resolution-dependent**: 1.2 fragments at 1024² but is clean + more natural
+  at 4096².
+
 ## Recommended production setting
 `coast_warp_strength ≈ 0.8`, `coast_warp_frequency = 0.5` for the C1 HD export.
 Kept OFF by default in `FbmUpscaleConfig` (byte-identical / v2-safe); the C1

--- a/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
+++ b/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
@@ -138,7 +138,21 @@ micro-feathering at it.
 
 ## Recommended production setting
 `coast_warp_strength ≈ 0.8`, `coast_warp_frequency = 0.5`,
-`coastal_amplitude_band ≈ 0.06` for the C1 HD export. All kept OFF/0 by default
-in `FbmUpscaleConfig` (byte-identical / v2-safe); the C1 production HD path opts
-in. Wiring these defaults into the C1 production upscale config is a product
-decision (deferred with the rest of the HD/UI wiring).
+`coastal_amplitude_band ≈ 0.06`, `amplitude_base ≈ 0.16`,
+**`submarine_damping = 0.0`** for the C1 HD export.
+
+The last one fixes a separate reported defect: with the default
+`submarine_damping = 0.3` the FBM is still visible in the OCEAN (~0.3× amplitude
+→ mottled bathymetry / contour ripples — "on voit le FBM, on ne devrait pas").
+Counterfactual: `0.3 → 0.0` removes it entirely (smooth bathymetry gradient;
+land/mountains unchanged — FBM above sea level is untouched). So set
+`submarine_damping = 0.0` for C1 HD (no underwater FBM). Combined production
+render (7 seeds: 2/42/99/1337/1988/2026/4138) = credible continents, irregular
+coasts, mountains w/ snow peaks, **smooth oceans**. (Residual: F3 ocean
+age-discontinuity lines on a few seeds — separate registered follow-up, not the
+upscale.)
+
+All these are existing/`FbmUpscaleConfig` fields kept OFF/default
+(byte-identical / v2-safe); the C1 production HD path opts in. Wiring these
+defaults into the C1 production upscale config is a product decision (deferred
+with the rest of the HD/UI wiring).

--- a/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
+++ b/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
@@ -138,8 +138,22 @@ micro-feathering at it.
 
 ## Recommended production setting
 `coast_warp_strength ≈ 0.8`, `coast_warp_frequency = 0.5`,
-`coastal_amplitude_band ≈ 0.20`, `amplitude_base ≈ 0.16`,
+`coastal_amplitude_band ≈ 0.30`, `amplitude_base ≈ 0.16`,
 **`submarine_damping = 0.0`** for the C1 HD export.
+
+(`coastal_amplitude_band` 0.20 → **0.30**: a 3rd reported pass showed faint
+reddish contour lines on the near-coast land. **Decisive attribution** — a
+HILLSHADE of the region shows the actual relief there is GENTLE/smooth (no
+sharp structures); the lines are the hypsometric TEST PALETTE's hard green→brown
+colour boundary (at normalised height 0.75) being wiggled by FBM that resumes at
+the band edge (0.70 for band 0.20) — i.e. a RENDERING artefact of the test
+palette, not a terrain defect (the heightmap data is good). Two consequences:
+(1) the production renderer/colormap determines whether this shows at all; (2)
+for clean test renders AND a sensible model, band 0.30 puts the FBM onset at
+height 0.80 — ABOVE the green/brown boundary — so all green lowland is smooth
+and FBM lives only in the brown highland. Verified: green coastal margins clean
+on seeds 2/42, mountains (seed 2 high-relief) fully preserved. So "FBM ∝
+elevation: smooth plains, rugged mountains" with FBM confined to highland.)
 
 (`coastal_amplitude_band` revised 0.06 → **0.20**: a second reported defect —
 faint FBM contour ripples on the LOW land NEAR the coast (confirmed real height,

--- a/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
+++ b/docs/reports/c1_continental_buoyancy/stage_coastline_warp.md
@@ -138,8 +138,18 @@ micro-feathering at it.
 
 ## Recommended production setting
 `coast_warp_strength ≈ 0.8`, `coast_warp_frequency = 0.5`,
-`coastal_amplitude_band ≈ 0.06`, `amplitude_base ≈ 0.16`,
+`coastal_amplitude_band ≈ 0.20`, `amplitude_base ≈ 0.16`,
 **`submarine_damping = 0.0`** for the C1 HD export.
+
+(`coastal_amplitude_band` revised 0.06 → **0.20**: a second reported defect —
+faint FBM contour ripples on the LOW land NEAR the coast (confirmed real height,
+not palette banding, via a grayscale crop). The 0.06 band killed only the
+coastline flicker; the near-coast lowland still carried FBM. Widening to ~0.20
+suppresses FBM on land within 0.20 altitude of sea (coastal plains → smooth)
+while keeping full FBM on the higher inland terrain — verified on seed 2
+(high-relief: mountains fully preserved, snow peaks intact) and seed 1988. This
+makes FBM amplitude effectively scale with elevation: smooth coastal plains,
+rugged mountains — geologically sensible. Pure config value, no code change.)
 
 The last one fixes a separate reported defect: with the default
 `submarine_damping = 0.3` the FBM is still visible in the OCEAN (~0.3× amplitude

--- a/docs/reports/c1_continental_buoyancy/stage_f3_ocean_lines.md
+++ b/docs/reports/c1_continental_buoyancy/stage_f3_ocean_lines.md
@@ -1,0 +1,45 @@
+# F3 — dark dotted lines in the ocean (#151)
+
+Reported residual after the coastline work: thin dark dotted/wandering lines
+in the OCEAN on several seeds (2, 99, 4138).
+
+## Cause PINNED (`pin_f3_ocean_lines`)
+
+Rendering the COARSE 64² fields (pre-upscale) for a strong-arc seed (4138):
+
+- The dark arc is **already in the coarse production altitude** (Stein-Stein
+  bathymetry) → it originates in C1, NOT the upscale.
+- The **age field is ≈0 almost everywhere except a sparse chain of cells with
+  age ≈ 447** (vs background ~0), lying exactly on the dark arc.
+- That arc **coincides with a convergent plate boundary** (boundary overlay).
+
+So F3 = the **flux-form age-advection pile-up** (the registered
+density-vs-Lagrangian artefact: a few cells accumulate ~1000× the background
+age at convergent boundaries) → **Stein-Stein turns those age spikes into the
+deepest cells** → dark dotted lines. Background ocean is age≈0 (no seafloor
+spreading to build an age gradient), so the spikes stand out starkly.
+
+## Fix — despike the age before Stein-Stein (always-on)
+
+A 3×3 **median** on the age field, in `c1_production_altitude`, before
+`apply_stein_stein_bathymetry`. Median kills sparse spikes while preserving
+smooth structure.
+
+**Verified (before/after age colormap, seeds 2 & 4138):** only the spike chain
+disappears; the (faint) background age structure is preserved — no legitimate
+age gradient is flattened (the C1 model has none without seafloor spreading).
+So always-on is safe (no trade-off → not gated behind a flag, unlike the
+coast-warp knob which did have one).
+
+**Scope:** Stein-Stein is the ONLY consumer of age on the altitude path
+(`c1_production_altitude` → viz render + upscale), so this fixes F3 **fully**
+for both. RENDER-side band-aid: the internal advected age field is unchanged;
+the root cause (age advection) is the deferred deep fix
+([[feedback_age_advection_density_vs_lagrangian]] — Lagrangian age / ridge
+crust-creation). Not byte-identical (despiked age changes Stein-Stein) — but
+consistent with the other #151 render changes (FBM resolution, coast warp);
+flag in the PR. Regression `upscale_from_c1_structure_converges` still passes
+(structure r unchanged; despike only smooths ocean bathymetry).
+
+**Result:** dark ocean lines gone on all affected seeds (2, 99, 4138); ocean
+smooth, land/mountains unchanged.


### PR DESCRIPTION
Follow-up of #151: make the C1→upscale HD render production-quality. All changes
are visual-fidelity fixes to the anisotropic-FBM upscale + the C1 production
altitude. Each defect was pinned by counterfactual before fixing.

## A. ONE SHARED, always-on change (affects v2) — resolution-independent FBM
`upscale_with_fbm` sampled noise in TARGET-pixel space (`freq = base/src_w;
nx = i·freq`) → the FBM feature count scaled with `target_size` (4× finer at
4096² than 1024² for the same config). Now sampled in COARSE-CELL space
(`sx·nscale`, referenced to 1024²) → feature size fixed relative to terrain,
resolution-independent. **This is the only always-on change to the shared
upscale, so it is the only one that can affect v2.**

### v2 impact (shared `upscale_with_fbm`; v2 viz + workflow phase_b, default hd_grid_size = 2048²)
- **v2 @1024² : BYTE-IDENTICAL** (`sx·nscale ≡ i·freq` exactly at target = 1024).
- **v2 @≠1024² (incl. the 2048² default) : CHANGES — by design** (resolution
  consistency). Re-validated before/after at 2048²: a **benign coarsening**
  (~2× larger FBM features), well-formed terrain, **NOT a calibration
  derangement** → v2 improved/neutral. The before/after used a representative
  coarse input — the freq change is a coordinate-mapping change, so its effect
  on FBM grain is **input-geometry-independent** (orthogonal to coarse content);
  the verdict (coarsening, not derangement) holds for v2.
  **Actionable limit: a v2-native render is recommended before the next v2 use
  at ≠1024² — a cheap confirmation that v2's exact FBM config coarsens benignly
  (expected).**

## B. New upscale fields, DEFAULT-OFF (v2 byte-identical; C1 HD opts in)
- `coast_warp_strength` / `coast_warp_frequency` — warp the COARSE-altitude
  sampling so the sea-level contour meanders (breaks the blocky 64² coast).
- `coastal_amplitude_band` — taper FBM to 0 near sea level (FBM ∝ elevation:
  smooth coastal plains, rugged mountains).
Both default 0.0 → `upscale_with_fbm` is byte-identical when unset (v2 unaffected).

## C. C1 production-altitude / HD-config only (not on any v2 path)
- **F3 ocean lines fixed** — age-advection pile-up spikes on convergent plate
  boundaries → Stein-Stein rendered them as deep dark dots. Fix: 3×3 median
  despike of age in `c1_production_altitude` before Stein-Stein (always-on for
  the C1 render + upscale; Stein-Stein is the only age consumer there).
  Render band-aid; root-cause age advection = deferred deep fix.
- `submarine_damping = 0.0` (C1 HD config value) — no FBM in the ocean (smooth
  bathymetry).

## Recommended C1 HD production config
`coast_warp_strength 1.5`, `coast_warp_frequency 0.5`, `coastal_amplitude_band
0.30`, `amplitude_base 0.16`, `submarine_damping 0.0`. Result (7 seeds): credible
continents, irregular natural coasts, smooth coastal plains, snow-peak mountains,
smooth oceans, no F3 lines. Wiring these defaults into the C1 production upscale
config is deferred with the rest of the HD/UI wiring.

## Notes
- Diagnostic harness `c1_closure_morphology` (all `#[ignore]`); reports under
  `docs/reports/c1_continental_buoyancy/stage_{coastline_warp,f3_ocean_lines,...}.md`.
- Build clean; `upscale_from_c1_structure_converges` + upscale lib tests green.
- Render-quality changes to the C1 altitude (A + C) are NOT byte-identical vs
  pre-#151 (they're the improvements); v2@1024 byte-identical (A only matters
  for v2 and is identical there).
