### PR TITLE
Issue #155 — C1 interior relief: HD erosion wiring + cratons (thick / resistant / dense)

### DIFF
--- a/crates/ymir-core/src/tectonics/isostasy.rs
+++ b/crates/ymir-core/src/tectonics/isostasy.rs
@@ -80,6 +80,18 @@ pub struct IsostasyConfig {
     /// deserialize to `MinMaxFraction` (avoids the #47-style break).
     #[serde(default)]
     pub sea_level_mode: SeaLevelMode,
+    /// #155 B-Jordan — optional CRATONIC crustal density (kg/m³). When
+    /// `Some`, [`compute_isostasy_craton`] uses it instead of `rho_crust`
+    /// on cells flagged cratonic → lower Airy buoyancy → a thick craton
+    /// (1.25× S̃) elevates LESS (compositional isostasy: old cratonic
+    /// lower crust is dense / the cold lithospheric root is ~neutrally
+    /// buoyant, so the thick crust does NOT over-elevate — worn-shield
+    /// height). Real cratonic crust ~2850-2950 vs 2750 normal. Default
+    /// `None` → scalar buoyancy = byte-identical (v2/export untouched).
+    /// Orthogonal to `craton_resist` (this is ALTITUDE via density; resist
+    /// is the S̃ order). Thickness ratio (1.25) stays anchored.
+    #[serde(default)]
+    pub craton_rho_crust: Option<f32>,
 }
 
 impl Default for IsostasyConfig {
@@ -93,6 +105,7 @@ impl Default for IsostasyConfig {
             sea_level_fraction: 0.4,
             altitude_smoothing_sigma: 2.0,
             sea_level_mode: SeaLevelMode::MinMaxFraction,
+            craton_rho_crust: None,
         }
     }
 }
@@ -128,6 +141,18 @@ impl IsostasyConfig {
             // 1988+4138). v2 + export keep the `Default` 2.0 (bit-compat).
             // See `stage_meso_expression.md`.
             altitude_smoothing_sigma: 0.5,
+            // #155 B-Jordan — cratonic crustal density 2900 (real range
+            // 2850-2950; old dense lower crust / cold neutrally-buoyant
+            // root). Thick craton (1.25× S̃) elevates LESS → worn high-
+            // plateau (~1650 m, S. African/Colorado type) instead of ~2340 m.
+            // Compositional isostasy — the 3rd real craton property (after
+            // thickness=Airy + resist=S̃-order); ALTITUDE-only (compute_isostasy
+            // scalar/None ignores it → loop S̃ unchanged; applies in
+            // upscale_from_c1 which threads cratonic_mask). Validated 4-density
+            // visual; 2900 corrects height without under-selling cratonic
+            // orogens (2950 over-lowers). Default keeps None (v2/export
+            // bit-compat). Anchored — not tuned to a target.
+            craton_rho_crust: Some(2900.0),
             ..Default::default()
         }
     }
@@ -153,9 +178,37 @@ pub struct IsostasyResult {
 /// The input is the Field2D from the solver (f64, dimensionless).
 /// The output is a normalized GridF32 heightmap suitable for erosion and export.
 pub fn compute_isostasy(thickness: &Field2D, config: &IsostasyConfig) -> IsostasyResult {
+    compute_isostasy_inner(thickness, config, None)
+}
+
+/// #155 B-Jordan — Airy isostasy with spatial CRATONIC density. Identical
+/// to [`compute_isostasy`] except cells where `craton[k]` is true use
+/// `config.craton_rho_crust` (if `Some`) for the buoyancy — a denser
+/// cratonic crust → lower buoyancy → a thick craton elevates LESS
+/// (compositional isostasy / worn-shield height). `craton` is a row-major
+/// `&[bool]` (length nx·ny) to avoid a tectonics→tectonics_c1 dependency
+/// cycle. With `craton_rho_crust == None` → byte-identical to the scalar.
+pub fn compute_isostasy_craton(
+    thickness: &Field2D,
+    config: &IsostasyConfig,
+    craton: &[bool],
+) -> IsostasyResult {
+    compute_isostasy_inner(thickness, config, Some(craton))
+}
+
+fn compute_isostasy_inner(
+    thickness: &Field2D,
+    config: &IsostasyConfig,
+    craton: Option<&[bool]>,
+) -> IsostasyResult {
     let nx = thickness.nx();
     let ny = thickness.ny();
     let buoyancy = 1.0 - config.rho_crust / config.rho_mantle;
+    // #155 B-Jordan: cratonic buoyancy (denser crust → less elevation).
+    let buoyancy_craton = match config.craton_rho_crust {
+        Some(r) => 1.0 - r / config.rho_mantle,
+        None => buoyancy,
+    };
 
     // 1. Compute raw isostatic elevation
     let mut h_raw = vec![0.0f32; nx * ny];
@@ -163,7 +216,8 @@ pub fn compute_isostasy(thickness: &Field2D, config: &IsostasyConfig) -> Isostas
     let mut h_max = f32::NEG_INFINITY;
 
     for (k, val) in thickness.data().iter().enumerate() {
-        let h = *val as f32 * buoyancy;
+        let b = if craton.is_some_and(|c| c[k]) { buoyancy_craton } else { buoyancy };
+        let h = *val as f32 * b;
         h_raw[k] = h;
         h_min = h_min.min(h);
         h_max = h_max.max(h);

--- a/crates/ymir-core/src/tectonics_c1/production_upscale.rs
+++ b/crates/ymir-core/src/tectonics_c1/production_upscale.rs
@@ -33,7 +33,7 @@
 use crate::erosion::hydraulic::run_erosion;
 use crate::grid::GridF32;
 use crate::seed::WorldSeed;
-use crate::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
+use crate::tectonics::isostasy::{compute_isostasy, compute_isostasy_craton, IsostasyConfig};
 use crate::tectonics_v2::boundaries::plate_type::PlateTypeField;
 use crate::tectonics_v2::field::Field2D;
 use crate::terrain::upscale::{upscale_with_fbm, FbmUpscaleConfig, UpscaleResult};
@@ -61,7 +61,36 @@ pub fn c1_production_altitude(
     iso: &IsostasyConfig,
     ss: &SteinSteinParams,
 ) -> GridF32 {
-    let isostasy = compute_isostasy(s, iso);
+    c1_production_altitude_inner(s, age, plate_type, iso, ss, None)
+}
+
+/// #155 B-Jordan — [`c1_production_altitude`] with spatial cratonic density.
+/// `craton` (row-major `&[bool]`, the cratonic mask) routes those cells to
+/// `compute_isostasy_craton` (denser cratonic crust → worn-shield altitude).
+/// `iso.craton_rho_crust == None` → byte-identical to the plain function.
+pub fn c1_production_altitude_craton(
+    s: &Field2D,
+    age: &Field2D,
+    plate_type: &PlateTypeField,
+    craton: &[bool],
+    iso: &IsostasyConfig,
+    ss: &SteinSteinParams,
+) -> GridF32 {
+    c1_production_altitude_inner(s, age, plate_type, iso, ss, Some(craton))
+}
+
+fn c1_production_altitude_inner(
+    s: &Field2D,
+    age: &Field2D,
+    plate_type: &PlateTypeField,
+    iso: &IsostasyConfig,
+    ss: &SteinSteinParams,
+    craton: Option<&[bool]>,
+) -> GridF32 {
+    let isostasy = match craton {
+        Some(c) => compute_isostasy_craton(s, iso, c),
+        None => compute_isostasy(s, iso),
+    };
     let mut altitude = isostasy.heightmap;
     // #151 F3 fix — despike the age before Stein-Stein. The flux-form age
     // advection piles age up at convergent plate boundaries (sparse cells
@@ -136,7 +165,11 @@ pub fn upscale_from_c1(
     // S̃ mesh non-convergence. Built via the SHARED `c1_production_altitude`
     // (same source of truth as the viz render) — do NOT inline a raw-S̃
     // path here; it reopens FOLLOWUPS #6 and silently diverges.
-    let mut coarse = c1_production_altitude(&state.s, &state.age, &state.plate_type, iso, ss);
+    // #155 B-Jordan: route the cratonic mask so cratonic cells get the
+    // dense-crust buoyancy (iso.craton_rho_crust). None → byte-identical.
+    let mut coarse = c1_production_altitude_craton(
+        &state.s, &state.age, &state.plate_type, state.cratonic_mask.data(), iso, ss,
+    );
 
     // Fixed normalisation to [0,1] (sea 0.0 → 0.5), resolution-independent.
     let half = ALTITUDE_NORM_HALF_RANGE;

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -3143,3 +3143,324 @@ fn probe_craton_calibration() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155 POST-A′ état-des-lieux — the product WITH interior cratons, via the
+/// canonical c1_hd_production (A′ active by default: thick + erosion-resistant
+/// cratons). 7 seeds, 2048², hypsometric (sea level) + hillshade + binarymap.
+/// Compares to the pre-A′ snapshot (product_2048): interiors now carry craton
+/// shields, margins keep their O-C ridges, oceans still flat (known gap).
+#[test]
+#[ignore]
+fn product_etat_des_lieux_aprime() {
+    let dir = output_dir().join("product_2048_aprime");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let cfg = FbmUpscaleConfig::c1_hd_production(2048); // erosion wired internally
+    let sea = 0.5f32;
+    eprintln!("#155 post-A′ état-des-lieux — 2048², all seeds, via c1_hd_production (A′ default-on)");
+    for &seed in &[2u64, 42, 99, 1337, 1988, 2026, 4138] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default(); // A′ active
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0,
+            iso_config: iso.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        let h = &up.heightmap;
+        save_heightmap01(h, &dir.join(format!("seed{seed:05}_hypso.png")));
+        save_binarymap(h, sea, &dir.join(format!("seed{seed:05}_binary.png")));
+        save_hillshade_crop(h, 0, 0, h.width, &dir.join(format!("seed{seed:05}_hillshade.png")));
+        let land = h.data.iter().filter(|&&v| v > sea).count();
+        eprintln!("  seed {seed}: {}² written, land = {:.1}%", h.width, 100.0 * land as f64 / (h.width*h.height) as f64);
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
+/// #155 PROMINENCE attribution — why is the orogen/craton differential
+/// crushed? Decompose end-of-loop S̃ (raw, consistent space) into three
+/// continental zones — margin orogen (O-C wedge), craton, platform — and
+/// test the hypothesis (i) orogens cap at EH h_eq=2.0 vs (ii) cratons
+/// drift up. Discriminator = a counterfactual run with NO craton
+/// differential (init ratio 1.0 + resist 1.0): does the margin/craton
+/// ratio re-open? + how many margin cells are above h_eq (EH-collapsed).
+#[test]
+#[ignore]
+fn probe_prominence_attribution() {
+    use ymir_core::tectonics_c1::boundary_classification::{
+        classify_boundaries, oc_override_seed_mask, retarget_upper_plate_continental,
+    };
+    use ymir_core::tectonics_c1::distance_field::wedge_distance_intra_plate_typed;
+    use ymir_core::tectonics_c1::closures::erosion::params::ErosionParams;
+    let iso = IsostasyConfig::c1_default();
+    let grid = 64usize;
+    let h_eq = 2.0f64;
+    let p95 = |mut v: Vec<f64>| -> f64 { if v.is_empty() { return f64::NAN; } v.sort_by(|a,b| a.partial_cmp(b).unwrap()); v[(v.len()*95/100).min(v.len()-1)] };
+    let med = |mut v: Vec<f64>| -> f64 { if v.is_empty() { return f64::NAN; } v.sort_by(|a,b| a.partial_cmp(b).unwrap()); v[v.len()/2] };
+    eprintln!("#155 prominence attribution — end-of-loop S̃ by zone (margin orogen / craton / platform)");
+    for &seed in &[42u64, 2026, 1988] {
+        // Geometry (zones) — from a default init (plate_id identical across variants).
+        let geom = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let kin0 = PlateKinematics::preset_phase_1_1(geom.num_plates);
+        let mut bi = classify_boundaries(&geom.plate_id, &kin0);
+        retarget_upper_plate_continental(&mut bi, &geom.plate_id, &geom.plate_type);
+        let oc_seed = oc_override_seed_mask(&bi, &geom.plate_id, &geom.plate_type);
+        let (wd, is_oc) = wedge_distance_intra_plate_typed(&geom.plate_id, &bi.upper_plate_mask, &oc_seed, 30.0);
+        let is_cont = |i: usize, j: usize| matches!(geom.plate_type.get(i, j), PlateType::Continental);
+        // EXCLUSIVE zones (de-confound craton∩wedge overlap): 1 pure orogen
+        // (wedge ∧ ¬craton), 2 pure craton (craton ∧ ¬wedge), 3 platform,
+        // 4 craton∩wedge (reported apart). wedge = O-C && wd<max_d.
+        let mut zone = vec![0u8; grid*grid];
+        for j in 0..grid { for i in 0..grid {
+            if !is_cont(i, j) { continue; }
+            let wedge = is_oc.get(i, j) && wd.get(i, j) < 30.0;
+            let crat = geom.cratonic_mask.get(i, j);
+            zone[j*grid+i] = match (wedge, crat) {
+                (true, false) => 1,
+                (false, true) => 2,
+                (false, false) => 3,
+                (true, true) => 4,
+            };
+        }}
+        let zsamp = |st: &C1State, z: u8| -> Vec<f64> {
+            let mut v = Vec::new();
+            for j in 0..grid { for i in 0..grid { if zone[j*grid+i]==z { v.push(st.s.get(i,j)); } }} v
+        };
+
+        let run = |ratio: f64, resist: f64| -> C1State {
+            let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams { craton_thickness_ratio: ratio, ..Default::default() });
+            let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+            let closures = C1Closures { erosion: ErosionParams { craton_resist: resist, ..ErosionParams::default() }, ..C1Closures::default() };
+            let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+            run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+            state
+        };
+
+        // craton S̃ at t=0 (A′ init, =1.25×base).
+        let c_t0 = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let craton_t0 = p95(zsamp(&c_t0, 2));
+
+        // A′ (default: ratio 1.25, resist 0.2).
+        let a = run(1.25, 0.2);
+        let (mg, cr, pf) = (p95(zsamp(&a,1)), p95(zsamp(&a,2)), p95(zsamp(&a,3)));
+        let mg_med = med(zsamp(&a,1)); let cr_med = med(zsamp(&a,2));
+        let above_heq = zsamp(&a,1).iter().filter(|&&v| v > h_eq).count();
+        let n_mg = zsamp(&a,1).len();
+        eprintln!("  seed {seed} [A′]: margin p95={mg:.3} (med {mg_med:.3}) craton p95={cr:.3} (med {cr_med:.3}, t0={craton_t0:.3}) platform p95={pf:.3}  ratio mg/cr={:.2}  margin>h_eq: {}/{} ({:.0}%)",
+            mg/cr.max(1e-6), above_heq, n_mg, 100.0*above_heq as f64/n_mg.max(1) as f64);
+
+        // Counterfactual: NO craton differential (ratio 1.0, resist 1.0).
+        let cf = run(1.0, 1.0);
+        let (mgc, crc) = (p95(zsamp(&cf,1)), p95(zsamp(&cf,2)));
+        eprintln!("  seed {seed} [CF no-craton-diff]: margin p95={mgc:.3} craton p95={crc:.3}  ratio mg/cr={:.2}  (re-opens if > A′)", mgc/crc.max(1e-6));
+    }
+}
+
+/// #155 OROGEN EQUILIBRIUM — DS targets h_max=2.5 but orogens reach ~1.0.
+/// Which agent brakes? Counterfactual chain-of-innocence: margin S̃ p95
+/// end-of-loop in {baseline A′, erosion-C1 OFF}. Erosion-OFF rises toward
+/// 2.5 → erosion rabote (mech 2). Stays low → DS rate too slow (mech 1)
+/// (advection mech 3 a-priori out: continental orogen is rigid/sealed,
+/// no-flux bidirectional). Margin = O-C wedge (is_oc && wd<max_d). 42/1988
+/// cratons≡margins (orogen on cratonic crust, S̃ starts 1.25×); 2026 =
+/// clean non-craton margin. Raw S̃, consistent space.
+#[test]
+#[ignore]
+fn probe_orogen_equilibrium() {
+    use ymir_core::tectonics_c1::boundary_classification::{
+        classify_boundaries, oc_override_seed_mask, retarget_upper_plate_continental,
+    };
+    use ymir_core::tectonics_c1::distance_field::wedge_distance_intra_plate_typed;
+    use ymir_core::tectonics_c1::closures::erosion::params::ErosionParams;
+    let iso = IsostasyConfig::c1_default();
+    let grid = 64usize;
+    let p95 = |mut v: Vec<f64>| -> f64 { if v.is_empty() { return f64::NAN; } v.sort_by(|a,b| a.partial_cmp(b).unwrap()); v[(v.len()*95/100).min(v.len()-1)] };
+    eprintln!("#155 orogen equilibrium — margin S̃ p95: baseline vs erosion-OFF (DS h_max=2.5)");
+    for &seed in &[42u64, 1988, 2026] {
+        let geom = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let kin0 = PlateKinematics::preset_phase_1_1(geom.num_plates);
+        let mut bi = classify_boundaries(&geom.plate_id, &kin0);
+        retarget_upper_plate_continental(&mut bi, &geom.plate_id, &geom.plate_type);
+        let oc_seed = oc_override_seed_mask(&bi, &geom.plate_id, &geom.plate_type);
+        let (wd, is_oc) = wedge_distance_intra_plate_typed(&geom.plate_id, &bi.upper_plate_mask, &oc_seed, 30.0);
+        let mut margin = vec![false; grid*grid];
+        for j in 0..grid { for i in 0..grid {
+            if matches!(geom.plate_type.get(i,j), PlateType::Continental) && is_oc.get(i,j) && wd.get(i,j) < 30.0 { margin[j*grid+i] = true; }
+        }}
+        let msamp = |st: &C1State| -> Vec<f64> { let mut v=Vec::new(); for j in 0..grid { for i in 0..grid { if margin[j*grid+i] { v.push(st.s.get(i,j)); } }} v };
+        let run = |erosion_on: bool| -> C1State {
+            let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+            let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+            let mut closures = C1Closures::default();
+            if !erosion_on { closures.erosion = ErosionParams { enabled: false, ..ErosionParams::default() }; }
+            let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+            run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+            state
+        };
+        let base = p95(msamp(&run(true)));
+        let no_ero = p95(msamp(&run(false)));
+        eprintln!("  seed {seed}: margin p95 baseline={base:.3}  erosion-OFF={no_ero:.3}  (rises→2.5 = erosion brakes; stays low = DS rate)  [DS h_max=2.5]");
+    }
+}
+
+/// #155 WORN-SHIELD sweep — re-calibrate craton_resist DOWN (cratons lower)
+/// to reopen prominence + plausible shield height, without re-inverting.
+/// Orogens are EH-ceiling-bound ~2.0 → prominence = cratons DOWN. A′
+/// resist=0.2 (5×) over-elevates (cratons ~1.3, prominence ~1.6×, height
+/// ~600-1100m). Sweep resist {0.2,0.33,0.5,0.7} (5×,3×,2×,1.4×) on RENDERED
+/// altitude (the lesson — not raw S̃). ratio_craton=1.25 fixed. 2026 =
+/// decisive (separate craton + inversion floor); 42/1988 control
+/// (craton≡margin). If no in-band (3-10×, resist 0.1-0.33) value hits
+/// worn-height + prominence + no-inversion → STRUCTURAL signal (worn-init
+/// needed, not a resist out-of-band).
+#[test]
+#[ignore]
+fn probe_worn_shield_sweep() {
+    use ymir_core::tectonics_c1::boundary_classification::{
+        classify_boundaries, oc_override_seed_mask, retarget_upper_plate_continental,
+    };
+    use ymir_core::tectonics_c1::distance_field::wedge_distance_intra_plate_typed;
+    use ymir_core::tectonics_c1::closures::erosion::params::ErosionParams;
+    let dir = output_dir().join("worn_shield");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let cfg = FbmUpscaleConfig::c1_hd_production(1024);
+    let p95 = |mut v: Vec<f64>| -> f64 { if v.is_empty() { return f64::NAN; } v.sort_by(|a,b| a.partial_cmp(b).unwrap()); v[(v.len()*95/100).min(v.len()-1)] };
+    let mean = |v: &[f64]| -> f64 { if v.is_empty() { return f64::NAN; } v.iter().sum::<f64>()/v.len() as f64 };
+    eprintln!("#155 worn-shield sweep — RENDERED altitude by zone vs craton_resist (ratio_craton=1.25 fixed)");
+    for &seed in &[2026u64, 42, 1988] {
+        let geom = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let kin0 = PlateKinematics::preset_phase_1_1(geom.num_plates);
+        let mut bi = classify_boundaries(&geom.plate_id, &kin0);
+        retarget_upper_plate_continental(&mut bi, &geom.plate_id, &geom.plate_type);
+        let oc_seed = oc_override_seed_mask(&bi, &geom.plate_id, &geom.plate_type);
+        let (wd, is_oc) = wedge_distance_intra_plate_typed(&geom.plate_id, &bi.upper_plate_mask, &oc_seed, 30.0);
+        // zone: 1 orogen(wedge¬craton), 2 craton(craton¬wedge), 3 platform, 4 both
+        let mut zone = vec![0u8; grid*grid];
+        for j in 0..grid { for i in 0..grid {
+            if !matches!(geom.plate_type.get(i,j), PlateType::Continental) { continue; }
+            let w = is_oc.get(i,j) && wd.get(i,j) < 30.0; let c = geom.cratonic_mask.get(i,j);
+            zone[j*grid+i] = match (w,c) { (true,false)=>1, (false,true)=>2, (false,false)=>3, (true,true)=>4 };
+        }}
+        eprintln!("  --- seed {seed} ---");
+        for &resist in &[0.2f64, 0.33, 0.5, 0.7] {
+            let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+            let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+            let closures = C1Closures { erosion: ErosionParams { craton_resist: resist, ..ErosionParams::default() }, ..C1Closures::default() };
+            let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+            run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+            let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+            let scale = up.heightmap.width / grid;
+            let zalt = |z: u8| -> Vec<f64> { let mut v=Vec::new(); for j in 0..grid { for i in 0..grid { if zone[j*grid+i]==z { for jj in 0..scale { for ii in 0..scale { let a=up.heightmap.get((i*scale+ii) as i32,(j*scale+jj) as i32) as f64; if a>0.5 { v.push(a); } }} } }} v };
+            let (oro, crat, plat) = (zalt(1), zalt(2), zalt(3));
+            let to_m = |norm: f64| (norm - 0.5) * 8000.0; // conversion-dependent, flagged
+            let crat_p95 = p95(crat.clone());
+            let prom = p95(oro.clone()) / crat_p95.max(1e-6);
+            let inverted = mean(&crat) < mean(&plat); // craton below platform = inverted
+            eprintln!("    resist={resist} ({:.0}×): craton p95={crat_p95:.3} (~{:.0} m above sea) prominence oro/cra={prom:.2}  inverted(vs platform)={inverted}",
+                1.0/resist, to_m(crat_p95));
+        }
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
+/// #155 B-JORDAN sweep — spatial cratonic density lowers thick-craton
+/// altitude (compositional isostasy) WITHOUT touching S̃ (orthogonal to
+/// resist). Sweep iso.craton_rho_crust {None, 2850, 2900, 2950} on RENDERED
+/// altitude. 2026 = decisive (separate craton): craton height plausible?
+/// prominence oro/craton → ~3×? altitude-order craton vs platform (Jordan
+/// too strong → altitude inversion even though S̃ ordered — resist covers
+/// S̃ NOT altitude). 42/1988 control: cratons≡margins → does Jordan LOWER
+/// the orogens there (craton∩wedge zone)? Loop S̃ shared (Jordan is
+/// altitude-only) → one loop/seed, upscale per density.
+#[test]
+#[ignore]
+fn probe_jordan_sweep() {
+    use ymir_core::tectonics_c1::boundary_classification::{
+        classify_boundaries, oc_override_seed_mask, retarget_upper_plate_continental,
+    };
+    use ymir_core::tectonics_c1::distance_field::wedge_distance_intra_plate_typed;
+    let iso0 = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let cfg = FbmUpscaleConfig::c1_hd_production(1024);
+    let p95 = |mut v: Vec<f64>| -> f64 { if v.is_empty() { return f64::NAN; } v.sort_by(|a,b| a.partial_cmp(b).unwrap()); v[(v.len()*95/100).min(v.len()-1)] };
+    let mean = |v: &[f64]| -> f64 { if v.is_empty() { return f64::NAN; } v.iter().sum::<f64>()/v.len() as f64 };
+    let to_m = |n: f64| (n - 0.5) * 8000.0; // conversion-dependent, flagged
+    eprintln!("#155 B-Jordan sweep — RENDERED altitude by zone vs craton_rho_crust");
+    for &seed in &[2026u64, 42, 1988] {
+        let geom = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let kin0 = PlateKinematics::preset_phase_1_1(geom.num_plates);
+        let mut bi = classify_boundaries(&geom.plate_id, &kin0);
+        retarget_upper_plate_continental(&mut bi, &geom.plate_id, &geom.plate_type);
+        let oc_seed = oc_override_seed_mask(&bi, &geom.plate_id, &geom.plate_type);
+        let (wd, is_oc) = wedge_distance_intra_plate_typed(&geom.plate_id, &bi.upper_plate_mask, &oc_seed, 30.0);
+        let mut zone = vec![0u8; grid*grid];
+        for j in 0..grid { for i in 0..grid {
+            if !matches!(geom.plate_type.get(i,j), PlateType::Continental) { continue; }
+            let w = is_oc.get(i,j) && wd.get(i,j) < 30.0; let c = geom.cratonic_mask.get(i,j);
+            zone[j*grid+i] = match (w,c) { (true,false)=>1, (false,true)=>2, (false,false)=>3, (true,true)=>4 };
+        }}
+        // C1 loop once (defaults A′: resist 0.2, thick 1.25). Jordan is altitude-only.
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso0.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        eprintln!("  --- seed {seed} ---");
+        for rho in [None, Some(2850.0f32), Some(2900.0), Some(2950.0)] {
+            let mut iso = iso0.clone(); iso.craton_rho_crust = rho;
+            let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+            let scale = up.heightmap.width / grid;
+            let zalt = |z: u8| -> Vec<f64> { let mut v=Vec::new(); for j in 0..grid { for i in 0..grid { if zone[j*grid+i]==z { for jj in 0..scale { for ii in 0..scale { let a=up.heightmap.get((i*scale+ii) as i32,(j*scale+jj) as i32) as f64; if a>0.5 { v.push(a); } }} } }} v };
+            let (oro, crat, plat, cw) = (zalt(1), zalt(2), zalt(3), zalt(4));
+            // orogen p95 = max of pure-orogen (z1) and craton∩wedge (z4) where present.
+            let oro_p95 = { let mut a=oro.clone(); a.extend(cw.clone()); p95(a) };
+            let crat_p95 = p95(crat.clone());
+            let prom = oro_p95 / crat_p95.max(1e-6);
+            let alt_inv = !crat.is_empty() && mean(&crat) < mean(&plat);
+            eprintln!("    rho={:?}: craton p95={crat_p95:.3} (~{:.0}m) orogen p95={oro_p95:.3} (~{:.0}m) prom={prom:.2}  craton<platform(altInv)={alt_inv}  [z4 craton∩wedge p95={:.3}]",
+                rho, to_m(crat_p95), to_m(oro_p95), p95(cw));
+        }
+    }
+    eprintln!("  out done");
+}
+
+/// #155 B-Jordan VISUAL — the density choice + craton/orogen morphology is
+/// a read, not a scalar (the rendered ratio is renorm-confounded). Render
+/// 2026 (separate craton, decisive) + 1988 (craton≡margin, control) at
+/// 2048² via c1_hd_production, sweeping craton_rho_crust {None,2850,2900,
+/// 2950}. hypso (height, renorm-confounded across densities — read with
+/// care) + hillshade (MORPHOLOGY — plateau-broad-flat vs chain-narrow — the
+/// KEY view). Gated (param, not productionized).
+#[test]
+#[ignore]
+fn probe_jordan_render() {
+    let dir = output_dir().join("jordan_render");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso0 = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let cfg = FbmUpscaleConfig::c1_hd_production(2048);
+    eprintln!("#155 B-Jordan render — 2026 + 1988, 2048², density {{None,2850,2900,2950}}");
+    for &seed in &[2026u64, 1988] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso0.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        for (tag, rho) in [("none", None), ("2850", Some(2850.0f32)), ("2900", Some(2900.0)), ("2950", Some(2950.0))] {
+            let mut iso = iso0.clone(); iso.craton_rho_crust = rho;
+            let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+            save_heightmap01(&up.heightmap, &dir.join(format!("seed{seed:05}_rho{tag}_hypso.png")));
+            save_hillshade_crop(&up.heightmap, 0, 0, up.heightmap.width, &dir.join(format!("seed{seed:05}_rho{tag}_hillshade.png")));
+            eprintln!("  seed {seed} rho={tag}: written");
+        }
+    }
+    eprintln!("  out = {}", dir.display());
+}


### PR DESCRIPTION
One causal arc closing the C1 interior-relief + worn-shield chantier. After the
macro-border (1a/1b-i) and méso-σ landed, the 2048² état-des-lieux showed two gaps:
the product was FBM-textured (not dissected), and continental **interiors were flat**.
This delivers both. References #155 (does not close it — see deferred below).

## The arc (3 maillons, FEAT+TEST each)
1. **HD erosion wired** (`d57c61b`) — `upscale_from_c1` applies `run_erosion` after FBM
   when `cfg.erosion` is Some; `FbmUpscaleConfig::c1_hd_production` is the canonical HD
   product config (erosion on, droplets ∝ target² at 4M@2048²). Delivers the dissected
   mountains (Case-2a gap). `sediment` forwarded (rivers/lakes hook); slope recomputed.
2. **Interior relief A′** (`0247ed7`) — flat interiors had nothing coupling craton→
   altitude. Adds the complete craton physics, each property won by a measured failure:

   | property | mechanism | designated by |
   |---|---|---|
   | **thickness** (1.25× S̃, Airy) | `Phase2InitParams.craton_thickness_ratio` | the flat-interior gap |
   | **resistance** (S̃ order) | `ErosionParams.craton_resist=0.2` (`apply_erosion_step_craton`) | the seed-2026 S̃ **inversion** (craton→low without it) |
   | **composition** (altitude) | `IsostasyConfig.craton_rho_crust=2900` (`compute_isostasy_craton`) | the **resist-sweep-no-effect** (height = thickness×isostasy, not erosion) |

3. **Worn-shield B-Jordan** (`576c000`) — compositional isostasy: dense cratonic crust
   (2900, real range 2850-2950) lowers the thick craton from ~2340 m to a ~1650 m worn
   **high-plateau** (S. African/Colorado type), at the anchored 1.25× thickness.
   ALTITUDE-only (loop S̃ unaffected); validated by a 4-density × 2-seed visual.

## Gating / safety
All three are **gated default-off** (`erosion: None`, `craton_resist=1.0`,
`craton_rho_crust: None`) → **byte-identical for v2/export/legacy**; the canonical C1
constructors (`c1_default`, `C1Closures::default`, `c1_hd_production`) activate them.
Isostasy 13/13. **Contained**: A′ moved one stale-hardcode test (`disabled_matches_
phase_1_4`, fixed to track the canonical); Jordan moved **zero** C1 tests (altitude-only
+ tolerance-robust). v2 untouched; only the pre-existing `rectangular_simulation` (v2)
stays red. Determinism run×2 holds.

## Cost
HD erosion ~2 min/seed @2048² → an **OFFLINE/background export** path, not interactive
(documented on `c1_hd_production`).

## Honest limits / deferred (documented, NOT gaps)
- **Prominence 3-5×**: orogens are EH-ceiling-bound (S̃~2.0); with anchored thick+dense
  cratons, C1 produces **high-plateau cratons rivaling orogens** (Tibet≈Himalaya, a real
  configuration), resolved in reading by **morphology** (broad plateau vs narrow ridge).
  Worn-LOW shields (orogens towering) = a different craton type → worn-init or a raised
  orogen EH ceiling — **deferred Phase-3**, not a knob.
- **norm→m vertical scale unpinned** — a product-contract gap (biome/climate/orography);
  craton metres are conversion-dependent; relief reported in normalized units.
- **`ErosionConfig.sea_level=0.1`** preserved as-judged (sea→0.5 correction = a separate
  re-judge follow-up).
- **seed-99** craton-less worlds → no shields (init follow-up); **submarine relief**
  (oceans flat) and downstream Living Landz layers (biome/river/slope) remain.

## Probes
The `#[ignore]` measurement suite (état-des-lieux, méso-B, attribution, sweeps,
Jordan render) that established each verdict — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
