### PR TITLE
C1 HD production: wire hydraulic erosion into upscale_from_c1 (deliver the judged product)

### DIFF
--- a/crates/ymir-core/src/tectonics_c1/production_upscale.rs
+++ b/crates/ymir-core/src/tectonics_c1/production_upscale.rs
@@ -30,6 +30,7 @@
 //! asserts the precondition (64²/256² structure convergence) so a
 //! future change that breaks it is caught, not just warned against.
 
+use crate::erosion::hydraulic::run_erosion;
 use crate::grid::GridF32;
 use crate::seed::WorldSeed;
 use crate::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
@@ -144,7 +145,31 @@ pub fn upscale_from_c1(
     }
     let sea_level_normalized = 0.5_f32;
 
-    upscale_with_fbm(&coarse, sea_level_normalized, seed, cfg)
+    let result = upscale_with_fbm(&coarse, sea_level_normalized, seed, cfg);
+
+    // #155 méso — HD hydraulic erosion (the dendritic dissection that makes
+    // the macro ridge read as credible eroded mountains). Applied AFTER the
+    // FBM, ONLY when `cfg.erosion` is Some (the canonical C1 HD product config
+    // `FbmUpscaleConfig::c1_hd_production` turns it on; default None →
+    // byte-identical). Slope is RECOMPUTED post-erosion (it changed);
+    // `sediment` is forwarded (the rivers/lakes hook, not consumed yet).
+    let Some(ero) = &cfg.erosion else {
+        return result;
+    };
+    let eroded = run_erosion(&result.heightmap, ero, seed, |_, _, _| true);
+    let h = &eroded.heightmap;
+    let mut slope = GridF32::new(h.width, h.height, 0.0);
+    for j in 0..h.height {
+        for i in 0..h.width {
+            let (gx, gy) = h.gradient_at(i, j);
+            slope.set(i, j, (gx * gx + gy * gy).sqrt());
+        }
+    }
+    UpscaleResult {
+        heightmap: eroded.heightmap,
+        slope,
+        sediment: Some(eroded.sediment),
+    }
 }
 
 #[cfg(test)]

--- a/crates/ymir-core/src/terrain/upscale.rs
+++ b/crates/ymir-core/src/terrain/upscale.rs
@@ -5,6 +5,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use super::noise::SeededNoise;
+use crate::erosion::hydraulic::ErosionConfig;
 use crate::grid::GridF32;
 use crate::seed::WorldSeed;
 
@@ -66,6 +67,17 @@ pub struct FbmUpscaleConfig {
     /// coast irregularity; this removes the micro-feathering. Default:
     /// 0.0 (OFF → byte-identical to pre-#151; v2 unaffected).
     pub coastal_amplitude_band: f64,
+    /// **HD hydraulic erosion** (#155 méso). When `Some`, [`upscale_from_c1`]
+    /// (tectonics_c1::production_upscale) applies droplet hydraulic erosion
+    /// to the HD heightmap AFTER the FBM step — the dendritic dissection that
+    /// turns the C1 macro ridge into credible eroded mountains (the méso bar
+    /// for Living Landz; validated by the 2048² état-des-lieux). Default
+    /// `None` → no erosion (byte-identical; smoke/regression/probe tests and
+    /// v2's `upscale_with_fbm` path are unaffected — only `upscale_from_c1`
+    /// reads this field). The canonical C1 HD product config that turns it
+    /// ON is [`FbmUpscaleConfig::c1_hd_production`].
+    #[serde(default)]
+    pub erosion: Option<ErosionConfig>,
 }
 
 impl Default for FbmUpscaleConfig {
@@ -86,6 +98,49 @@ impl Default for FbmUpscaleConfig {
             coast_warp_strength: 0.0,
             coast_warp_frequency: 0.5,
             coastal_amplitude_band: 0.0,
+            erosion: None,
+        }
+    }
+}
+
+impl FbmUpscaleConfig {
+    /// Canonical C1 HD product config (#155) — the #151 coastline params
+    /// + HD hydraulic erosion ON (the validated 2048² état-des-lieux
+    /// product). `target_size` parameterised; `num_droplets` is scaled at
+    /// the judged density (4M at 2048²) ∝ `target_size²` so the dissection
+    /// is resolution-coherent (#151 spirit), 2048² == 4M exactly (the judged
+    /// point). The path that DELIVERS the HD product must use THIS (else the
+    /// erosion-off product — judged non-deliverable — ships).
+    ///
+    /// COST (product characteristic): the 4M-droplet erosion at 2048² is
+    /// ~2 min/seed (measured 105–125 s). This is an OFFLINE / background
+    /// export path, NOT interactive — the Living Landz pipeline must generate
+    /// the HD product in the background, not on-the-fly.
+    ///
+    /// NOTE (#155 follow-up): `ErosionConfig::sea_level` defaults to 0.1 and
+    /// is PRESERVED here as-judged — the état-des-lieux rendered with that
+    /// (mismatched) value. The normalised sea level is actually 0.5; setting
+    /// `sea_level = 0.5` is the CORRECT value but CHANGES coastal deposition
+    /// → a separate follow-up maillon to re-judge the coastal render, NOT a
+    /// silent fix here. Do not "correct" it in passing.
+    #[must_use]
+    pub fn c1_hd_production(target_size: usize) -> Self {
+        let num_droplets =
+            (4_000_000u64 * (target_size as u64).pow(2) / (2048u64).pow(2)) as usize;
+        Self {
+            target_size,
+            coast_warp_strength: 1.5,
+            coast_warp_frequency: 0.5,
+            coastal_amplitude_band: 0.30,
+            amplitude_base: 0.16,
+            submarine_damping: 0.0,
+            erosion: Some(ErosionConfig {
+                num_droplets,
+                batch_size: 100_000,
+                // sea_level 0.1 preserved as-judged (see note above).
+                ..Default::default()
+            }),
+            ..Default::default()
         }
     }
 }
@@ -96,6 +151,10 @@ pub struct UpscaleResult {
     pub heightmap: GridF32,
     /// The slope magnitude field (useful for erosion and viz).
     pub slope: GridF32,
+    /// Sediment / water-passage map from HD erosion (#155) — `Some` only
+    /// when `cfg.erosion` ran. Forwarded from `ErosionResult.sediment`; the
+    /// hook for a future rivers/lakes chantier (NOT consumed yet).
+    pub sediment: Option<GridF32>,
 }
 
 /// Hermite smoothstep: 0 at lo, 1 at hi, smooth transition.
@@ -341,7 +400,7 @@ pub fn upscale_with_fbm(
         }
     }
 
-    UpscaleResult { heightmap, slope: slope_out }
+    UpscaleResult { heightmap, slope: slope_out, sediment: None }
 }
 
 /// Compute slope magnitude and direction on the coarse grid.

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -2870,3 +2870,162 @@ fn probe_sigma_macro() {
         }
     }
 }
+
+/// #155 méso B viability — the central bet: does ISOTROPIC hydraulic
+/// erosion on an already-tectonically-ORIENTED FBM texture yield distinct
+/// PARALLEL cordilleras, or generic DENDRITIC dissection that erases the
+/// orientation? Throwaway (no wiring, no prod change): on the REAL macro
+/// ridge (σ=0.5, no synthetic injection), upscale with a BOOSTED
+/// anisotropic FBM (amplitude/anisotropy/slope-factor up), then
+/// run_erosion. Compare pre- vs post-erosion hillshades:
+///   - cordilleras survive/sharpen → B viable, wire HD erosion cleanly;
+///   - dendritic dissection (orientation erased) → B needs an ORIENTED
+///     erosion (anisotropy input in hydraulic.rs), more work to scope.
+/// Visual is authoritative ([[feedback_visual_over_scalar]]).
+#[test]
+#[ignore]
+fn probe_meso_erosion_orientation() {
+    use ymir_core::erosion::hydraulic::{run_erosion, ErosionConfig};
+    let dir = output_dir().join("meso_erosion_orient");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default(); // σ=0.5
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    // BOOSTED anisotropic FBM: stronger oriented ridges on the macro slopes.
+    let cfg = FbmUpscaleConfig {
+        target_size: 1024,
+        amplitude_base: 0.30,        // 0.16 → 0.30 (taller méso ridges)
+        max_anisotropy: 8.0,         // 3.0 → 8.0 (long margin-parallel stretch)
+        amplitude_slope_factor: 5.0, // 3.0 → 5.0 (amplitude on the ridge flanks)
+        coast_warp_strength: 1.5, coast_warp_frequency: 0.5,
+        coastal_amplitude_band: 0.30, submarine_damping: 0.0,
+        ..Default::default()
+    };
+    let ero_cfg = ErosionConfig { num_droplets: 2_000_000, batch_size: 50_000, ..Default::default() };
+    eprintln!("#155 méso B viability — isotropic erosion on oriented FBM: cordilleras or dendritic?");
+    for &seed in &[1988u64, 42u64] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0,
+            iso_config: iso.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        save_hillshade_crop(&up.heightmap, 0, 0, up.heightmap.width,
+            &dir.join(format!("seed{seed:05}_1_oriented_fbm.png")));
+        let eroded = run_erosion(&up.heightmap, &ero_cfg, &WorldSeed::new(seed), |_, _, _| true);
+        save_hillshade_crop(&eroded.heightmap, 0, 0, eroded.heightmap.width,
+            &dir.join(format!("seed{seed:05}_2_eroded.png")));
+        eprintln!("  seed {seed}: oriented-FBM + eroded hillshades written");
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
+/// Land/sea binary map (Living Landz output): land (h > sea) green, sea blue.
+fn save_binarymap(h: &GridF32, sea: f32, path: &Path) {
+    let (nx, ny) = (h.width, h.height);
+    let mut img = ImageBuffer::<Rgb<u8>, Vec<u8>>::new(nx as u32, ny as u32);
+    for j in 0..ny { for i in 0..nx {
+        let v = h.get(i as i32, j as i32);
+        let c = if v > sea { Rgb([70, 140, 70]) } else { Rgb([40, 80, 160]) };
+        img.put_pixel(i as u32, (ny - 1 - j) as u32, c);
+    }}
+    img.save(path).expect("save binarymap PNG");
+}
+
+/// #155 PRODUCT état-des-lieux — the C1 product at the Living Landz target
+/// 2048², ALL seeds, WITH sea level visible (hypsometric) + binarymap.
+/// Pipeline = C1 (σ=0.5) → upscale_from_c1 (prod #151 FBM) → run_erosion
+/// (the decided méso = dendritic dissection; NOTE erosion is NOT YET WIRED
+/// into upscale_from_c1, Case 2a — applied manually here pending that
+/// maillon). Full world, no crop. Judge: credible mountains on all seeds?
+/// coasts natural / relief stays on land? oceans flat (known gap)?
+#[test]
+#[ignore]
+fn product_etat_des_lieux() {
+    use ymir_core::erosion::hydraulic::{run_erosion, ErosionConfig};
+    let dir = output_dir().join("product_2048");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default(); // σ=0.5
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let cfg = FbmUpscaleConfig {
+        target_size: 2048, coast_warp_strength: 1.5, coast_warp_frequency: 0.5,
+        coastal_amplitude_band: 0.30, amplitude_base: 0.16, submarine_damping: 0.0,
+        ..Default::default()
+    };
+    let ero_cfg = ErosionConfig { num_droplets: 4_000_000, batch_size: 100_000, ..Default::default() };
+    let sea = 0.5f32; // upscale_from_c1 maps sea level to 0.5
+    eprintln!("#155 product état-des-lieux — 2048², all seeds, hypsometric + binarymap (C1 σ0.5 + upscale + erosion)");
+    for &seed in &[2u64, 42, 99, 1337, 1988, 2026, 4138] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0,
+            iso_config: iso.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        let eroded = run_erosion(&up.heightmap, &ero_cfg, &WorldSeed::new(seed), |_, _, _| true);
+        let h = &eroded.heightmap;
+        save_heightmap01(h, &dir.join(format!("seed{seed:05}_hypso.png")));
+        save_binarymap(h, sea, &dir.join(format!("seed{seed:05}_binary.png")));
+        save_hillshade_crop(h, 0, 0, h.width, &dir.join(format!("seed{seed:05}_hillshade.png")));
+        let land = h.data.iter().filter(|&&v| v > sea).count();
+        eprintln!("  seed {seed}: {}² written, land = {:.1}%", h.width, 100.0 * land as f64 / (h.width*h.height) as f64);
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
+/// #155 HD-production wiring ACCEPTANCE — upscale_from_c1 with the canonical
+/// c1_hd_production config now delivers the eroded (dissected) product the
+/// 2048² état-des-lieux judged. Confirms: (1) product ≡ état-des-lieux
+/// (hypso/hillshade), (2) determinism run×2 byte-identical, (3) cost at
+/// 2048², (4) sediment hook present + slope recomputed post-erosion.
+#[test]
+#[ignore]
+fn hd_production_acceptance() {
+    let dir = output_dir().join("hd_production");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let cfg = FbmUpscaleConfig::c1_hd_production(2048);
+    eprintln!("#155 HD production acceptance — c1_hd_production(2048), seeds 1988/42/2026");
+    eprintln!("  cfg: target={} erosion={}", cfg.target_size,
+        cfg.erosion.as_ref().map(|e| e.num_droplets).unwrap_or(0));
+    for &seed in &[1988u64, 42, 2026] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0,
+            iso_config: iso.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+        // COST + product: ONE 2048² pass (the heavy, judged config).
+        let t0 = std::time::Instant::now();
+        let up1 = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        let dt = t0.elapsed();
+        let sed = up1.sediment.is_some();
+        let land = up1.heightmap.data.iter().filter(|&&v| v > 0.5).count();
+        // DETERMINISM: proven cheaply at 512² (run×2), NOT at the heavy 2048².
+        let cfg_det = FbmUpscaleConfig::c1_hd_production(512);
+        let d1 = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg_det);
+        let d2 = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg_det);
+        let det = d1.heightmap.data == d2.heightmap.data;
+        eprintln!("  seed {seed}: {}² in {dt:.2?}  det(512²)={}  sediment={}  slope_ok={}  land={:.1}%",
+            up1.heightmap.width, if det {"OK"} else {"MISMATCH"}, sed,
+            up1.slope.data.iter().any(|&s| s > 0.0),
+            100.0 * land as f64 / (up1.heightmap.width*up1.heightmap.height) as f64);
+        save_heightmap01(&up1.heightmap, &dir.join(format!("seed{seed:05}_hypso.png")));
+        save_hillshade_crop(&up1.heightmap, 0, 0, up1.heightmap.width, &dir.join(format!("seed{seed:05}_hillshade.png")));
+        assert!(det, "seed {seed}: HD production not deterministic run×2 (512²)");
+        assert!(sed, "seed {seed}: sediment hook missing");
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/crates/ymir-viz/src/visualization/v2_viz.rs
+++ b/crates/ymir-viz/src/visualization/v2_viz.rs
@@ -1393,7 +1393,7 @@ fn load_phase_caches_from_dir(
                 // safe. Re-running UpscaleFbm regenerates the real
                 // slope from scratch.
                 let slope = GridF32::from_vec(nx, ny, vec![0.0; nx * ny]);
-                fbm_cache.result = Some(UpscaleResult { heightmap, slope });
+                fbm_cache.result = Some(UpscaleResult { heightmap, slope, sediment: None });
                 fbm_cache.last_status = Some(Ok("loaded from disk".into()));
                 fbm_cache.mark_dirty();
                 info!("[import] upscale_fbm result restored");


### PR DESCRIPTION
Closes the prospective/actual gap identified by the product état-des-lieux @2048²:
the margin-mountain realism it validated only existed via manually-applied erosion —
the shipped product was undissected FBM. This wires `run_erosion` into the
production path.

- `FbmUpscaleConfig.erosion: Option<ErosionConfig>` — `#[serde(default)]`, default
  `None` → byte-identical for all existing callers (smoke, structure-convergence
  regression, méso probes, v2 — `upscale_with_fbm` never reads the field).
- `FbmUpscaleConfig::c1_hd_production()` — the canonical C1 HD product config:
  #151 params + `erosion: Some(validated)` (4M droplets / 2048², verbatim the
  config the état-des-lieux judged; droplet count scales ∝ target_size² at that
  density). Mirrors the `IsostasyConfig::c1_default` gating pattern.
- `UpscaleResult.sediment: Option<GridF32>` — forwarded from `ErosionResult`
  (free); the hook for the future rivers/lakes layer. Not coding rivers here.
- `slope` recomputed post-erosion — the Living Landz slopemap becomes a correct
  by-product.

## Acceptance (measured)
- Product ≡ état-des-lieux: regenerated 1988/42/2026 @2048² via c1_hd_production —
  land% identical (24.1/21.2/28.7), same pipeline + config → the wired product
  reproduces the judged one.
- Determinism: run×2 byte-identical, proven at 512² (the `rng_for_indexed`
  batch-seeding is size-independent).
- Cost @2048²: ~2 min/seed (1988: 112s, 42: 125s, 2026: 105s) — inherent to the
  validated 4M-droplet density. **This is an offline export path, not
  interactive** — the future Living Landz output pipeline should generate in the
  background.
- Byte-identity: smoke + structure-convergence green (default None unchanged);
  v2 untouched (does not call upscale_from_c1; v2_viz change is mechanical
  struct-init only [adjust per the check]).

## Known limits / follow-ups (#155 stays open)
- `ErosionConfig.sea_level = 0.1` is preserved **as-judged** (the état-des-lieux
  ran with it; the normalized sea level is 0.5). Correcting to 0.5 changes coastal
  deposition → a separate correctness follow-up that must re-judge the coastal
  render, not a silent fix. Documented in code.
- Continental-interior relief (the dominant remaining realism gap — relief is
  margin-bound) and submarine relief: later chantiers per the état-des-lieux
  prioritization.

## Refs
État-des-lieux @2048² (7 seeds, `product_2048/`), #155 (not closed).