### PR TITLE
Issue #155 interior relief — thick + erosion-resistant cratons (A′)

### DIFF
--- a/crates/ymir-core/src/tectonics_c1/closures/erosion/params.rs
+++ b/crates/ymir-core/src/tectonics_c1/closures/erosion/params.rs
@@ -60,6 +60,16 @@ pub struct ErosionParams {
     /// Defensive against pathological `k · A^m · S^n · dt > S̃`
     /// configurations.
     pub floor: f64,
+    /// #155 A′ — craton erosion-resistance. `K` is multiplied by this
+    /// factor on cells flagged cratonic, so ancient stable cratons erode
+    /// SLOWER (their defining property alongside thick crust). Default
+    /// `1.0` = OFF / byte-identical (v2, unit tests, generic erosion). The
+    /// canonical C1 config (`C1Closures::default`) sets it < 1 (anchored in
+    /// the real craton/non-craton erosion-rate band ~3-10×); without it an
+    /// init-thick craton is planed (and can INVERT) by normal erosion — the
+    /// measured 2026 craton-S̃ inversion. Pairs with the init thickness
+    /// differential (`Phase2InitParams::craton_thickness_ratio`).
+    pub craton_resist: f64,
 }
 
 impl Default for ErosionParams {
@@ -70,6 +80,7 @@ impl Default for ErosionParams {
             m: 0.5,
             n: 1.0,
             floor: 0.2,
+            craton_resist: 1.0, // OFF by default — byte-identical
         }
     }
 }

--- a/crates/ymir-core/src/tectonics_c1/closures/erosion/source_term.rs
+++ b/crates/ymir-core/src/tectonics_c1/closures/erosion/source_term.rs
@@ -54,6 +54,39 @@ pub fn apply_erosion_step(
     dt: f64,
     dx: f64,
 ) {
+    erosion_loop(s, altitude, drainage_areas, params, dt, dx, None);
+}
+
+/// #155 A′ — erosion with craton resistance. Identical to
+/// [`apply_erosion_step`] except `K` is scaled by `params.craton_resist`
+/// on cells where `craton` is set (ancient cratons erode slower — their
+/// defining property; resolves the measured craton-S̃ inversion that
+/// planed elevated cratons like normal crust). `craton_resist == 1.0`
+/// (default) → byte-identical to the plain step. The C1 time loop calls
+/// THIS, passing the state's cratonic mask.
+#[allow(clippy::too_many_arguments)]
+pub fn apply_erosion_step_craton(
+    s: &mut Field2D,
+    altitude: &GridF32,
+    drainage_areas: &[u32],
+    params: &ErosionParams,
+    dt: f64,
+    dx: f64,
+    craton: &crate::tectonics_c1::state::BoolField,
+) {
+    erosion_loop(s, altitude, drainage_areas, params, dt, dx, Some(craton));
+}
+
+#[allow(clippy::too_many_arguments)]
+fn erosion_loop(
+    s: &mut Field2D,
+    altitude: &GridF32,
+    drainage_areas: &[u32],
+    params: &ErosionParams,
+    dt: f64,
+    dx: f64,
+    craton: Option<&crate::tectonics_c1::state::BoolField>,
+) {
     if !params.enabled {
         return;
     }
@@ -88,7 +121,12 @@ pub fn apply_erosion_step(
             if a <= 0.0 {
                 continue;
             }
-            let erosion_rate = k * a.powf(m) * slope.powf(n_exp);
+            // #155 A′: cratons resist erosion (K × craton_resist where masked).
+            let k_cell = match craton {
+                Some(mask) if mask.get(i, j) => k * params.craton_resist,
+                _ => k,
+            };
+            let erosion_rate = k_cell * a.powf(m) * slope.powf(n_exp);
             let delta = erosion_rate * dt;
             let s_old = s.get(i, j);
             // Issue #145 — clean non-injecting removal. The legacy

--- a/crates/ymir-core/src/tectonics_c1/init_r7/mod.rs
+++ b/crates/ymir-core/src/tectonics_c1/init_r7/mod.rs
@@ -108,6 +108,25 @@ pub struct Phase2InitParams {
     pub cluster: ContinentalClusterParams,
     /// Ridge-aligned age = 0 init (sub-component 3, Path 3.A).
     pub age: AgeInitParams,
+    /// #155 A′ — cratonic crustal-thickness ratio. After the cratonic
+    /// mask is built, continental cratonic cells get their initial S̃
+    /// multiplied by this (Airy: thick craton crust → elevated). Default
+    /// 1.25 (canonical C1; real crustal ratio ~40 km craton / ~32 km
+    /// platform). Set to 1.0 to disable (byte-identical to pre-#155 init).
+    /// Pairs with `ErosionParams::craton_resist` so the differential is
+    /// not planed/inverted by erosion (the measured 2026 inversion).
+    ///
+    /// MAGNITUDE (measured, defaults A′-on): cratons render ~600-1100 m
+    /// above non-craton land (conversion-dependent — the robust measure is
+    /// the ~0.134 normalised difference / S̃ ratio ~1.5-1.8; the metres
+    /// figure depends on the unpinned norm→m vertical scale). NOT
+    /// geologically wrong — real cratons include high plateaus (~1000-
+    /// 1500 m, e.g. southern African); the 300-500 m target was the MOST
+    /// WORN shields. Lowering it = a MODEL refinement (worn-init / Jordan
+    /// compositional isostasy / cumulative wear over eons — 300 steps ≠
+    /// eons), NOT a knob (params stay anchored: 1.25 = crustal ratio,
+    /// craton_resist mid-band). Worn-shield height = documented follow-up.
+    pub craton_thickness_ratio: f64,
 }
 
 impl Default for Phase2InitParams {
@@ -116,6 +135,7 @@ impl Default for Phase2InitParams {
             r7: R7InitParams::default(),
             cluster: ContinentalClusterParams::default(),
             age: AgeInitParams::default(),
+            craton_thickness_ratio: 1.25,
         }
     }
 }
@@ -235,7 +255,7 @@ pub fn init_c1_state_phase_2_r7(
             seed_coords: Some(&seed_coords),
         }),
     };
-    let s = init_s_field(InitMode::default(), &init_ctx);
+    let mut s = init_s_field(InitMode::default(), &init_ctx);
 
     // Step 7 — kinematics (Phase 1.1 preset; Track C/D
     // placeholder per Stage E4 W7 concern).
@@ -260,6 +280,20 @@ pub fn init_c1_state_phase_2_r7(
     // pub(crate)-promoted helper).
     let cratonic_mask =
         build_phase_1_1_cratonic_mask(nx, ny, &plate_id, &plate_type, &seed_coords);
+
+    // Step 11 (#155 A′) — cratonic crustal-thickness differential. Thick
+    // cratonic crust (Airy isostasy → elevated worn shields). Multiply the
+    // initial continental cratonic S̃ by the ratio (mask is built only on
+    // continental cells). ratio == 1.0 → no-op (byte-identical pre-#155).
+    if params.craton_thickness_ratio != 1.0 {
+        for j in 0..ny {
+            for i in 0..nx {
+                if cratonic_mask.get(i, j) {
+                    s.set(i, j, s.get(i, j) * params.craton_thickness_ratio);
+                }
+            }
+        }
+    }
 
     C1State {
         s,

--- a/crates/ymir-core/src/tectonics_c1/time_loop.rs
+++ b/crates/ymir-core/src/tectonics_c1/time_loop.rs
@@ -63,7 +63,7 @@ use super::closures::davis_suppe::source_term::{apply_davis_suppe_step_routed, D
 use super::closures::equilibrium_height::params::EquilibriumHeightParams;
 use super::closures::equilibrium_height::source_term::apply_equilibrium_height_step;
 use super::closures::erosion::params::ErosionParams;
-use super::closures::erosion::source_term::{apply_erosion_step, compute_drainage_areas};
+use super::closures::erosion::source_term::{apply_erosion_step_craton, compute_drainage_areas};
 use super::closures::oceanic_bathymetry::params::SteinSteinParams;
 use super::closures::oceanic_bathymetry::source_term::apply_stein_stein_bathymetry;
 use super::closures::rifting::{
@@ -324,7 +324,12 @@ impl Default for C1Closures {
         Self {
             davis_suppe: DavisSuppeParams::default(),
             equilibrium_height: EquilibriumHeightParams::default(),
-            erosion: ErosionParams::default(),
+            // #155 A′ — canonical C1 activates craton erosion-resistance
+            // (anchored mid-band ~5×). Pairs with the init thickness
+            // differential (Phase2InitParams::craton_thickness_ratio) so
+            // cratons (thick + resistant) stand as elevated worn shields.
+            // ErosionParams::default() keeps 1.0 (off) for v2/unit/generic.
+            erosion: ErosionParams { craton_resist: 0.2, ..ErosionParams::default() },
             oceanic_bathymetry: SteinSteinParams::default(),
             subduction: SubductionParams::default(),
             accretion: AccretionParams::default(),
@@ -743,13 +748,15 @@ pub fn run_with_closures<F>(
                     config.drainage_max_distance,
                 );
                 let drainage_areas = compute_drainage_areas(&drainage_map);
-                apply_erosion_step(
+                // #155 A′: craton-aware erosion (resist from params; 1.0 = byte-identical).
+                apply_erosion_step_craton(
                     &mut state.s,
                     &altitude,
                     &drainage_areas,
                     &closures.erosion,
                     dt,
                     config.dx,
+                    &state.cratonic_mask,
                 );
             }
         }

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -3029,3 +3029,117 @@ fn hd_production_acceptance() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155 INTERIOR relief — economical-hypothesis test. The interior is flat
+/// because NOTHING couples craton/age → continental altitude (EH treats
+/// cratons uniformly; isostasy = S̃ only; age → oceanic only). Hypothesis:
+/// the interior needs no new closure — just LARGE-SCALE altitude variation
+/// (from the cratonic_mask we already HAVE) so the aval (σ=0.5 + FBM +
+/// erosion) dresses it into relief, the way the macro gradient lets the
+/// aval work at margins. Test (throwaway, post-loop = advection-free):
+/// bump continental S̃ by Δ·smooth(cratonic_mask) → upscale_from_c1 (erosion
+/// ON) → does interior relief APPEAR over cratons vs the flat baseline?
+/// Visual authoritative; interior altitude std (continental, away from
+/// coast) base vs bumped as a scalar companion.
+#[test]
+#[ignore]
+fn probe_interior_craton() {
+    let dir = output_dir().join("interior_craton");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let cfg = FbmUpscaleConfig::c1_hd_production(1024); // 1024² for speed
+    let delta = 1.0f64; // S̃ bump in craton cores (→ ~+0.17 raw altitude)
+    eprintln!("#155 interior craton — does the aval dress a gentle craton gradient into relief? (Δ={delta})");
+    for &seed in &[42u64, 2026, 1988] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0,
+            iso_config: iso.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let n_craton = (0..grid*grid).filter(|k| state.cratonic_mask.get(k % grid, k / grid)).count();
+
+        // BASELINE (flat interior).
+        let up_base = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        save_hillshade_crop(&up_base.heightmap, 0, 0, up_base.heightmap.width, &dir.join(format!("seed{seed:05}_1_base.png")));
+
+        // Smooth craton field → gentle large-scale gradient.
+        let mut cf = GridF32::new(grid, grid, 0.0);
+        for j in 0..grid { for i in 0..grid {
+            if state.cratonic_mask.get(i, j) { cf.set(i, j, 1.0); }
+        }}
+        let cf = cf.gaussian_blur(4.0);
+        // BUMP continental S̃ post-loop (advection-free, large-scale).
+        for j in 0..grid { for i in 0..grid {
+            if matches!(state.plate_type.get(i, j), PlateType::Continental) {
+                let add = delta * cf.get(i as i32, j as i32) as f64;
+                state.s.set(i, j, state.s.get(i, j) + add);
+            }
+        }}
+        let up_bump = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        save_hillshade_crop(&up_bump.heightmap, 0, 0, up_bump.heightmap.width, &dir.join(format!("seed{seed:05}_2_craton_bumped.png")));
+        save_heightmap01(&up_bump.heightmap, &dir.join(format!("seed{seed:05}_2_craton_hypso.png")));
+
+        // Interior relief proxy: std of HD altitude over land cells (>0.5).
+        let interior_std = |h: &GridF32| -> f64 {
+            let land: Vec<f64> = h.data.iter().filter(|&&v| v > 0.5).map(|&v| v as f64).collect();
+            if land.is_empty() { return 0.0; }
+            let m = land.iter().sum::<f64>() / land.len() as f64;
+            (land.iter().map(|v| (v - m).powi(2)).sum::<f64>() / land.len() as f64).sqrt()
+        };
+        eprintln!("  seed {seed}: cratons={} cells  land-alt std base={:.4} bumped={:.4}",
+            n_craton, interior_std(&up_base.heightmap), interior_std(&up_bump.heightmap));
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
+/// #155 A′ CALIBRATION — judge the now-active (default) craton elevation on
+/// RENDERED altitude in METERS (not the raw S̃ ratio). Defaults are A′-on
+/// (craton_thickness 1.25 + craton_resist 0.2). Measures craton vs
+/// non-craton LAND mean altitude (HD, c1_hd_production) in metres
+/// (norm→m: (v−0.5)·2·max_elevation_m, max_elevation_m=4000). Target ~300-
+/// 500 m worn shield. Too high → check note (b) (base-erosion melting the
+/// non-craton denominator) before any in-band resist nudge.
+#[test]
+#[ignore]
+fn probe_craton_calibration() {
+    let dir = output_dir().join("craton_calib");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let cfg = FbmUpscaleConfig::c1_hd_production(1024);
+    let max_elev_m = 4000.0f64;
+    eprintln!("#155 A′ calibration — craton vs non-craton land altitude (m), defaults A′-on");
+    for &seed in &[42u64, 1988, 2026] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default(); // A′ active
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0,
+            iso_config: iso.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        let scale = up.heightmap.width / grid;
+        let (mut cs, mut cn, mut ns, mut nn) = (0.0f64, 0usize, 0.0f64, 0usize);
+        for j in 0..grid { for i in 0..grid {
+            let craton = state.cratonic_mask.get(i, j);
+            for jj in 0..scale { for ii in 0..scale {
+                let v = up.heightmap.get((i*scale+ii) as i32, (j*scale+jj) as i32) as f64;
+                if v <= 0.5 { continue; } // land only
+                let m = (v - 0.5) * 2.0 * max_elev_m;
+                if craton { cs += m; cn += 1; } else { ns += m; nn += 1; }
+            }}
+        }}
+        let (cm, nm) = (cs / cn.max(1) as f64, ns / nn.max(1) as f64);
+        eprintln!("  seed {seed}: craton land mean = {cm:.0} m  non-craton = {nm:.0} m  craton above = {:.0} m  (target shield ~300-500)", cm - nm);
+        save_heightmap01(&up.heightmap, &dir.join(format!("seed{seed:05}_hypso.png")));
+        save_hillshade_crop(&up.heightmap, 0, 0, up.heightmap.width, &dir.join(format!("seed{seed:05}_hillshade.png")));
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/crates/ymir-core/tests/c1_phase_2_bathymetry_acceptance.rs
+++ b/crates/ymir-core/tests/c1_phase_2_bathymetry_acceptance.rs
@@ -409,7 +409,10 @@ fn disabled_matches_phase_1_4() {
     let closures_b = C1Closures {
         davis_suppe: DavisSuppeParams::default(),
         equilibrium_height: EquilibriumHeightParams::default(),
-        erosion: ErosionParams::default(),
+        // #155 A′: track the canonical erosion (now craton_resist=0.2 in
+        // C1Closures::default) rather than hardcoding ErosionParams::default
+        // (=1.0) — Path B must match Path A's `..C1Closures::default()`.
+        erosion: C1Closures::default().erosion,
         oceanic_bathymetry: SteinSteinParams {
             enabled: false,
             ..SteinSteinParams::default()


### PR DESCRIPTION
Continental interiors were flat (nothing coupled craton→altitude). A′ adds the
complete craton physics — thick crust (Airy elevates) + erosion-resistance
(maintains) — the true causal chain (init-thick → preserved-by-resistance →
isostasy-elevates → aval-dissects), correcting the S̃ field, not a render cosmetic.
References #155.

## What
- `Phase2InitParams.craton_thickness_ratio` (1.25 = crustal ratio): init_r7 step 11
  scales continental cratonic S̃. 1.0 → byte-identical init.
- `ErosionParams.craton_resist` (default 1.0 = OFF, byte-identical v2/unit): K scaled
  on cratons. `apply_erosion_step_craton` (delegating; plain step unchanged).
- Canonical C1 ACTIVATES it (`C1Closures::default().erosion.craton_resist=0.2`); v2 is
  byte-identical (uses neither C1Closures nor Phase2InitParams).

## Built by A's instructive failure
A-alone survives advection/EH/DS but the in-loop erosion inverts seed 2026
(craton→low). The inversion diagnosed the missing erosion-resistance. A′ removes it:
no inversion any seed (2026 0.67→1.95), robust elevated shields all seeds (visual).

## Contained
Only `disabled_matches_phase_1_4` moved — a stale hardcode (Path B froze
`ErosionParams::default`, now ≠ canonical), fixed to track the canonical. All other
C1 + ALL v2 green.

## Documented follow-ups (NOT knobs)
- Magnitude: cratons ~600-1100 m above lowland (conversion-dependent; robust = ~0.134
  norm / S̃ ratio ~1.5-1.8). Real cratons include high plateaus; worn-shield height =
  a MODEL refinement (worn-init / Jordan isostasy / eons of wear), params anchored.
- norm→m vertical scale unpinned = a product-contract gap (outputs-completeness).
- seed-99 craton-less worlds → no shields (init follow-up).