### PR TITLE
C1 vertical contract: repair the phantom land-ceiling in isostasy normalization

### DIFF
--- a/crates/ymir-core/src/tectonics/isostasy.rs
+++ b/crates/ymir-core/src/tectonics/isostasy.rs
@@ -178,7 +178,7 @@ pub struct IsostasyResult {
 /// The input is the Field2D from the solver (f64, dimensionless).
 /// The output is a normalized GridF32 heightmap suitable for erosion and export.
 pub fn compute_isostasy(thickness: &Field2D, config: &IsostasyConfig) -> IsostasyResult {
-    compute_isostasy_inner(thickness, config, None)
+    compute_isostasy_inner(thickness, config, None, None)
 }
 
 /// #155 B-Jordan — Airy isostasy with spatial CRATONIC density. Identical
@@ -193,13 +193,40 @@ pub fn compute_isostasy_craton(
     config: &IsostasyConfig,
     craton: &[bool],
 ) -> IsostasyResult {
-    compute_isostasy_inner(thickness, config, Some(craton))
+    compute_isostasy_inner(thickness, config, Some(craton), None)
+}
+
+/// #155 vertical-scale — Airy isostasy with BOTH the cratonic density mask
+/// (`craton`, see [`compute_isostasy_craton`]) AND a CONTINENTAL mask that
+/// repairs the land-normalisation ceiling.
+///
+/// **The land-ceiling repair.** [`compute_isostasy`] normalises the LAND ramp
+/// `[h_sea, h_max] → [sea_norm, 1.0]` against the GLOBAL raw `h_max`. In the C1
+/// production that global max is the OCEANIC advective pile-up cell (S̃ ≈ 2.15
+/// at the rigid margin, #145) — a cell Stein-Stein then overwrites into deep
+/// ocean. So real continental land is normalised against a phantom oceanic
+/// ceiling (tops at ~0.94) and `peak_altitude_m` describes that ocean cell, not
+/// any land (the `project_c1_vertical_scale_contract` diagnostic). When
+/// `continental` is `Some`, the land ceiling is the max `h` over CONTINENTAL
+/// cells instead — the real terrestrial summit; oceanic cells (S-S-overwritten)
+/// no longer inflate it. `continental == None` → byte-identical to the global
+/// `h_max` behaviour (v2/export untouched — they have no S-S/no advective spike,
+/// so no phantom: the fix is C1-specific). Row-major `&[bool]` (length nx·ny),
+/// same convention as `craton` (avoids a tectonics→tectonics_c1 cycle).
+pub fn compute_isostasy_c1(
+    thickness: &Field2D,
+    config: &IsostasyConfig,
+    craton: Option<&[bool]>,
+    continental: &[bool],
+) -> IsostasyResult {
+    compute_isostasy_inner(thickness, config, craton, Some(continental))
 }
 
 fn compute_isostasy_inner(
     thickness: &Field2D,
     config: &IsostasyConfig,
     craton: Option<&[bool]>,
+    continental: Option<&[bool]>,
 ) -> IsostasyResult {
     let nx = thickness.nx();
     let ny = thickness.ny();
@@ -236,6 +263,26 @@ fn compute_isostasy_inner(
     let h_range = (h_cap - h_min).max(1e-10);
     let h_sea = h_min + config.sea_level_fraction * h_range;
 
+    // 2b. #155 land-ceiling repair. The LAND ramp tops at this ceiling. By
+    // default (continental == None) it is the global raw h_max — but in the C1
+    // production that is the OCEANIC advective spike (S-S-overwritten), so real
+    // land is normalised against a phantom. When a continental mask is given,
+    // use the max h over CONTINENTAL cells: the real terrestrial summit, with
+    // oceanic cells excluded (they get S-S bathymetry downstream regardless).
+    // See `compute_isostasy_c1`. Fallback to h_max if the mask flags no cell.
+    let land_cap = match continental {
+        Some(cont) => {
+            let mut m = f32::NEG_INFINITY;
+            for k in 0..nx * ny {
+                if cont[k] {
+                    m = m.max(h_raw[k]);
+                }
+            }
+            if m.is_finite() { m } else { h_max }
+        }
+        None => h_max,
+    };
+
     // 3. Map to normalized [0, 1] with sea level at a known position
     // sea_norm = max_depth / (max_depth + max_elevation)
     let sea_norm = config.max_depth_m / (config.max_depth_m + config.max_elevation_m);
@@ -249,7 +296,9 @@ fn compute_isostasy_inner(
             let t = (h - h_min) / (h_sea - h_min).max(1e-10);
             t * sea_norm
         } else {
-            let t = (h - h_sea) / (h_max - h_sea).max(1e-10);
+            // #155 land ramp tops at land_cap (continental summit, not the
+            // phantom oceanic h_max). Cells above land_cap clamp to 1.0 below.
+            let t = (h - h_sea) / (land_cap - h_sea).max(1e-10);
             sea_norm + t * (1.0 - sea_norm)
         };
         data[k] = normalized.clamp(0.0, 1.0);
@@ -261,8 +310,11 @@ fn compute_isostasy_inner(
 
     let land_ratio = land_count as f32 / (nx * ny) as f32;
 
-    // 4. Compute actual peak altitude and depth for metadata
-    let peak_altitude_m = (h_max - h_sea) / (h_max - h_min).max(1e-10) * config.max_elevation_m;
+    // 4. Compute actual peak altitude and depth for metadata. #155: the peak
+    // is the real continental summit (land_cap), not the phantom oceanic h_max
+    // — so peak_altitude_m describes an actual land cell (None path: land_cap
+    // == h_max, byte-identical).
+    let peak_altitude_m = (land_cap - h_sea) / (land_cap - h_min).max(1e-10) * config.max_elevation_m;
     let actual_depth_m = (h_sea - h_min) / (h_max - h_min).max(1e-10) * config.max_depth_m;
 
     let heightmap = GridF32::from_vec(nx, ny, data);

--- a/crates/ymir-core/src/tectonics_c1/production_upscale.rs
+++ b/crates/ymir-core/src/tectonics_c1/production_upscale.rs
@@ -33,8 +33,8 @@
 use crate::erosion::hydraulic::run_erosion;
 use crate::grid::GridF32;
 use crate::seed::WorldSeed;
-use crate::tectonics::isostasy::{compute_isostasy, compute_isostasy_craton, IsostasyConfig};
-use crate::tectonics_v2::boundaries::plate_type::PlateTypeField;
+use crate::tectonics::isostasy::{compute_isostasy_c1, IsostasyConfig};
+use crate::tectonics_v2::boundaries::plate_type::{PlateType, PlateTypeField};
 use crate::tectonics_v2::field::Field2D;
 use crate::terrain::upscale::{upscale_with_fbm, FbmUpscaleConfig, UpscaleResult};
 
@@ -87,10 +87,17 @@ fn c1_production_altitude_inner(
     ss: &SteinSteinParams,
     craton: Option<&[bool]>,
 ) -> GridF32 {
-    let isostasy = match craton {
-        Some(c) => compute_isostasy_craton(s, iso, c),
-        None => compute_isostasy(s, iso),
-    };
+    // #155 land-ceiling repair — the C1 production ALWAYS supplies the
+    // continental mask so the land ramp tops at the real terrestrial summit,
+    // not the phantom oceanic advective spike (which Stein-Stein overwrites
+    // below). Built from plate_type (row-major, length nx·ny). v2/export do
+    // NOT go through this path → they keep `compute_isostasy` (no mask,
+    // byte-identical). See `compute_isostasy_c1`.
+    let continental: Vec<bool> = (0..plate_type.ny())
+        .flat_map(|j| (0..plate_type.nx()).map(move |i| (i, j)))
+        .map(|(i, j)| plate_type.get(i, j) == PlateType::Continental)
+        .collect();
+    let isostasy = compute_isostasy_c1(s, iso, craton, &continental);
     let mut altitude = isostasy.heightmap;
     // #151 F3 fix — despike the age before Stein-Stein. The flux-form age
     // advection piles age up at convergent plate boundaries (sparse cells

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -3553,3 +3553,93 @@ fn probe_vertical_scale_ceiling() {
     }
     eprintln!("  ATTRIBUTION: EH caps S̃ at 2.0 → peak_altitude_m is a fraction of 4000 → conversion codomain tops at 4000 < 6000-8000.");
 }
+
+/// #155 vertical-scale chantier — characterise the LAND-ceiling repair BEFORE
+/// coding. The cause: compute_isostasy normalises land against global raw h_max
+/// (the oceanic advective spike). Measures, on the production state: raw h by
+/// plate_type, so we can choose the terrestrial ceiling (max-continental vs a
+/// robust percentile) and quantify over-saturation (how many land cells would
+/// clamp to 1.0 under each). Read-only — no isostasy change yet.
+#[test]
+#[ignore]
+fn probe_land_ceiling_repair() {
+    let iso = IsostasyConfig::c1_default();
+    let grid = 64usize;
+    let buoy = 1.0 - iso.rho_crust / iso.rho_mantle;
+    let buoy_c = match iso.craton_rho_crust { Some(r) => 1.0 - r / iso.rho_mantle, None => buoy };
+    let pct = |v: &[f64], q: f64| -> f64 { if v.is_empty() { return f64::NAN; } let mut s = v.to_vec(); s.sort_by(|a,b| a.partial_cmp(b).unwrap()); s[((q*(s.len()-1) as f64).round() as usize).min(s.len()-1)] };
+    eprintln!("#155 land-ceiling repair — raw h by plate_type (buoy cont={buoy:.4} craton={buoy_c:.4})");
+    for &seed in &[42u64, 1988, 2026] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        // raw h = S̃ * buoyancy (craton density on cratonic cells), global vs continental.
+        let mut h_all = Vec::new();
+        let mut h_cont = Vec::new();
+        for j in 0..grid { for i in 0..grid {
+            let k = j*grid+i;
+            let b = if state.cratonic_mask.data()[k] { buoy_c } else { buoy };
+            let h = state.s.get(i,j) * b as f64;
+            h_all.push(h);
+            if matches!(state.plate_type.get(i,j), PlateType::Continental) { h_cont.push(h); }
+        }}
+        let h_min = h_all.iter().cloned().fold(f64::INFINITY, f64::min);
+        let h_max_glob = h_all.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let h_max_cont = h_cont.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        // land = h > h_sea (isostasy's own threshold), under the GLOBAL h_max ramp.
+        let h_range = (pct(&h_all, 0.92) - h_min).max(1e-10); // sea uses PercentileCapped{0.92} (the LOW cap)
+        let h_sea = h_min + iso.sea_level_fraction as f64 * h_range;
+        let land: Vec<f64> = h_all.iter().cloned().filter(|&h| h > h_sea).collect();
+        let land_cont: Vec<f64> = h_cont.iter().cloned().filter(|&h| h > h_sea).collect();
+        eprintln!("  seed {seed}: h_min={h_min:.3} h_sea={h_sea:.3} | h_max GLOBAL={h_max_glob:.3} CONTINENTAL={h_max_cont:.3} (ratio {:.2})", h_max_glob/h_max_cont.max(1e-6));
+        eprintln!("    land cells (h>h_sea): {} total, {} continental | land p50={:.3} p95={:.3} p99={:.3} max={:.3}",
+            land.len(), land_cont.len(), pct(&land,0.5), pct(&land,0.95), pct(&land,0.99), pct(&land,1.0));
+        // over-saturation: under a candidate ceiling C, land cells with h>=C clamp to 1.0.
+        for &(tag, c) in &[("maxCont", h_max_cont), ("landP99", pct(&land,0.99)), ("landP95", pct(&land,0.95))] {
+            let clamp = land.iter().filter(|&&h| h >= c).count();
+            eprintln!("    ceiling {tag}={c:.3} → {clamp}/{} land cells clamp to 1.0 ({:.1}%)", land.len(), 100.0*clamp as f64/land.len().max(1) as f64);
+        }
+    }
+}
+
+/// #155 land-ceiling repair ACCEPTANCE — contrast the phantom (global h_max)
+/// vs repaired (continental ceiling) peak_altitude_m, the over-saturation, and
+/// the rendered land change. compute_isostasy_craton (no continental mask) =
+/// pre-fix phantom; compute_isostasy_c1 (continental mask) = repaired; the
+/// production upscale_from_c1 now uses the repaired path. Renders hypso +
+/// hillshade for the visual re-judge (land now spreads to 1.0).
+#[test]
+#[ignore]
+fn probe_land_ceiling_acceptance() {
+    use ymir_core::tectonics::isostasy::{compute_isostasy_craton, compute_isostasy_c1};
+    let dir = output_dir().join("land_ceiling_accept");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let cfg = FbmUpscaleConfig::c1_hd_production(1024);
+    eprintln!("#155 land-ceiling acceptance — phantom vs repaired peak_altitude_m + render");
+    for &seed in &[42u64, 1988, 2026] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let continental: Vec<bool> = (0..grid*grid).map(|k| matches!(state.plate_type.get(k%grid, k/grid), PlateType::Continental)).collect();
+        let phantom = compute_isostasy_craton(&state.s, &iso, state.cratonic_mask.data());
+        let repaired = compute_isostasy_c1(&state.s, &iso, Some(state.cratonic_mask.data()), &continental);
+        // over-saturation: land cells (coarse) at exactly 1.0 in the repaired map.
+        let clamp = repaired.heightmap.data.iter().filter(|&&v| v >= 0.999).count();
+        let land = repaired.heightmap.data.iter().filter(|&&v| v > repaired.sea_level_normalized).count();
+        // production render (repaired path).
+        let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        let hd_max = up.heightmap.data.iter().cloned().fold(0.0f32, f32::max);
+        eprintln!("  seed {seed}: peak_altitude_m phantom={:.0} → repaired={:.0} m  | coarse land-clamp@1.0: {clamp}/{land} ({:.1}%)  | HD land-max norm={hd_max:.3}",
+            phantom.peak_altitude_m, repaired.peak_altitude_m, 100.0*clamp as f64/land.max(1) as f64);
+        save_heightmap01(&up.heightmap, &dir.join(format!("seed{seed:05}_hypso.png")));
+        save_hillshade_crop(&up.heightmap, 0, 0, up.heightmap.width, &dir.join(format!("seed{seed:05}_hillshade.png")));
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -44,7 +44,7 @@ use image::{ImageBuffer, Rgb};
 use ymir_core::grid::GridF32;
 use ymir_core::morphology::{land_morphology, LandMorphology};
 use ymir_core::tectonics_c1::boundary_classification::{classify_boundaries, BoundaryType};
-use ymir_core::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
+use ymir_core::tectonics::isostasy::{compute_isostasy, compute_isostasy_craton, IsostasyConfig};
 use ymir_core::tectonics_c1::closures::oceanic_bathymetry::source_term::apply_stein_stein_bathymetry;
 use ymir_core::tectonics_c1::init_r7::{init_c1_state_phase_2_r7, Phase2InitParams};
 use ymir_core::tectonics_c1::kinematics::PlateKinematics;
@@ -3463,4 +3463,93 @@ fn probe_jordan_render() {
         }
     }
     eprintln!("  out = {}", dir.display());
+}
+
+/// #155 VERTICAL-SCALE CONTRACT + HIGH-MOUNTAIN CEILING (read-only diagnostic).
+///
+/// VOLET 1 (contract): the production altitude is DOUBLE-NORMALISED with an
+/// internally INCOHERENT metre scale, which is the source of the ~×2 norm→m
+/// ambiguity flagged in `project_c1_vertical_scale_contract`:
+///  - `compute_isostasy` outputs an ASYMMETRIC [0,1] (sea at
+///    `sea_norm = max_depth_m/(max_depth_m+max_elevation_m) = 500/4500 ≈ 0.111`);
+///    on LAND the metre anchor is `IsostasyResult.peak_altitude_m` =
+///    `(h_max−h_sea)/(h_max−h_min)·max_elevation_m`, i.e. FIELD-RELATIVE
+///    (depends on the seed's raw S̃ spread), NOT a fixed constant.
+///  - Stein-Stein then OVERWRITES oceanic cells with `−depth_m/depth_scale_m`
+///    (depth_scale=5000), a SECOND, FIXED metre scale with sea at 0 (not 0.111).
+///  - `upscale_from_c1` then re-normalises `(v+1.13)/2.26` → land tops at 0.943,
+///    S-S sea→0.5 but isostasy-continental-sea→0.549 (the two "sea levels" differ).
+/// So there is NO single norm→m: land = field-relative `peak_altitude_m`,
+/// ocean = fixed 5000 m, spliced at incompatible zeros. The downstream guess
+/// `(v−0.5)·2·4000` used in `probe_craton_calibration` is exactly one arbitrary
+/// pick — measured here against the model's OWN `peak_altitude_m`.
+///
+/// VOLET 2 (ceiling attribution): print, per seed, the model's OWN peak metres
+/// (`peak_altitude_m`), the S̃ ceiling on the margin orogen vs EH `h_eq=2.0`,
+/// and the HD rendered land-max under the downstream guess. Attributes the
+/// 6000–8000 m gap: (EH) S̃ capped at 2.0 → (ramp) `peak_altitude_m` is a
+/// FRACTION of `max_elevation_m=4000` → (conversion) the codomain itself tops
+/// at 4000 m. NOT a fix; scopes the Phase-3 EH/critical-wedge chantier.
+#[test]
+#[ignore]
+fn probe_vertical_scale_ceiling() {
+    use ymir_core::tectonics_c1::boundary_classification::{
+        classify_boundaries, oc_override_seed_mask, retarget_upper_plate_continental,
+    };
+    use ymir_core::tectonics_c1::distance_field::wedge_distance_intra_plate_typed;
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let h_eq = 2.0f64;
+    let max_elev = iso.max_elevation_m;
+    let p95 = |mut v: Vec<f64>| -> f64 { if v.is_empty() { return f64::NAN; } v.sort_by(|a,b| a.partial_cmp(b).unwrap()); v[(v.len()*95/100).min(v.len()-1)] };
+    eprintln!("#155 vertical-scale + ceiling — max_elevation_m={max_elev}, sea_norm={:.3}, EH h_eq={h_eq}",
+        iso.max_depth_m / (iso.max_depth_m + iso.max_elevation_m));
+    for &seed in &[42u64, 1988, 2026] {
+        // Zones (margin orogen) — same construction as probe_prominence_attribution.
+        let geom = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let kin0 = PlateKinematics::preset_phase_1_1(geom.num_plates);
+        let mut bi = classify_boundaries(&geom.plate_id, &kin0);
+        retarget_upper_plate_continental(&mut bi, &geom.plate_id, &geom.plate_type);
+        let oc_seed = oc_override_seed_mask(&bi, &geom.plate_id, &geom.plate_type);
+        let (wd, is_oc) = wedge_distance_intra_plate_typed(&geom.plate_id, &bi.upper_plate_mask, &oc_seed, 30.0);
+
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default(); // A′ active
+        let config = C1TimeLoopConfig {
+            rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0,
+            iso_config: iso.clone(), drainage_max_distance: 30,
+        };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+        // S̃ ceiling on the margin orogen (raw, consistent space).
+        let mut margin = Vec::new();
+        let mut s_global_max = f64::NEG_INFINITY;
+        for j in 0..grid { for i in 0..grid {
+            let s = state.s.get(i, j);
+            s_global_max = s_global_max.max(s);
+            if matches!(geom.plate_type.get(i,j), PlateType::Continental)
+                && is_oc.get(i,j) && wd.get(i,j) < 30.0 { margin.push(s); }
+        }}
+        let n_margin = margin.len();
+        let n_at_ceiling = margin.iter().filter(|&&s| s >= 1.9).count();
+        let margin_p95 = p95(margin.clone());
+
+        // The model's OWN metre statement (IsostasyResult metadata).
+        let iso_res = compute_isostasy_craton(&state.s, &iso, state.cratonic_mask.data());
+        let peak_m = iso_res.peak_altitude_m;
+
+        // HD rendered land-max under the DOWNSTREAM guess convention (v−0.5)·2·4000.
+        let cfg = FbmUpscaleConfig::c1_hd_production(512);
+        let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        let hd_land_max_norm = up.heightmap.data.iter().cloned().fold(0.0f32, f32::max);
+        let hd_guess_m = (hd_land_max_norm as f64 - 0.5) * 2.0 * max_elev as f64;
+
+        eprintln!("  seed {seed}:");
+        eprintln!("    S̃: global_max={s_global_max:.3}  margin orogen p95={margin_p95:.3}  cells≥1.9: {n_at_ceiling}/{n_margin}  (EH h_eq={h_eq})");
+        eprintln!("    model peak_altitude_m = {peak_m:.0} m  (= fraction of max_elevation_m={max_elev:.0}; the ramp's land ceiling)");
+        eprintln!("    HD land-max norm={hd_land_max_norm:.3} → guess-convention {hd_guess_m:.0} m  vs target 6000-8000");
+    }
+    eprintln!("  ATTRIBUTION: EH caps S̃ at 2.0 → peak_altitude_m is a fraction of 4000 → conversion codomain tops at 4000 < 6000-8000.");
 }

--- a/docs/reports/c1_continental_buoyancy/stage_vertical_scale_contract.md
+++ b/docs/reports/c1_continental_buoyancy/stage_vertical_scale_contract.md
@@ -1,0 +1,113 @@
+# #155 — Vertical-scale contract + high-mountain ceiling (diagnostic)
+
+Read-only diagnostic. Two **distinct** problems, deliberately not conflated:
+1. **CONTRACT** — what is `1.0` in metres, what does `[0,1]` cover? (Definition by
+   reading the model — no parameter change.)
+2. **CEILING** — orogens render far below the 6000–8000 m (Himalaya) target. This is
+   a MODEL limit, not a scale-definition gap; pinning the scale does not create relief.
+
+Probe: `c1_closure_morphology::probe_vertical_scale_ceiling` (+ `probe_orogen_equilibrium`),
+`#[ignore]`, seeds {42, 1988, 2026}, A′ defaults, `c1_hd_production`.
+
+---
+
+## Volet 1 — the vertical contract (reading, not a decision)
+
+**There is NO single `norm→metres` mapping. The altitude is double-normalised with an
+internally incoherent metre scale — this IS the ~×2 ambiguity** flagged in
+`project_c1_vertical_scale_contract`.
+
+The conversion chain (`c1_production_altitude` → `upscale_from_c1`):
+
+1. **`compute_isostasy_inner`** produces an **asymmetric** `[0,1]` heightmap.
+   - sea level sits at `sea_norm = max_depth_m/(max_depth_m+max_elevation_m)
+     = 500/4500 ≈ **0.111**` (NOT 0.5).
+   - LAND ramp `[h_sea, h_max] → [0.111, 1.0]`; the metre anchor is
+     `IsostasyResult.peak_altitude_m = (h_max−h_sea)/(h_max−h_min)·max_elevation_m`
+     — **field-relative** (depends on the seed's raw S̃ spread), NOT a fixed constant.
+     So `1.0` ≠ a fixed number of metres on land.
+   - OCEAN ramp `[h_min, h_sea] → [0, 0.111]`.
+
+2. **`apply_stein_stein_bathymetry`** then **overwrites** oceanic cells with
+   `−depth_m / depth_scale_m` (`depth_scale = 5000`) → a **second, FIXED** metre scale
+   (`1 unit = 5000 m`), with **sea at 0** (not 0.111). The two halves now use different
+   metres-per-unit AND different sea-level zeros — incoherent by construction (the S-S
+   module doc explicitly notes it breaks the isostasy `[0,1]` contract; downstream
+   consumers were gradient-only so it never mattered — until a metre scale is needed).
+
+3. **`upscale_from_c1`** re-normalises `(v + 1.13)/2.26`, clamp `[0,1]`:
+   - deepest S-S ocean `−1.13 → 0.0`; S-S sea `0 → 0.5`; isostasy-continental sea
+     `0.111 → 0.549`; land top `1.0 → 0.943`.
+   - **Two "sea levels" now disagree** (0.5 vs 0.549), and land tops at 0.943 not 1.0.
+
+→ **Honest contract:** land metres = field-relative `peak_altitude_m`; ocean metres =
+fixed 5000 m; spliced at incompatible zeros, then re-offset. Pinning a single scale is a
+**model decision** (unify it), not a reading. Until then: **report relief in normalized
+units / ratios, not metres.** The downstream guess `(v−0.5)·2·4000` (used in
+`probe_craton_calibration`) is exactly *one arbitrary pick* of the ambiguous scale.
+
+**Extra incoherence found by measurement:** `peak_altitude_m ≈ 3300 m` (stable across
+seeds) is a **PHANTOM** — it is computed from the global raw `h_max`, which is the
+**oceanic** advective pile-up cell (S̃ ≈ 2.15 at the rigid margin, #145). That cell is
+then *overwritten by Stein-Stein into deep ocean*. So `peak_altitude_m` describes a cell
+that becomes ocean — it does **not** state any actual land elevation. The real rendered
+land max is ~half that (below).
+
+---
+
+## Volet 2 — the high-mountain gap, quantified + attributed (diagnostic, not a fix)
+
+| seed | orogen margin S̃ p95 | cells ≥ 1.9 (EH region) | model `peak_altitude_m` (phantom) | **HD rendered land-max** (guess conv.) |
+|------|--------------------:|------------------------:|----------------------------------:|---------------------------------------:|
+| 42   | 1.302               | 0 / 1042                | 3333 m                            | **1746 m**                              |
+| 1988 | 1.466               | 0 / 1160                | 3325 m                            | **2075 m**                              |
+| 2026 | 1.351               | 0 / 1285                | 3274 m                            | **1864 m**                              |
+
+**The gap:** rendered orogens top out at **~1750–2075 m** vs the **6000–8000 m** target
+→ a factor of **~3–4×** short.
+
+### Attribution (chain-of-innocence) — what binds, in order
+
+1. **NOT the EH ceiling.** Orogens equilibrate at S̃ ~1.3–1.5; **0 of ~1100 margin cells
+   reach 1.9**. The EH `h_eq = 2.0` headroom is **entirely unused**. → **Raising `h_eq`
+   does nothing** (orogens never reach the current ceiling). *(This corrects the earlier
+   "orogens EH-ceiling-bound at S̃~2.0" verdict — that S̃~2.0 figure was the OCEANIC
+   margin spike, S-S-overwritten, not the continental orogen.)*
+
+2. **The DS-deposition vs erosion balance is the dominant cap.** `probe_orogen_equilibrium`
+   (erosion-OFF counterfactual): margin p95 rises only **1.30→1.59 / 1.47→1.73 /
+   1.35→1.59**. So in-loop erosion brakes ~0.25, BUT even erosion-OFF orogens stall at
+   **~1.6–1.7** — below the DS margin-peaked target (≈1.95 @ d=1) and far below `h_max=2.5`.
+   The deposition rate + advective smearing of the margin band is the **primary** S̃ limiter.
+
+3. **`max_elevation_m = 4000` is a hard codomain ceiling.** Even a hypothetically-maxed
+   land cell cannot render above 4000 m. **6000–8000 m is outside the conversion codomain
+   entirely** — independent of any S̃ gain.
+
+### Ceiling chantier — scoped (for separate decision, NOT coded)
+
+To reach the Himalaya, in causal order:
+- **(a) PRIMARY — lift the orogen S̃ equilibrium from ~1.4 toward/past 2.0.** This is the
+  **critical-wedge over-thickening** subject (more convergent-margin deposition / less
+  advective smearing / less in-loop erosion at the wedge). *This is the real binding
+  constraint — not the EH ceiling.* Watch [[feedback_recursive_tuning_signals_structural]].
+- **(b) SECONDARY — raise the EH ceiling `h_eq`** at convergent margins, so the lifted S̃
+  is not re-capped at 2.0. Moot until (a) lifts S̃ near 2.0.
+- **(c) raise `max_elevation_m`** (and unify the scale per Volet 1) so the conversion admits
+  >4000 m absolute. Note: raising `max_elevation_m` alone scales *everything* (plains too)
+  → it adds absolute height but no prominence; it only matters once (a) widens the S̃ spread.
+
+**Reframe of the deferred Phase-3 "EH/prominence" subject:** it is NOT "raise the EH
+ceiling" — it is "**lift the orogen S̃ equilibrium (critical-wedge)**," with EH-raise +
+`max_elevation_m`-raise + scale-unification as downstream follow-ons. Same bind as the
+relative-prominence verdict, now measured in absolute height: the orogens are simply LOW
+in S̃, not capped by EH.
+
+---
+
+## Discipline notes
+- Volet 1 = reading; the scale is what the model encodes (two-scale, phantom peak) — not
+  tuned toward a target height. Pinning the scale does not create relief.
+- Volet 2 = diagnostic; the critical-wedge lift is a model change, scoped separately.
+- The metre figures use the downstream `(v−0.5)·2·4000` convention **only to quantify the
+  gap** — they inherit the Volet-1 ambiguity and are not a pinned contract.


### PR DESCRIPTION
`compute_isostasy` normalized the land ramp (and `peak_altitude_m`) against the
global raw `h_max` — which in the C1 path is the **oceanic advective spike** (S̃ ~2.15,
later overwritten to deep ocean by Stein-Stein). So land was normalized against a
ceiling that describes no land cell: the highest land reached only ~0.72-0.76, and
`peak_altitude_m` (~3300 m) was a phantom.

`compute_isostasy_c1(.., continental: &[bool])` caps the land ramp and
`peak_altitude_m` at **max-continental** (excluding the oceanic spike via the plate-type
mask). The C1 production path supplies the mask for both the viz render and the
upscale → render==upscale coherence.

## Why max-continental (not a percentile)
Measurement: land-P99 ≈ global max (doesn't isolate the spike); the filter must be the
causal property (continental nature), not a magnitude proxy (altitude > sea). The mask
is the right filter.

## Acceptance (measured)
- `peak_altitude_m`: 3333→2772, 3325→3108, 3274→2722 m — a real land cell, not the
  ~3300 phantom.
- Over-saturation: 0.8 / 0.0 / 0.0% of land clamped to 1.0 (clamped cells are
  S-S-overwritten ocean, not land).
- HD land-max norm: 0.72→0.92, 0.76→0.85, 0.73→0.92 — land uses the freed range;
  render re-judged credible (no clamp plateau).
- isostasy 13/13, C1 green; determinism holds (mask deterministic from plate_type).

## Gating
`continental` mask is optional; `None` → current global-max behavior, byte-identical.
v2/export have no Stein-Stein and no advective spike → no phantom → they don't pay
(unchanged). The repair is genuinely C1-specific. (Jordan precedent.)

## Scope / follow-on (#155 stays open)
**Land-ceiling only.** The dual sea level (isostasy-sea 0.111 + S-S-sea 0, bridged to
0.5/0.549 by the upscale re-offset) and the ocean-scale mismatch (max_depth_m=500 vs
S-S /5000) are a **distinct downstream maillon** (Maillon 2: sea-level unification +
norm→m function). Measured: repairing the land ceiling left the dual sea level
unchanged → orthogonal, not phantom-compensation → genuinely separate next step.

## Commits
- `b25ea76` DIAG (vertical-scale diagnostic: probe + report — the chantier foundation)
- `18e4a5d` FEAT (compute_isostasy_c1 land-ceiling repair, gated)
- `0125678` TEST (repair/acceptance probes)

## Refs
#155 (not closed). Foundation: `stage_vertical_scale_contract.md`.