### PR TITLE
Issue #155 — C1 relief macro-border: O-C orogenic ridge (1a + 1b-i)

### DIFF
--- a/crates/ymir-core/src/tectonics_c1/boundary_classification.rs
+++ b/crates/ymir-core/src/tectonics_c1/boundary_classification.rs
@@ -70,6 +70,7 @@
 //! performance + UI work can revisit if the orogenic visual at
 //! 64²-512² shows staircase artefacts on oblique boundaries.
 
+use crate::tectonics_v2::boundaries::plate_type::{PlateType, PlateTypeField};
 use crate::tectonics_v2::field::PeriodicIndex;
 use crate::tectonics_v2::voronoi::PlateIdField;
 
@@ -307,6 +308,74 @@ pub fn classify_boundaries(
     BoundaryInfo { boundary_type, upper_plate_mask }
 }
 
+/// #155 maillon 1a — retarget the Davis-Suppe "upper plate" to the
+/// CONTINENTAL plate at **O-C (subduction)** convergences.
+///
+/// [`classify_boundaries`] marks `upper_plate_mask` by the velocity
+/// heuristic `is_upper = v_mag_c > v_mag_n` (the FASTER plate, plate_type-
+/// blind). Real orogeny thickens the overriding **continental** plate
+/// (Andes on South America). This post-process overrides ONLY O-C
+/// convergent cells:
+/// - a Convergent **Continental** cell with an Oceanic differing-plate
+///   neighbour → `upper = true` (overriding plate, gets the DS wedge);
+/// - a Convergent **Oceanic** cell with a Continental differing-plate
+///   neighbour → `upper = false` (subducting / lower plate).
+///
+/// **Strict fallback (critical):** C-C (collision) and O-O cells are
+/// **NOT touched** — the velocity-based `upper_plate_mask` from
+/// `classify_boundaries` stays, so any seed WITHOUT O-C subduction is
+/// byte-identical. Reuses the same 4-neighbour periodic convention as
+/// `classify_boundaries`.
+///
+/// Scope is QUI is thickened, NOT the wedge geometry (dome vs chain) nor
+/// C-C collision orogeny — those are maillon 1b. Called only on the
+/// production DS path (`time_loop`), where `plate_type` is in hand; the
+/// 28 test/age-init callers of `classify_boundaries` are unaffected.
+pub fn retarget_upper_plate_continental(
+    boundary: &mut BoundaryInfo,
+    plate_id: &PlateIdField,
+    plate_type: &PlateTypeField,
+) {
+    let nx = plate_id.nx();
+    let ny = plate_id.ny();
+    let idx_x = PeriodicIndex::new(nx);
+    let idx_y = PeriodicIndex::new(ny);
+    for j in 0..ny {
+        for i in 0..nx {
+            if !matches!(boundary.boundary_type.get(i, j), BoundaryType::Convergent) {
+                continue;
+            }
+            let pid_c = plate_id.get(i, j);
+            let cont_c = matches!(plate_type.get(i, j), PlateType::Continental);
+            // Differing-plate 4-neighbours = the boundary partners.
+            let mut has_oceanic_diff = false;
+            let mut has_continental_diff = false;
+            for (ni, nj) in [
+                (idx_x.next(i), j),
+                (idx_x.prev(i), j),
+                (i, idx_y.next(j)),
+                (i, idx_y.prev(j)),
+            ] {
+                if plate_id.get(ni, nj) == pid_c {
+                    continue;
+                }
+                match plate_type.get(ni, nj) {
+                    PlateType::Oceanic => has_oceanic_diff = true,
+                    PlateType::Continental => has_continental_diff = true,
+                }
+            }
+            if cont_c && has_oceanic_diff {
+                // O-C: continental side overrides → gets the wedge.
+                boundary.upper_plate_mask.set(i, j, true);
+            } else if !cont_c && has_continental_diff {
+                // O-C: oceanic side subducts → lower plate, no wedge.
+                boundary.upper_plate_mask.set(i, j, false);
+            }
+            // else C-C / O-O → strictly untouched (velocity fallback).
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -321,6 +390,63 @@ mod tests {
             }
         }
         p
+    }
+
+    /// #155 maillon 1a — the BOUNDED proof. The retarget helper must
+    /// flip ONLY O-C (subduction) convergent cells and leave C-C
+    /// (collision) and O-O cells byte-identical to the velocity-based
+    /// `upper_plate_mask`. Geography-independent (no kinematics, no
+    /// seed): three synthetic 4×1 boundaries, one per plate-type pair.
+    ///
+    /// This is the test that proves the C-C/O-O fallback leaks nothing —
+    /// the real-seed runs all carry O-C boundaries (seed 2026 retargets
+    /// 13044 cells, NOT zero, falsifying the earlier "pure-intraplate"
+    /// premise), so the boundedness must be proven structurally here.
+    #[test]
+    fn retarget_bounded_to_oc_subduction() {
+        use crate::tectonics_c1::state::BoolField;
+        // 4×1 (ny=1 ⇒ periodic y-neighbour is self ⇒ x-axis only).
+        // plate_id [0,0,1,1]; the 0|1 boundary is between cell 1 & 2.
+        let nx = 4;
+        let ny = 1;
+        let plate_id = build_plate_id(nx, ny, |i, _| if i < 2 { 0 } else { 1 });
+
+        // Common: only cells 1 & 2 are Convergent (the boundary pair).
+        let make_boundary = |m1: bool, m2: bool| {
+            let mut bt = BoundaryTypeField::filled(nx, ny, BoundaryType::Internal);
+            bt.set(1, 0, BoundaryType::Convergent);
+            bt.set(2, 0, BoundaryType::Convergent);
+            let mut mask = BoolField::filled(nx, ny, false);
+            mask.set(1, 0, m1);
+            mask.set(2, 0, m2);
+            BoundaryInfo { boundary_type: bt, upper_plate_mask: mask }
+        };
+        let pt = |a: PlateType, b: PlateType| {
+            // cells 0,1 = `a`; cells 2,3 = `b`.
+            let mut p = PlateTypeField::filled(nx, ny, a);
+            p.set(2, 0, b);
+            p.set(3, 0, b);
+            p
+        };
+
+        // --- O-C: continental (cells 0,1) overriding oceanic (2,3). ---
+        // Seed the mask "wrong" (cont=false, ocean=true) to see the flip.
+        let mut oc = make_boundary(false, true);
+        retarget_upper_plate_continental(&mut oc, &plate_id, &pt(PlateType::Continental, PlateType::Oceanic));
+        assert!(oc.upper_plate_mask.get(1, 0), "O-C: continental cell must become upper=true");
+        assert!(!oc.upper_plate_mask.get(2, 0), "O-C: oceanic cell must become lower=false");
+
+        // --- C-C: both continental → strictly untouched. ---
+        let mut cc = make_boundary(false, true);
+        retarget_upper_plate_continental(&mut cc, &plate_id, &pt(PlateType::Continental, PlateType::Continental));
+        assert!(!cc.upper_plate_mask.get(1, 0), "C-C: cell 1 mask must stay false (velocity fallback)");
+        assert!(cc.upper_plate_mask.get(2, 0), "C-C: cell 2 mask must stay true (velocity fallback)");
+
+        // --- O-O: both oceanic → strictly untouched. ---
+        let mut oo = make_boundary(true, false);
+        retarget_upper_plate_continental(&mut oo, &plate_id, &pt(PlateType::Oceanic, PlateType::Oceanic));
+        assert!(oo.upper_plate_mask.get(1, 0), "O-O: cell 1 mask must stay true (velocity fallback)");
+        assert!(!oo.upper_plate_mask.get(2, 0), "O-O: cell 2 mask must stay false (velocity fallback)");
     }
 
     #[test]

--- a/crates/ymir-core/src/tectonics_c1/boundary_classification.rs
+++ b/crates/ymir-core/src/tectonics_c1/boundary_classification.rs
@@ -376,6 +376,54 @@ pub fn retarget_upper_plate_continental(
     }
 }
 
+/// #155 maillon 1b-i — companion to [`retarget_upper_plate_continental`]:
+/// the mask of cells that ARE O-C continental-override seeds (the cells
+/// `retarget` sets `upper = true` via the O-C branch). Used to route the
+/// Davis-Suppe wedge GEOMETRY by convergence type: cells whose nearest
+/// upper-plate seed is O-C get the margin-peaked ridge profile (Andes),
+/// C-C / velocity-fallback seeds keep the rising-to-plateau dome (Tibet).
+///
+/// Same O-C criterion and 4-neighbour periodic convention as `retarget`:
+/// a Convergent **Continental** cell with an Oceanic differing-plate
+/// neighbour. C-C / O-O / non-Convergent cells → `false`.
+pub fn oc_override_seed_mask(
+    boundary: &BoundaryInfo,
+    plate_id: &PlateIdField,
+    plate_type: &PlateTypeField,
+) -> BoolField {
+    let nx = plate_id.nx();
+    let ny = plate_id.ny();
+    let idx_x = PeriodicIndex::new(nx);
+    let idx_y = PeriodicIndex::new(ny);
+    let mut mask = BoolField::filled(nx, ny, false);
+    for j in 0..ny {
+        for i in 0..nx {
+            if !matches!(boundary.boundary_type.get(i, j), BoundaryType::Convergent) {
+                continue;
+            }
+            if !matches!(plate_type.get(i, j), PlateType::Continental) {
+                continue;
+            }
+            let pid_c = plate_id.get(i, j);
+            let has_oceanic_diff = [
+                (idx_x.next(i), j),
+                (idx_x.prev(i), j),
+                (i, idx_y.next(j)),
+                (i, idx_y.prev(j)),
+            ]
+            .into_iter()
+            .any(|(ni, nj)| {
+                plate_id.get(ni, nj) != pid_c
+                    && matches!(plate_type.get(ni, nj), PlateType::Oceanic)
+            });
+            if has_oceanic_diff {
+                mask.set(i, j, true);
+            }
+        }
+    }
+    mask
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ymir-core/src/tectonics_c1/closures/davis_suppe/source_term.rs
+++ b/crates/ymir-core/src/tectonics_c1/closures/davis_suppe/source_term.rs
@@ -158,6 +158,46 @@ pub fn apply_davis_suppe_step(
     params: &DavisSuppeParams,
     dt: f64,
 ) {
+    apply_davis_suppe_step_inner(
+        s, plate_id, boundary, wedge_distance, kinematics, params, dt, None,
+    );
+}
+
+/// #155 maillon 1b-i — geometry-routed Davis-Suppe step. Identical to
+/// [`apply_davis_suppe_step`] except cells flagged in `oc_wedge` (their
+/// nearest upper-plate seed is an O-C subduction; see
+/// [`super::super::distance_field::wedge_distance_intra_plate_typed`])
+/// use the **margin-peaked ridge** target `h_critical_oc(d) = h_max ·
+/// exp(−d / l_taper)` — peaking near the margin and decaying inland
+/// (Andes) — instead of the rising-to-plateau dome (Tibet) the C-C /
+/// velocity-fallback cells keep. Reuses `l_taper` as the ridge length
+/// (no new knob): the O-C profile is the literal inverse of the C-C one.
+pub fn apply_davis_suppe_step_routed(
+    s: &mut Field2D,
+    plate_id: &PlateIdField,
+    boundary: &BoundaryInfo,
+    wedge_distance: &Field2D,
+    kinematics: &PlateKinematics,
+    params: &DavisSuppeParams,
+    dt: f64,
+    oc_wedge: &crate::tectonics_c1::state::BoolField,
+) {
+    apply_davis_suppe_step_inner(
+        s, plate_id, boundary, wedge_distance, kinematics, params, dt, Some(oc_wedge),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_davis_suppe_step_inner(
+    s: &mut Field2D,
+    plate_id: &PlateIdField,
+    boundary: &BoundaryInfo,
+    wedge_distance: &Field2D,
+    kinematics: &PlateKinematics,
+    params: &DavisSuppeParams,
+    dt: f64,
+    oc_wedge: Option<&crate::tectonics_c1::state::BoolField>,
+) {
     if !params.enabled {
         return;
     }
@@ -183,8 +223,17 @@ pub fn apply_davis_suppe_step(
             if d >= max_d {
                 continue;
             }
-            // h_critical and current S̃.
-            let h_crit = h_max * (1.0 - (-d / l_taper).exp());
+            // h_critical and current S̃. #155 1b-i: O-C cells (nearest
+            // upper-plate seed is a subduction) use the margin-peaked
+            // ridge target h_max·exp(−d/l_taper) — peaks near the margin,
+            // decays inland (Andes); C-C / fallback keep the classical
+            // rising-to-plateau h_max·(1−exp(−d/l_taper)) (Tibet).
+            let is_oc = oc_wedge.is_some_and(|m| m.get(i, j));
+            let h_crit = if is_oc {
+                h_max * (-d / l_taper).exp()
+            } else {
+                h_max * (1.0 - (-d / l_taper).exp())
+            };
             let h_now = s.get(i, j);
             // Saturation: no source when already at or above
             // critical taper — `max(0, h_crit - h_now)`.

--- a/crates/ymir-core/src/tectonics_c1/distance_field.rs
+++ b/crates/ymir-core/src/tectonics_c1/distance_field.rs
@@ -254,6 +254,94 @@ pub fn wedge_distance_intra_plate(
     dist
 }
 
+/// #155 maillon 1b-i — typed variant of [`wedge_distance_intra_plate`]
+/// that ALSO propagates each seed's convergence type to its reachable
+/// wedge cells. Identical Dijkstra (same distances), plus a companion
+/// `is_oc` mask: each reached cell inherits the O-C flag of the seed on
+/// its shortest path (the nearest upper-plate seed). The Davis-Suppe
+/// step then routes geometry by type — O-C cells get the margin-peaked
+/// ridge profile (Andes), C-C / velocity-fallback cells keep the
+/// rising-to-plateau dome (Tibet).
+///
+/// `oc_seed_mask` (from
+/// [`super::boundary_classification::oc_override_seed_mask`]) must align
+/// with the `true` cells of `upper_plate_mask`: it flags which of those
+/// seeds are O-C continental overrides.
+pub fn wedge_distance_intra_plate_typed(
+    plate_id: &crate::tectonics_v2::voronoi::PlateIdField,
+    upper_plate_mask: &super::state::BoolField,
+    oc_seed_mask: &super::state::BoolField,
+    max_distance: f64,
+) -> (Field2D, super::state::BoolField) {
+    let nx = plate_id.nx();
+    let ny = plate_id.ny();
+    let idx_x = PeriodicIndex::new(nx);
+    let idx_y = PeriodicIndex::new(ny);
+
+    let mut dist = Field2D::filled(nx, ny, max_distance);
+    let mut is_oc = super::state::BoolField::filled(nx, ny, false);
+
+    let mut heap: BinaryHeap<std::cmp::Reverse<(OrdF64, usize, usize)>> = BinaryHeap::new();
+    for j in 0..ny {
+        for i in 0..nx {
+            if upper_plate_mask.get(i, j) {
+                dist.set(i, j, 0.0);
+                is_oc.set(i, j, oc_seed_mask.get(i, j));
+                heap.push(std::cmp::Reverse((OrdF64(0.0), i, j)));
+            }
+        }
+    }
+
+    let neighbours: [(i32, i32, f64); 8] = [
+        (1, 0, 1.0),
+        (-1, 0, 1.0),
+        (0, 1, 1.0),
+        (0, -1, 1.0),
+        (1, 1, DIAG),
+        (1, -1, DIAG),
+        (-1, 1, DIAG),
+        (-1, -1, DIAG),
+    ];
+
+    while let Some(std::cmp::Reverse((OrdF64(d), i, j))) = heap.pop() {
+        if d > dist.get(i, j) {
+            continue;
+        }
+        if d >= max_distance {
+            continue;
+        }
+        let plate_c = plate_id.get(i, j);
+        let oc_c = is_oc.get(i, j);
+        for &(di, dj, cost) in neighbours.iter() {
+            let ni = if di > 0 {
+                idx_x.next(i)
+            } else if di < 0 {
+                idx_x.prev(i)
+            } else {
+                i
+            };
+            let nj = if dj > 0 {
+                idx_y.next(j)
+            } else if dj < 0 {
+                idx_y.prev(j)
+            } else {
+                j
+            };
+            if plate_id.get(ni, nj) != plate_c {
+                continue;
+            }
+            let new_d = d + cost;
+            if new_d < dist.get(ni, nj) && new_d < max_distance {
+                dist.set(ni, nj, new_d);
+                is_oc.set(ni, nj, oc_c);
+                heap.push(std::cmp::Reverse((OrdF64(new_d), ni, nj)));
+            }
+        }
+    }
+
+    (dist, is_oc)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/ymir-core/src/tectonics_c1/time_loop.rs
+++ b/crates/ymir-core/src/tectonics_c1/time_loop.rs
@@ -55,9 +55,11 @@ use crate::tectonics_v2::field::{Field2D, PeriodicIndex};
 use crate::tectonics_v2::workflow::drainage::compute_drainage_targets;
 use crate::tectonics_v2::workflow::phase_a_common::compute_sea_level_ref_s_space;
 
-use super::boundary_classification::{classify_boundaries, retarget_upper_plate_continental};
+use super::boundary_classification::{
+    classify_boundaries, oc_override_seed_mask, retarget_upper_plate_continental,
+};
 use super::closures::accretion::{apply_accretion_step, AccretionParams, ConvergenceTracker};
-use super::closures::davis_suppe::source_term::{apply_davis_suppe_step, DavisSuppeParams};
+use super::closures::davis_suppe::source_term::{apply_davis_suppe_step_routed, DavisSuppeParams};
 use super::closures::equilibrium_height::params::EquilibriumHeightParams;
 use super::closures::equilibrium_height::source_term::apply_equilibrium_height_step;
 use super::closures::erosion::params::ErosionParams;
@@ -68,7 +70,7 @@ use super::closures::rifting::{
     apply_rifting_split, apply_rifting_thinning, DivergenceTracker, RiftingParams,
 };
 use super::closures::subduction::{apply_subduction_step, SubductionParams};
-use super::distance_field::wedge_distance_intra_plate;
+use super::distance_field::wedge_distance_intra_plate_typed;
 use super::kinematics::PlateKinematics;
 use super::state::C1State;
 use crate::tectonics_v2::boundaries::plate_type::PlateType;
@@ -527,18 +529,22 @@ pub fn run_with_closures<F>(
     // Outer cache for the Track-D-disabled path (Phase 1.x +
     // Track A/B regression — `plate_id` is invariant, the cache
     // stays valid for the full run).
-    let outer_cache: Option<(_, _)> = if !any_track_d_enabled {
+    let outer_cache: Option<(_, _, _)> = if !any_track_d_enabled {
         let mut bi = classify_boundaries(&state.plate_id, kinematics);
         // #155 1a: retarget DS upper plate to the continental side at O-C
         // subductions (continent thickens, not the faster/oceanic plate);
         // C-C/O-O strictly untouched.
         retarget_upper_plate_continental(&mut bi, &state.plate_id, &state.plate_type);
-        let wd = wedge_distance_intra_plate(
+        // #155 1b-i: type the wedge so the DS step routes geometry — O-C
+        // seeds → margin-peaked ridge, C-C/fallback → rising dome.
+        let oc_seed = oc_override_seed_mask(&bi, &state.plate_id, &state.plate_type);
+        let (wd, oc_wedge) = wedge_distance_intra_plate_typed(
             &state.plate_id,
             &bi.upper_plate_mask,
+            &oc_seed,
             davis_suppe.max_distance,
         );
-        Some((bi, wd))
+        Some((bi, wd, oc_wedge))
     } else {
         None
     };
@@ -567,23 +573,27 @@ pub fn run_with_closures<F>(
         // recompute from the current `plate_id` (which may have
         // been mutated by the previous step's Track D events).
         // When Track D is disabled, reuse the outer cache.
-        let per_step_cache: Option<(_, _)> = if any_track_d_enabled {
+        let per_step_cache: Option<(_, _, _)> = if any_track_d_enabled {
             let mut bi = classify_boundaries(&state.plate_id, kinematics);
             // #155 1a: retarget DS upper plate to the continental side at O-C
             // (Track-D path: recomputed per step as plate_type may change).
             retarget_upper_plate_continental(&mut bi, &state.plate_id, &state.plate_type);
-            let wd = wedge_distance_intra_plate(
+            // #155 1b-i: type the wedge for geometry routing (per step,
+            // as plate_type may have changed via Track D events).
+            let oc_seed = oc_override_seed_mask(&bi, &state.plate_id, &state.plate_type);
+            let (wd, oc_wedge) = wedge_distance_intra_plate_typed(
                 &state.plate_id,
                 &bi.upper_plate_mask,
+                &oc_seed,
                 davis_suppe.max_distance,
             );
-            Some((bi, wd))
+            Some((bi, wd, oc_wedge))
         } else {
             None
         };
-        let (boundary, wedge_d): (&_, &_) = match (&per_step_cache, &outer_cache) {
-            (Some((b, w)), _) => (b, w),
-            (None, Some((b, w))) => (b, w),
+        let (boundary, wedge_d, oc_wedge): (&_, &_, &_) = match (&per_step_cache, &outer_cache) {
+            (Some((b, w, o)), _) => (b, w, o),
+            (None, Some((b, w, o))) => (b, w, o),
             (None, None) => unreachable!(
                 "boundary cache must be present: either per-step (Track D) or outer (cached)"
             ),
@@ -631,7 +641,7 @@ pub fn run_with_closures<F>(
         std::mem::swap(&mut state.age, &mut age_next);
 
         // 2. Davis-Suppe orogenic source term (Phase 1.2).
-        apply_davis_suppe_step(
+        apply_davis_suppe_step_routed(
             &mut state.s,
             &state.plate_id,
             boundary,
@@ -639,6 +649,7 @@ pub fn run_with_closures<F>(
             kinematics,
             &davis_suppe,
             dt,
+            oc_wedge,
         );
 
         // 3. Equilibrium height sink (Phase 1.3).

--- a/crates/ymir-core/src/tectonics_c1/time_loop.rs
+++ b/crates/ymir-core/src/tectonics_c1/time_loop.rs
@@ -55,7 +55,7 @@ use crate::tectonics_v2::field::{Field2D, PeriodicIndex};
 use crate::tectonics_v2::workflow::drainage::compute_drainage_targets;
 use crate::tectonics_v2::workflow::phase_a_common::compute_sea_level_ref_s_space;
 
-use super::boundary_classification::classify_boundaries;
+use super::boundary_classification::{classify_boundaries, retarget_upper_plate_continental};
 use super::closures::accretion::{apply_accretion_step, AccretionParams, ConvergenceTracker};
 use super::closures::davis_suppe::source_term::{apply_davis_suppe_step, DavisSuppeParams};
 use super::closures::equilibrium_height::params::EquilibriumHeightParams;
@@ -528,7 +528,11 @@ pub fn run_with_closures<F>(
     // Track A/B regression — `plate_id` is invariant, the cache
     // stays valid for the full run).
     let outer_cache: Option<(_, _)> = if !any_track_d_enabled {
-        let bi = classify_boundaries(&state.plate_id, kinematics);
+        let mut bi = classify_boundaries(&state.plate_id, kinematics);
+        // #155 1a: retarget DS upper plate to the continental side at O-C
+        // subductions (continent thickens, not the faster/oceanic plate);
+        // C-C/O-O strictly untouched.
+        retarget_upper_plate_continental(&mut bi, &state.plate_id, &state.plate_type);
         let wd = wedge_distance_intra_plate(
             &state.plate_id,
             &bi.upper_plate_mask,
@@ -564,7 +568,10 @@ pub fn run_with_closures<F>(
         // been mutated by the previous step's Track D events).
         // When Track D is disabled, reuse the outer cache.
         let per_step_cache: Option<(_, _)> = if any_track_d_enabled {
-            let bi = classify_boundaries(&state.plate_id, kinematics);
+            let mut bi = classify_boundaries(&state.plate_id, kinematics);
+            // #155 1a: retarget DS upper plate to the continental side at O-C
+            // (Track-D path: recomputed per step as plate_type may change).
+            retarget_upper_plate_continental(&mut bi, &state.plate_id, &state.plate_type);
             let wd = wedge_distance_intra_plate(
                 &state.plate_id,
                 &bi.upper_plate_mask,

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -921,6 +921,166 @@ fn coast_palette_check() {
     eprintln!("  out = {}", dir.display());
 }
 
+/// Bresenham line into an RGB image (clamped).
+fn draw_line(img: &mut ImageBuffer<Rgb<u8>, Vec<u8>>, x0: i32, y0: i32, x1: i32, y1: i32, c: [u8; 3]) {
+    let (w, h) = (img.width() as i32, img.height() as i32);
+    let dx = (x1 - x0).abs();
+    let dy = -(y1 - y0).abs();
+    let sx = if x0 < x1 { 1 } else { -1 };
+    let sy = if y0 < y1 { 1 } else { -1 };
+    let (mut x, mut y) = (x0, y0);
+    let mut err = dx + dy;
+    loop {
+        if x >= 0 && y >= 0 && x < w && y < h { img.put_pixel(x as u32, y as u32, Rgb(c)); }
+        if x == x1 && y == y1 { break; }
+        let e2 = 2 * err;
+        if e2 >= dy { err += dy; x += sx; }
+        if e2 <= dx { err += dx; y += sy; }
+    }
+}
+
+/// #151 RELIEF profile — 1D cuts ACROSS the convergent arc (seed 42),
+/// sampling raw S̃ and the COARSE production altitude (pre-FBM) vs
+/// distance, to read whether a marginal Davis-Suppe orogen pic exists
+/// in S̃ (force) and whether it survives the S̃→altitude conversion
+/// (expression). Arc located via the DS convergence classifier
+/// (`classify_boundaries` → Convergent). Same run/fields as
+/// `export_relief_compare`. Outputs CSV (the numbers) + a PNG plot per
+/// cut; prints cut centres + inward normals so the cut placement is
+/// auditable.
+#[test]
+#[ignore]
+fn profile_convergent_arc_seed42() {
+    let dir = output_dir().join("relief_profile");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let seed = 42u64;
+    let grid = 64usize;
+
+    let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+    let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+    let closures = C1Closures::default();
+    let config = C1TimeLoopConfig {
+        rigid_continental_crust: true, n_steps: 300,
+        dx: 1.0 / grid as f64, dy: 1.0 / grid as f64,
+        iso_config: iso_config.clone(), drainage_max_distance: 30,
+    };
+    run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+    // Coarse production altitude (pre-FBM): isostasy + Stein-Stein + despike.
+    let alt = c1_production_altitude(&state.s, &state.age, &state.plate_type, &iso_config, &ss);
+    let binfo = classify_boundaries(&state.plate_id, &kin);
+    let cont = |i: usize, j: usize| matches!(state.plate_type.get(i, j), PlateType::Continental);
+
+    // Convergent cells adjacent to land (the orogen sites along the coast).
+    let mut conv: Vec<(usize, usize)> = Vec::new();
+    for j in 0..grid { for i in 0..grid {
+        if matches!(binfo.boundary_type.get(i, j), BoundaryType::Convergent) {
+            conv.push((i, j));
+        }
+    }}
+    // COAST convergences (south half): convergent cells with BOTH a
+    // continental and an oceanic 4-neighbour → a real coast convergence
+    // with a well-defined inward normal (excludes mid-ocean convergences,
+    // which gave degenerate normal=0 cuts).
+    let has_both = |ci: usize, cj: usize| {
+        let (mut land, mut sea) = (false, false);
+        for (di, dj) in [(-1i32,0i32),(1,0),(0,-1),(0,1)] {
+            let (a, b) = (ci as i32 + di, cj as i32 + dj);
+            if a>=0 && b>=0 && (a as usize)<grid && (b as usize)<grid {
+                if cont(a as usize, b as usize) { land = true; } else { sea = true; }
+            }
+        }
+        land && sea
+    };
+    let mut south: Vec<(usize, usize)> = conv.iter().copied()
+        .filter(|&(i, j)| j < grid / 2 && has_both(i, j)).collect();
+    south.sort_by_key(|&(i, _)| i);
+    eprintln!("seed {seed}: {} convergent cells total, {} south COAST convergences", conv.len(), south.len());
+    eprintln!("  south coast-convergent cells (i,j): {south:?}");
+
+    // 3 cut centres spread along the south arc.
+    let centres: Vec<(usize, usize)> = if south.len() >= 3 {
+        [south.len() / 5, south.len() / 2, 4 * south.len() / 5].iter().map(|&k| south[k]).collect()
+    } else { south.clone() };
+
+    // Inward normal at a cell: toward continental neighbours.
+    let normal = |ci: usize, cj: usize| -> (f64, f64) {
+        let (mut nx, mut ny) = (0.0, 0.0);
+        for dj in -1i32..=1 { for di in -1i32..=1 {
+            if di == 0 && dj == 0 { continue; }
+            let (a, b) = (ci as i32 + di, cj as i32 + dj);
+            if a >= 0 && b >= 0 && (a as usize) < grid && (b as usize) < grid {
+                let s = if cont(a as usize, b as usize) { 1.0 } else { -1.0 };
+                nx += s * di as f64; ny += s * dj as f64;
+            }
+        }}
+        let n = (nx * nx + ny * ny).sqrt().max(1e-9);
+        (nx / n, ny / n)
+    };
+
+    for (ci, &(cx, cy)) in centres.iter().enumerate() {
+        let (nx, ny) = normal(cx, cy);
+        eprintln!("  cut {ci}: centre=({cx},{cy}) inward_normal=({nx:.2},{ny:.2})  [t<0 ocean → t=0 convergence → t>0 interior]");
+        // Sample t = -10..=12 cells along the inward normal.
+        let mut rows: Vec<(i32, f64, f64, u8, char)> = Vec::new();
+        for t in -10i32..=12 {
+            let i = (cx as f64 + t as f64 * nx).round();
+            let j = (cy as f64 + t as f64 * ny).round();
+            if i < 0.0 || j < 0.0 || i >= grid as f64 || j >= grid as f64 { continue; }
+            let (i, j) = (i as usize, j as usize);
+            let s = state.s.get(i, j);
+            let a = alt.get(i as i32, j as i32) as f64;
+            let cv = matches!(binfo.boundary_type.get(i, j), BoundaryType::Convergent) as u8;
+            let pt = if cont(i, j) { 'C' } else { 'O' };
+            rows.push((t, s, a, cv, pt));
+        }
+        // CSV (plate_type: C continental [altitude = isostasy(S̃)] / O
+        // oceanic [altitude = Stein-Stein bathymetry, S̃ NOT used]).
+        let mut csv = String::from("dist_cells,s_thickness,coarse_altitude,convergent,plate_type\n");
+        for &(t, s, a, cv, pt) in &rows {
+            csv.push_str(&format!("{t},{s:.4},{a:.4},{cv},{pt}\n"));
+        }
+        std::fs::write(dir.join(format!("seed{seed:05}_cut{ci}.csv")), &csv).unwrap();
+        // Console table.
+        eprintln!("    dist  S̃       altitude  pt  conv");
+        for &(t, s, a, cv, pt) in &rows {
+            eprintln!("    {t:>4}  {s:>6.3}  {a:>+7.3}   {pt}  {}", if cv == 1 { "<-- CONV" } else { "" });
+        }
+
+        // PNG plot: S̃ (blue) + altitude (brown), each normalised to its
+        // own range; gray vertical marker at t=0; gray baseline.
+        let (w, h) = (640i32, 360i32);
+        let (ml, mr, mt, mb) = (40i32, 20, 20, 30);
+        let mut img = ImageBuffer::<Rgb<u8>, Vec<u8>>::from_pixel(w as u32, h as u32, Rgb([250, 250, 250]));
+        let smin = rows.iter().map(|r| r.1).fold(f64::MAX, f64::min);
+        let smax = rows.iter().map(|r| r.1).fold(f64::MIN, f64::max);
+        let amin = rows.iter().map(|r| r.2).fold(f64::MAX, f64::min);
+        let amax = rows.iter().map(|r| r.2).fold(f64::MIN, f64::max);
+        let n = rows.len() as i32;
+        let xof = |k: i32| ml + k * (w - ml - mr) / (n - 1).max(1);
+        let yof = |v: f64, lo: f64, hi: f64| {
+            let t = ((v - lo) / (hi - lo).max(1e-9)).clamp(0.0, 1.0);
+            (h - mb) - (t * (h - mt - mb) as f64) as i32
+        };
+        // t=0 marker.
+        if let Some(k0) = rows.iter().position(|r| r.0 == 0) {
+            draw_line(&mut img, xof(k0 as i32), mt, xof(k0 as i32), h - mb, [150, 150, 150]);
+        }
+        for k in 1..rows.len() {
+            let (x0, x1) = (xof(k as i32 - 1), xof(k as i32));
+            draw_line(&mut img,
+                x0, yof(rows[k - 1].1, smin, smax), x1, yof(rows[k].1, smin, smax), [30, 60, 200]);
+            draw_line(&mut img,
+                x0, yof(rows[k - 1].2, amin, amax), x1, yof(rows[k].2, amin, amax), [160, 90, 30]);
+        }
+        img.save(dir.join(format!("seed{seed:05}_cut{ci}.png"))).unwrap();
+        eprintln!("    S̃ range [{smin:.3},{smax:.3}]  altitude range [{amin:.3},{amax:.3}]");
+    }
+    eprintln!("  out = {} (BLUE=S̃, BROWN=coarse altitude, GRAY=convergence t=0)", dir.display());
+}
+
 /// RELIEF EXPRESSION-vs-GENERATION diagnostic — per seed, three
 /// co-registered views from the SAME final C1State: (1) HD altitude
 /// (production #151 config, the real product where relief is missing),

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -921,6 +921,65 @@ fn coast_palette_check() {
     eprintln!("  out = {}", dir.display());
 }
 
+/// RELIEF EXPRESSION-vs-GENERATION diagnostic — per seed, three
+/// co-registered views from the SAME final C1State: (1) HD altitude
+/// (production #151 config, the real product where relief is missing),
+/// (2) RAW S̃ thickness (no FBM — does Davis-Suppe orogeny exist in the
+/// thickness?), (3) boundary TYPES — convergences (red) reusing the DS
+/// convergence classifier (`classify_boundaries`), so the analysis can
+/// overlay convergence ↔ altitude ↔ S̃: orogen in S̃ + flat altitude =
+/// EXPRESSION; flat in both at a convergence = GENERATION.
+#[test]
+#[ignore]
+fn export_relief_compare() {
+    let dir = output_dir().join("relief_compare");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let seeds: [u64; 7] = [2, 42, 99, 1337, 1988, 2026, 4138];
+    let cfg = FbmUpscaleConfig {
+        target_size: 1024, coast_warp_strength: 1.5, coast_warp_frequency: 0.5,
+        coastal_amplitude_band: 0.30, amplitude_base: 0.16, submarine_damping: 0.0,
+        ..Default::default()
+    };
+    eprintln!("#151 relief compare — altitude(1024² prod) / raw S̃ / convergence map, per seed");
+    for &seed in &seeds {
+        let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300,
+            dx: 1.0 / 64.0, dy: 1.0 / 64.0,
+            iso_config: iso_config.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+        let up = upscale_from_c1(&state, &iso_config, &ss, &WorldSeed::new(seed), &cfg);
+        save_heightmap01(&up.heightmap, &dir.join(format!("seed{seed:05}_altitude.png")));
+        save_s_scaled(&state.s, &dir.join(format!("seed{seed:05}_sthickness.png")), 8);
+
+        let binfo = classify_boundaries(&state.plate_id, &kin);
+        let grid = 64usize;
+        let mut bimg = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(grid as u32 * 8, grid as u32 * 8);
+        for j in 0..grid { for i in 0..grid {
+            let base = if matches!(state.plate_type.get(i, j), PlateType::Continental) {
+                [60, 130, 60]
+            } else { [40, 80, 160] };
+            let col = match binfo.boundary_type.get(i, j) {
+                BoundaryType::Convergent => [220, 30, 30],
+                BoundaryType::Divergent => [40, 220, 220],
+                BoundaryType::Transform => [230, 220, 40],
+                _ => base,
+            };
+            put_block(&mut bimg, i, grid - 1 - j, 8, col);
+        }}
+        bimg.save(dir.join(format!("seed{seed:05}_boundaries.png"))).unwrap();
+        eprintln!("  seed {seed} done");
+    }
+    eprintln!("  out = {}", dir.display());
+    eprintln!("  legend: convergent=RED divergent=CYAN transform=YELLOW; land=green ocean=blue");
+}
+
 /// F3 PIN — the dark dotted lines in the OCEAN. Render, at the COARSE
 /// 64² resolution (pre-upscale), the production altitude (Stein-Stein
 /// bathymetry), the age field, and the plate boundaries, to test:

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -2047,3 +2047,306 @@ fn hypsometric(h: f32, sea_norm: f32) -> [u8; 3] {
         lerp((h - mid) / (1.0 - mid).max(1e-6), [140, 100, 50], [245, 245, 245])
     }
 }
+
+/// #155 amplitude reading (a) — does the 1b-i O-C margin ridge read as a
+/// MOUNTAIN CHAIN after the HD upscale (upscale_from_c1 = isostasy +
+/// Stein-Stein + bicubic + FBM detail oriented by the altitude gradient),
+/// or stay a low soft band? Hillshade (palette-free) of the HD 1024²
+/// product on seeds 42 (S arc) + 1988 (N+E margins) — the franc-O-C seeds.
+/// Hypothesis: 1b-i turned the dome's MOU gradient into a margin-peaked
+/// NET gradient; the FBM amplifies gradients → a low-but-sharp ridge may
+/// become a chain in HD where the dome could not. Measure before coding
+/// any force/meso fix (reading a before b/c).
+#[test]
+#[ignore]
+fn measure_ridge_hd_amplitude() {
+    let dir = output_dir().join("ridge_hd_amplitude");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let cfg = FbmUpscaleConfig {
+        target_size: 1024, coast_warp_strength: 1.5, coast_warp_frequency: 0.5,
+        coastal_amplitude_band: 0.30, amplitude_base: 0.16, submarine_damping: 0.0,
+        ..Default::default()
+    };
+    eprintln!("#155 (a) ridge HD amplitude — hillshade of upscale_from_c1 (1024²)");
+    for &seed in &[42u64, 1988u64] {
+        let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300,
+            dx: 1.0 / 64.0, dy: 1.0 / 64.0,
+            iso_config: iso_config.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let up = upscale_from_c1(&state, &iso_config, &ss, &WorldSeed::new(seed), &cfg);
+        let h = &up.heightmap;
+        // Full-frame hillshade (palette-free relief).
+        save_hillshade_crop(h, 0, 0, h.width, &dir.join(format!("seed{seed:05}_hillshade_full.png")));
+        // Also grayscale full (continuous height, no palette bands).
+        save_gray01_crop(h, 0, 0, h.width, &dir.join(format!("seed{seed:05}_gray_full.png")));
+        eprintln!("  seed {seed}: HD {}² hillshade + gray written", h.width);
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
+/// #155 amplitude reading — quantitative O-C-margin vs passive-margin
+/// contrast. Does 1b-i leave a measurable elevation signal at O-C
+/// margins above passive (non-convergent) margins, or is it ≈1 (coastal
+/// band erases it)? Measured on the COARSE production altitude (where
+/// 1b-i imprints directly, before FBM dilution). Bands: cells 1..=6
+/// inland of their respective margin. O-C band = typed-wedge is_oc &&
+/// 1<=d<=6; passive band = continental, !is_oc, Manhattan dist-to-ocean
+/// 1..=6. Ratio >1 (even modest) = sub-visible signal erosion could
+/// amplify; ≈1 = 1b-i imprints ~nothing in elevation.
+#[test]
+#[ignore]
+fn measure_oc_vs_passive_margin() {
+    use ymir_core::tectonics_c1::boundary_classification::{
+        classify_boundaries, oc_override_seed_mask, retarget_upper_plate_continental,
+    };
+    use ymir_core::tectonics_c1::distance_field::wedge_distance_intra_plate_typed;
+    let iso_config = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    eprintln!("#155 O-C vs passive margin elevation contrast (coarse altitude, band 1..=6)");
+    for &seed in &[42u64, 1988u64, 1337u64, 2u64] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300,
+            dx: 1.0 / 64.0, dy: 1.0 / 64.0,
+            iso_config: iso_config.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+        // Reproduce production geometry on the final state.
+        let mut bi = classify_boundaries(&state.plate_id, &kin);
+        retarget_upper_plate_continental(&mut bi, &state.plate_id, &state.plate_type);
+        let oc_seed = oc_override_seed_mask(&bi, &state.plate_id, &state.plate_type);
+        let (wd, is_oc) = wedge_distance_intra_plate_typed(
+            &state.plate_id, &bi.upper_plate_mask, &oc_seed, 30.0,
+        );
+        let alt = c1_production_altitude(&state.s, &state.age, &state.plate_type, &iso_config, &ss);
+
+        let is_cont = |i: usize, j: usize| matches!(state.plate_type.get(i, j), PlateType::Continental);
+        // Manhattan dist-to-ocean over continental cells (multi-source BFS).
+        let mut d_ocean = vec![usize::MAX; grid * grid];
+        let mut q = std::collections::VecDeque::new();
+        for j in 0..grid { for i in 0..grid {
+            if !is_cont(i, j) { d_ocean[j * grid + i] = 0; q.push_back((i, j)); }
+        }}
+        while let Some((i, j)) = q.pop_front() {
+            let dc = d_ocean[j * grid + i];
+            for (di, dj) in [(-1i32, 0i32), (1, 0), (0, -1), (0, 1)] {
+                let (ni, nj) = (i as i32 + di, j as i32 + dj);
+                if ni < 0 || nj < 0 || ni as usize >= grid || nj as usize >= grid { continue; }
+                let (ni, nj) = (ni as usize, nj as usize);
+                if d_ocean[nj * grid + ni] > dc + 1 {
+                    d_ocean[nj * grid + ni] = dc + 1;
+                    q.push_back((ni, nj));
+                }
+            }
+        }
+
+        // ARTIFACT GUARD (see [[feedback_ratio_across_affine_rescaled_spaces]]):
+        // report the O-C−passive GAP in the SAME normalised [0,1] space the
+        // HD product uses ((alt+half)/(2·half), sea→0.5), NOT a ratio on raw
+        // altitude. A raw-altitude ratio here (1.2-1.5) vs an HD-normalised
+        // ratio (1.05-1.12) elsewhere is a false "collapse" (pure +offset
+        // arithmetic) — it misled the #155 amplitude diagnostic for a full
+        // round. Gap-in-consistent-space is cross-state comparable; ratio is
+        // not. `half` mirrors production_upscale::ALTITUDE_NORM_HALF_RANGE.
+        let half = 1.13_f64;
+        let norm = |a: f64| ((a + half) / (2.0 * half)).clamp(0.0, 1.0);
+        let (mut oc_sum, mut oc_n) = (0.0f64, 0usize);
+        let (mut pa_sum, mut pa_n) = (0.0f64, 0usize);
+        for j in 0..grid { for i in 0..grid {
+            if !is_cont(i, j) { continue; }
+            let a = norm(alt.get(i as i32, j as i32) as f64);
+            let dw = wd.get(i, j);
+            if is_oc.get(i, j) && dw >= 1.0 && dw <= 6.0 {
+                oc_sum += a; oc_n += 1;
+            } else if !is_oc.get(i, j) {
+                let do_ = d_ocean[j * grid + i];
+                if do_ >= 1 && do_ <= 6 { pa_sum += a; pa_n += 1; }
+            }
+        }}
+        let oc_mean = oc_sum / oc_n.max(1) as f64;
+        let pa_mean = pa_sum / pa_n.max(1) as f64;
+        eprintln!(
+            "  seed {seed:5}: O-C band (norm) = {oc_mean:.4} (n={oc_n:4})  passive band (norm) = {pa_mean:.4} (n={pa_n:4})  GAP = {:+.4}",
+            oc_mean - pa_mean
+        );
+    }
+}
+
+/// #155 reading (a-erosion) PROXY — apply v2 droplet hydraulic erosion
+/// (erosion::hydraulic::run_erosion — SAME TYPE as the expected phase-4
+/// HD erosion, so representative) to the C1 upscaled heightmap, and ask
+/// the DIFFERENTIAL question: does erosion amplify the O-C ridge
+/// PREFERENTIALLY (O-C/passive elevation ratio RISES → ridge emerges,
+/// (a) succeeds) or UNIFORMLY (ratio flat → ridge stays drowned, (a)
+/// fails → (b)/(c))? Measures the same O-C-vs-passive contrast on the HD
+/// heightmap PRE and POST erosion (coarse band cells mapped to HD
+/// blocks), plus a post-erosion hillshade for the eye.
+#[test]
+#[ignore]
+fn measure_aerosion_proxy() {
+    use ymir_core::tectonics_c1::boundary_classification::{
+        classify_boundaries, oc_override_seed_mask, retarget_upper_plate_continental,
+    };
+    use ymir_core::tectonics_c1::distance_field::wedge_distance_intra_plate_typed;
+    use ymir_core::erosion::hydraulic::{run_erosion, ErosionConfig};
+    let dir = output_dir().join("aerosion_proxy");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let cfg = FbmUpscaleConfig {
+        target_size: 1024, coast_warp_strength: 1.5, coast_warp_frequency: 0.5,
+        coastal_amplitude_band: 0.30, amplitude_base: 0.16, submarine_damping: 0.0,
+        ..Default::default()
+    };
+    let ero_cfg = ErosionConfig { num_droplets: 2_000_000, batch_size: 50_000, ..Default::default() };
+    eprintln!("#155 (a-erosion) proxy — droplet hydraulic erosion on C1 HD; O-C/passive ratio pre vs post");
+    for &seed in &[42u64, 1988u64, 1337u64] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300,
+            dx: 1.0 / 64.0, dy: 1.0 / 64.0,
+            iso_config: iso_config.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+        let mut bi = classify_boundaries(&state.plate_id, &kin);
+        retarget_upper_plate_continental(&mut bi, &state.plate_id, &state.plate_type);
+        let oc_seed = oc_override_seed_mask(&bi, &state.plate_id, &state.plate_type);
+        let (wd, is_oc) = wedge_distance_intra_plate_typed(
+            &state.plate_id, &bi.upper_plate_mask, &oc_seed, 30.0,
+        );
+        let is_cont = |i: usize, j: usize| matches!(state.plate_type.get(i, j), PlateType::Continental);
+        // dist-to-ocean (Manhattan) for the passive band.
+        let mut d_ocean = vec![usize::MAX; grid * grid];
+        let mut q = std::collections::VecDeque::new();
+        for j in 0..grid { for i in 0..grid {
+            if !is_cont(i, j) { d_ocean[j * grid + i] = 0; q.push_back((i, j)); }
+        }}
+        while let Some((i, j)) = q.pop_front() {
+            let dc = d_ocean[j * grid + i];
+            for (di, dj) in [(-1i32, 0i32), (1, 0), (0, -1), (0, 1)] {
+                let (ni, nj) = (i as i32 + di, j as i32 + dj);
+                if ni < 0 || nj < 0 || ni as usize >= grid || nj as usize >= grid { continue; }
+                let (ni, nj) = (ni as usize, nj as usize);
+                if d_ocean[nj * grid + ni] > dc + 1 { d_ocean[nj * grid + ni] = dc + 1; q.push_back((ni, nj)); }
+            }
+        }
+        // Coarse band membership: 0 = none, 1 = O-C, 2 = passive.
+        let mut band = vec![0u8; grid * grid];
+        for j in 0..grid { for i in 0..grid {
+            if !is_cont(i, j) { continue; }
+            let dw = wd.get(i, j);
+            if is_oc.get(i, j) && dw >= 1.0 && dw <= 6.0 { band[j * grid + i] = 1; }
+            else if !is_oc.get(i, j) {
+                let do_ = d_ocean[j * grid + i];
+                if do_ >= 1 && do_ <= 6 { band[j * grid + i] = 2; }
+            }
+        }}
+
+        let up = upscale_from_c1(&state, &iso_config, &ss, &WorldSeed::new(seed), &cfg);
+        let h0 = up.heightmap.clone();
+        let eroded = run_erosion(&h0, &ero_cfg, &WorldSeed::new(seed), |_, _, _| true);
+        let h1 = &eroded.heightmap;
+        let scale = h0.width / grid; // 16
+
+        // Mean HD height over the coarse band's HD blocks.
+        let mean_over_band = |hd: &GridF32, target: u8| -> f64 {
+            let (mut s, mut n) = (0.0f64, 0usize);
+            for j in 0..grid { for i in 0..grid {
+                if band[j * grid + i] != target { continue; }
+                for jj in 0..scale { for ii in 0..scale {
+                    s += hd.get((i * scale + ii) as i32, (j * scale + jj) as i32) as f64; n += 1;
+                }}
+            }}
+            s / n.max(1) as f64
+        };
+        // ARTIFACT GUARD ([[feedback_ratio_across_affine_rescaled_spaces]]):
+        // h0/h1 are ALREADY normalised [0,1] (upscale_from_c1 output), so
+        // report the O-C−passive GAP (cross-state comparable) — NOT a ratio,
+        // and NEVER compare this number to a raw-altitude ratio (that mix is
+        // the false-collapse trap). The differential verdict is gap_post vs
+        // gap_pre: gap RISES → erosion amplifies the ridge preferentially.
+        let (oc0, pa0) = (mean_over_band(&h0, 1), mean_over_band(&h0, 2));
+        let (oc1, pa1) = (mean_over_band(h1, 1), mean_over_band(h1, 2));
+        eprintln!(
+            "  seed {seed:5}: PRE  O-C={oc0:.4} passive={pa0:.4} GAP={:+.4}  | POST O-C={oc1:.4} passive={pa1:.4} GAP={:+.4}",
+            oc0 - pa0, oc1 - pa1,
+        );
+        save_hillshade_crop(h1, 0, 0, h1.width, &dir.join(format!("seed{seed:05}_eroded_hillshade.png")));
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
+/// #155 reading (a) CLOSURE — visual confirmation in CONSISTENT
+/// normalization. The corrected quantitative verdict: the O-C ridge
+/// signal survives upscale + is amplified by erosion (gap +60-76% in
+/// consistent space). This triptych confirms by eye whether that
+/// preserved-but-modest ridge reads as a distinct CHAIN or stays
+/// coastal-dominated (→ méso/structure the next subject).
+///
+/// CRITICAL: all three states share the SAME normalization AND
+/// resolution. The coarse is routed through `upscale_from_c1` with a
+/// FLAT config (amplitude_base=0, coast_warp=0 → pure bicubic of the
+/// normalized coarse), so it differs from the upscale state ONLY by the
+/// FBM detail — not by a normalization offset (the artifact we caught)
+/// nor a 64²-vs-1024² hillshade-gradient mismatch (a second cross-space
+/// trap). State 2 = prod #151 config; state 3 = state 2 + v2 erosion.
+#[test]
+#[ignore]
+fn triptych_consistent_norm() {
+    use ymir_core::erosion::hydraulic::{run_erosion, ErosionConfig};
+    let dir = output_dir().join("triptych_norm");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso_config = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    // Flat config: pure bicubic upscale of the normalized coarse (NO FBM,
+    // NO warp) → macro ossature at 1024², same normalization as prod.
+    let cfg_flat = FbmUpscaleConfig {
+        target_size: 1024, amplitude_base: 0.0, coast_warp_strength: 0.0,
+        coastal_amplitude_band: 0.0, ..Default::default()
+    };
+    // Prod #151 config (the real aval).
+    let cfg_prod = FbmUpscaleConfig {
+        target_size: 1024, coast_warp_strength: 1.5, coast_warp_frequency: 0.5,
+        coastal_amplitude_band: 0.30, amplitude_base: 0.16, submarine_damping: 0.0,
+        ..Default::default()
+    };
+    let ero_cfg = ErosionConfig { num_droplets: 2_000_000, batch_size: 50_000, ..Default::default() };
+    eprintln!("#155 (a) closure — consistent-norm hillshade triptych (coarse-bicubic / upscale / eroded)");
+    for &seed in &[1337u64, 1988u64, 42u64] {
+        let mut state = init_c1_state_phase_2_r7(64, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300,
+            dx: 1.0 / 64.0, dy: 1.0 / 64.0,
+            iso_config: iso_config.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+        let coarse = upscale_from_c1(&state, &iso_config, &ss, &WorldSeed::new(seed), &cfg_flat);
+        let up = upscale_from_c1(&state, &iso_config, &ss, &WorldSeed::new(seed), &cfg_prod);
+        let eroded = run_erosion(&up.heightmap, &ero_cfg, &WorldSeed::new(seed), |_, _, _| true);
+
+        let w = coarse.heightmap.width;
+        save_hillshade_crop(&coarse.heightmap, 0, 0, w, &dir.join(format!("seed{seed:05}_1_coarse_norm.png")));
+        save_hillshade_crop(&up.heightmap, 0, 0, w, &dir.join(format!("seed{seed:05}_2_upscale_norm.png")));
+        save_hillshade_crop(&eroded.heightmap, 0, 0, w, &dir.join(format!("seed{seed:05}_3_eroded_norm.png")));
+        eprintln!("  seed {seed}: triptych written ({w}²)");
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/crates/ymir-core/tests/c1_phase_1_2_davis_suppe.rs
+++ b/crates/ymir-core/tests/c1_phase_1_2_davis_suppe.rs
@@ -336,18 +336,16 @@ fn davis_suppe_wedge_body_invariants() {
         "Phase 1.2 (c1) saturation failed: fill_near = {fill_near:.3} ≤ 0.5 — \
          closure under-fills the near-boundary wedge band"
     );
-    // #155 maillon 1a KNOWN-RED (deliberately left failing — issue #155).
-    // Maillon 1a retargets the DS wedge onto the CONTINENTAL plate at O-C
-    // subductions (relief now appears — measured +12.4 % mean continental
-    // S̃ on seed 42), but does NOT yet fix the wedge GEOMETRY: the deposit
-    // fills the continental INTERIOR (a Tibet-style dome, `h_critical(d)`
-    // rises with d), so the far band (d∈10-20) fills and the near/far
-    // asymmetry collapses (≈1.11). (c2) encodes the CORRECT target — a
-    // margin-concentrated ridge (near>far, the Andes we want) — so it is
-    // NOT re-baselined: it is the macro-border thermometer, RED while the
-    // geometry is a dome (1a) and expected to go GREEN once maillon 1b
-    // concentrates the wedge near the O-C margin. Consistent with the
-    // direction note above (~lines 324-329), which anticipated this flip.
+    // #155 maillon 1b-i RESTORED. This near>far asymmetry is the macro-
+    // border thermometer. It briefly went RED under maillon 1a (≈1.11):
+    // 1a retargeted the DS wedge onto the continental plate at O-C
+    // subductions but left the geometry a Tibet-style dome filling the
+    // interior. Maillon 1b-i routes the O-C wedge to a margin-peaked ridge
+    // profile (`h_max·exp(−d/l_taper)`, peaks at the margin, decays
+    // inland), concentrating the relief near the boundary → near/far rises
+    // back above 1.5 (measured ≈1.70). Green here means the O-C relief is
+    // a margin ridge (Andes), not an interior dome. Consistent with the
+    // direction note above (~lines 324-329).
     assert!(
         asymmetry > 1.5,
         "Phase 1.2 (c2) asymmetry failed: mean(d∈0-5)/mean(d∈10-20) = {asymmetry:.3} ≤ 1.5 — \

--- a/crates/ymir-core/tests/c1_phase_1_2_davis_suppe.rs
+++ b/crates/ymir-core/tests/c1_phase_1_2_davis_suppe.rs
@@ -336,6 +336,18 @@ fn davis_suppe_wedge_body_invariants() {
         "Phase 1.2 (c1) saturation failed: fill_near = {fill_near:.3} ≤ 0.5 — \
          closure under-fills the near-boundary wedge band"
     );
+    // #155 maillon 1a KNOWN-RED (deliberately left failing — issue #155).
+    // Maillon 1a retargets the DS wedge onto the CONTINENTAL plate at O-C
+    // subductions (relief now appears — measured +12.4 % mean continental
+    // S̃ on seed 42), but does NOT yet fix the wedge GEOMETRY: the deposit
+    // fills the continental INTERIOR (a Tibet-style dome, `h_critical(d)`
+    // rises with d), so the far band (d∈10-20) fills and the near/far
+    // asymmetry collapses (≈1.11). (c2) encodes the CORRECT target — a
+    // margin-concentrated ridge (near>far, the Andes we want) — so it is
+    // NOT re-baselined: it is the macro-border thermometer, RED while the
+    // geometry is a dome (1a) and expected to go GREEN once maillon 1b
+    // concentrates the wedge near the O-C margin. Consistent with the
+    // direction note above (~lines 324-329), which anticipated this flip.
     assert!(
         asymmetry > 1.5,
         "Phase 1.2 (c2) asymmetry failed: mean(d∈0-5)/mean(d∈10-20) = {asymmetry:.3} ≤ 1.5 — \

--- a/docs/reports/c1_continental_buoyancy/stage_orogeny_diagnostic.md
+++ b/docs/reports/c1_continental_buoyancy/stage_orogeny_diagnostic.md
@@ -1,0 +1,104 @@
+# Orogeny diagnostic — why C1 continents are plateaus without mountain chains
+
+The understanding that must precede any relief-chantier fix (the analogue of the
+#145 buoyancy diagnostic). Symptom established by the quantitative cut profiles
+(`profile_convergent_arc_seed42`); cause established by code-reading + ONE
+counterfactual. Both MEASURED, not presumed.
+
+## Symptom (profiles across the convergent arc, seed 42, 3 cuts, consistent)
+At a coast convergence: S̃ has a **sharp spike at t=0** (1.4–2.1) but on the
+**OCEANIC** cell (plate_type=O) → altitude there = Stein-Stein bathymetry
+(deep, ~−0.55) → invisible. The **CONTINENTAL** side (t≥1) is a flat plateau
+(S̃≈1.0, altitude≈+0.4). No orogen.
+
+## Code-read verdict — (A): an orogeny mechanism EXISTS but is mis-targeted
+Three mechanisms act at a convergence; none builds a continental orogen:
+
+1. **Davis-Suppe** (`apply_davis_suppe_step`) — thickens the "upper plate"
+   wedge body toward `h_critical(d) = h_max·(1−exp(−d/l_taper))`. But "upper"
+   is defined in `classify_boundaries` by **`is_upper = v_mag_c > v_mag_n`** —
+   the strictly **FASTER** plate, **plate_type-BLIND**. In real orogeny the
+   overriding (thickening) plate is the CONTINENTAL one (Andes on South
+   America). The model targets the faster plate → if the ocean converges
+   faster, DS thickens OCEANIC cells (lost to Stein-Stein); the continent gets
+   nothing. DS also SKIPS the convergent boundary cells themselves (acts on the
+   interior wedge body).
+2. **Subduction arc-mass** (`distribute_arc_mass` via `apply_subduction_step`) —
+   DOES add S̃ to continental cells (arc volcanism): `arc_efficiency=0.5` of the
+   consumed oceanic mass, spread by BFS over `arc_distance=3` onto ALL
+   continental cells reached (`per_cell = arc_mass/n`). Real continental
+   thickening, but DIFFUSE + weak (small consumed mass, spread wide, capped by
+   equilibrium-height, eroded) → a soft broad bump, not a chain.
+3. **Advective pile-up at the rigid margin** — the t=0 oceanic S̃ spike is
+   NEITHER DS NOR a closure deposit: oceanic crust advects into the rigid
+   no-flux continental margin (#145 `step_upwind_masked`) and accumulates on the
+   oceanic boundary cell. Subduction consumes it; advection refills faster.
+
+**Causal chain:** convergence → ocean advects into the rigid margin → no-flux
+piles S̃ on the OCEANIC boundary cell → `apply_stein_stein_bathymetry`
+overwrites that cell's altitude with age-based depth (S̃ **ignored**) → no relief.
+Meanwhile DS thickens the FASTER plate (not the continent), subduction arc-mass
+is diffuse, accretion only merges plates → continent stays a plateau.
+
+**Altitude branch (confirmed):** `apply_stein_stein_bathymetry` overwrites
+**Oceanic** cells (`altitude = −stein_stein_depth(age)`, S̃ unused);
+**Continental** cells keep `isostasy(S̃)`. So a high-S̃ OCEANIC cell never
+becomes relief; a high-S̃ CONTINENTAL cell does (the dome counterfactual + the
+existing cratonic domes prove this path works).
+
+## Counterfactual — DOUBLE verdict (both measured)
+Throwaway: force `upper = continental` (the convergent CONTINENTAL cells seed
+the DS wedge), re-run seed 42 (env-gated patch in `time_loop`, reverted after).
+
+1. **Lever (A) is REAL** (not an innocenced suspect this time — a true lever):
+   the continent thickens and gains relief — cut-2 continental side S̃ 1.13→1.39,
+   altitude +0.43→+0.55; S̃ render interior visibly browner; altitude render a
+   brown highland massif where the baseline was green/flat. **DS mis-targeting
+   (faster vs continental) was a dominant cause of the flat continent.**
+2. **Geometry is wrong**: the relief is a **broad interior DOME (Tibet)**, NOT a
+   **linear marginal chain (Andes)**. Cause: `h_critical(d)` RISES with distance
+   from the boundary + `max_distance≈30` ≈ the whole 64² continent → the wedge
+   FILLS the interior instead of BORDERING the margin.
+
+## Chantier macro-border = TWO distinct components
+- **Retarget** (`upper → continental`): necessary, proven. NOT 1 line — requires
+  threading `plate_type` into `classify_boundaries` (19 callers; via optional
+  param or a continental-aware path). The upper-plate criterion
+  (`is_upper = v_mag_c > v_mag_n`) is the mis-target.
+- **Geometry** (concentrate the wedge near the margin): necessary for a chain,
+  distinct from retarget.
+
+## Physical nuance — dome vs ridge are BOTH real (do not "fix" dome uniformly)
+Tibet (broad plateau) and the Andes (narrow chain) are two real orogen types by
+convergence type:
+- **Subduction (ocean under continent, O-C)** → narrow chain along the margin
+  (Andes).
+- **Collision (continent-continent, C-C)** → wide thickened plateau (Tibet).
+
+So the geometry fix is NOT "always concentrate near the margin" (that would make
+Andes everywhere, wrong at collisions) but **"concentrate at SUBDUCTIONS, fill at
+COLLISIONS"** — routed by convergence type. The diversity the analysis wants is
+HAVING BOTH per tectonics, not replacing a uniform defect (dome) with another
+(uniform ridge).
+
+**Does the model distinguish subduction from collision? (code-read, verified):**
+- `classify_boundaries` is plate_type-BLIND (Convergent/Divergent/Transform by
+  velocity normal only) — does NOT distinguish O-C from C-C.
+- BUT the **subduction** closure already keys on the O-C geometry (Filter 2 =
+  Oceanic cell + Continental neighbour) → the INFORMATION (plate_type of the two
+  plates at the boundary) IS available and already used there.
+- There is NO collision (C-C) orogeny: `accretion` only merges plates.
+- ⇒ The model HAS the ingredients to route by convergence type; DS simply does
+  not consume them. A geometry fix can branch on the boundary's plate-type pair:
+  narrow marginal wedge at O-C, broad fill at C-C.
+
+## Injection points (surface only)
+- Retarget: the `is_upper` criterion in `classify_boundaries` (thread `plate_type`).
+- Geometry by type: branch the DS wedge profile/extent (`l_taper`/`max_distance`,
+  or which side it deposits) on the O-C vs C-C plate-type pair at the boundary.
+- Existing continental-deposit hook: `distribute_arc_mass` (subduction) already
+  puts S̃ on the continental side — concentrating it would make an O-C chain.
+
+## NOT done here
+The fix is not coded. This is the diagnostic. The chantier (retarget + type-routed
+geometry) scopes from this. The throwaway counterfactual patch was reverted.


### PR DESCRIPTION
Macro-border ossature for C1 relief: the Davis-Suppe orogenic wedge now
lands on the continental plate at oceanic-continental (O-C) subductions
and is shaped as a margin-peaked ridge (Andes-like coastal cordillera).
References #155 (does not close it — méso + interior are the follow-on chantiers).

## What changed
- **1a — retarget** (`2d8e241`): `retarget_upper_plate_continental` flips the
  DS "upper plate" from the velocity heuristic (faster plate, plate_type-blind,
  which often thickened the oceanic side → lost to Stein-Stein) to the
  **continental** side at O-C convergences. C-C and O-O strictly untouched
  (velocity fallback); bounded-to-O-C proven structurally by
  `retarget_bounded_to_oc_subduction`.
- **1b-i — geometry** (`17929b1`): O-C wedge cells use a margin-peaked target
  `h_max·exp(−d/l_taper)` (peaks at the margin, decays inland), routed by a typed
  wedge-distance that propagates each seed's O-C flag. C-C / fallback keep the
  rising-to-plateau dome (Tibet). Reuses `l_taper` — **no new knob**. Test callers
  of `apply_davis_suppe_step` are byte-identical (None path).
- **Diagnostics** (`64ef899`, `#[ignore]`, test-only): the relief-chantier
  measurement instruments (HD hillshade, O-C-vs-passive contrast, hydraulic-erosion
  proxy, consistent-norm triptych), reporting the contrast as a **gap in a
  consistent normalised space** (guarded against the affine-ratio artifact).

## Validation
- **c2 near/far asymmetry** restored GREEN (1.702 > 1.5, was 1.11 under the 1a dome)
  — for the right reason (relief margin-concentrated, `fill_near` 1.03).
- **Quantitative:** O-C−passive elevation gap survives upscale and is amplified by
  hydraulic erosion (+60–76% through the aval, consistent normalised space).
- **Visual (7 seeds):** linear margin ridges follow the O-C arcs; erosion produces
  an Andes-like coastal cordillera preferentially at O-C margins; O-O oceanic
  convergence makes no continental relief.
- No new C1 regression; Track A/B/D acceptance + galleries stay green.

## Known limit (actionable, not a hidden defect)
The cordillera is distinct only on a **franc** O-C arc (e.g. 1988, 42). On a
**fragmented** arc (e.g. 1337) the ridge does not separate from the passive coastal
escarpment — a force/geometry-on-weak-arcs subject, distinct from méso.

## Out of scope / follow-on
- **1b-ii (C-C collision)**: sans objet in the current quasi-static topology
  (0/7 seeds show a real continent-continent collision).
- **Méso** (interior tectonic structure: parallel ridges, longitudinal valleys)
  and the flat **interior** are the next chantiers — reading (a) confirmed the
  downstream carries the macro signal; what's missing is meso-scale structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
