### PR TITLE
C1 vertical contract: sea-unification + exposed norm→m conversion (closes the vertical scale)

### DIFF
--- a/crates/ymir-core/src/tectonics_c1/production_upscale.rs
+++ b/crates/ymir-core/src/tectonics_c1/production_upscale.rs
@@ -99,6 +99,34 @@ fn c1_production_altitude_inner(
         .collect();
     let isostasy = compute_isostasy_c1(s, iso, craton, &continental);
     let mut altitude = isostasy.heightmap;
+
+    // #155 Maillon 2 — sea-CENTRE the continental altitude to metres /
+    // depth_scale (sea → 0), matching the Stein-Stein oceanic convention
+    // (which already writes −depth/depth_scale_m, sea at 0). The isostasy
+    // heightmap is [0,1] with continental sea at `sea_norm` (≈0.111); converting
+    // it to a sea-centred metres/depth_scale field means the downstream FIXED
+    // re-offset `(alt + 1.13)/2.26` (shared by the viz render AND
+    // `upscale_from_c1`) maps sea → 0.5 EXACTLY — no more 0.5-vs-0.549 mismatch
+    // between the two stages — and the whole field (land + ocean) shares ONE
+    // linear norm→m scale (see `c1_altitude_norm_to_metres`). `peak_altitude_m`
+    // (land summit) and `max_depth_m` (continental shelf) are the metre anchors
+    // from the isostasy metadata; `depth_scale_m` is the shared unit. Oceanic
+    // cells are overwritten by Stein-Stein just below, so converting them here
+    // is harmless (they re-enter in the same metres/depth_scale convention).
+    let sea_norm = isostasy.sea_level_normalized;
+    let peak_m = isostasy.peak_altitude_m;
+    let shelf_m = isostasy.max_depth_m;
+    let scale = ss.depth_scale_m as f32;
+    for v in altitude.data.iter_mut() {
+        let n = *v;
+        let metres = if n >= sea_norm {
+            (n - sea_norm) / (1.0 - sea_norm).max(1e-10) * peak_m
+        } else {
+            -(sea_norm - n) / sea_norm.max(1e-10) * shelf_m
+        };
+        *v = metres / scale;
+    }
+
     // #151 F3 fix — despike the age before Stein-Stein. The flux-form age
     // advection piles age up at convergent plate boundaries (sparse cells
     // with ~1000× the background age — the registered density-vs-Lagrangian
@@ -147,6 +175,36 @@ fn median_3x3(field: &Field2D) -> Field2D {
 /// incomparable and break the measured cross-resolution robustness.
 /// Value matches the production gallery palette half-range.
 const ALTITUDE_NORM_HALF_RANGE: f32 = 1.13;
+
+/// #155 Maillon 2 — **THE unified C1 vertical-scale contract.** Convert an HD
+/// heightmap normalised value (sea = 0.5, the `upscale_from_c1` / viz-render
+/// convention) to METRES. A SINGLE linear scale across land AND ocean — no
+/// piecewise seam, no per-regime slope: the consumer reads metres without
+/// knowing whether it is on land or sea.
+///
+/// ```text
+///     metres = (norm − 0.5) · 2 · ALTITUDE_NORM_HALF_RANGE · depth_scale_m
+/// ```
+///
+/// With the defaults (`1.13`, `5000`): `metres = (norm − 0.5) · 11300`. Sea
+/// (0.5) → 0 m; `norm = 1.0` → +5650 m; `norm = 0.0` → −5650 m. Land occupies
+/// `[0.5, ~0.85]` (the upper land bound is `max_elevation_m = 4000 m`, set by
+/// isostasy); ocean occupies `[0, 0.5]` (down to the Stein-Stein asymptote
+/// ~5651 m). The headroom `~0.85 → 1.0` is RESERVED for the separate
+/// critical-wedge high-mountain chantier — the scale tells the truth, and the
+/// gap it reveals is the diagnostic of the relief not yet produced.
+///
+/// This is the contract downstream consumers (rivers, biome, climate) read to
+/// reason in defined metres. Coherent BY CONSTRUCTION with the sea-centred
+/// production altitude (`c1_production_altitude`) — see its body.
+pub fn c1_altitude_norm_to_metres(norm: f32, ss: &SteinSteinParams) -> f32 {
+    (norm - 0.5) * 2.0 * ALTITUDE_NORM_HALF_RANGE * ss.depth_scale_m as f32
+}
+
+/// Inverse of [`c1_altitude_norm_to_metres`]: metres → normalised value.
+pub fn c1_metres_to_altitude_norm(metres: f32, ss: &SteinSteinParams) -> f32 {
+    metres / (2.0 * ALTITUDE_NORM_HALF_RANGE * ss.depth_scale_m as f32) + 0.5
+}
 
 /// Upscale a C1 simulation state to a detailed heightmap via the
 /// anisotropic-FBM upscale, **through the robustness-preserving

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -3643,3 +3643,57 @@ fn probe_land_ceiling_acceptance() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155 Maillon 2 ACCEPTANCE — sea-level unification + norm→m contract.
+/// Checks: (1) continental sea maps to EXACTLY 0.5 (no 0.549) after the
+/// production offset; (2) c1_altitude_norm_to_metres round-trips + key anchors;
+/// (3) render re-judge (hypso/hillshade). Resolution invariance is preserved by
+/// construction (sea-centering is on the 64² coarse, before upscale).
+#[test]
+#[ignore]
+fn probe_sea_unification_acceptance() {
+    use ymir_core::tectonics_c1::production_upscale::{
+        c1_production_altitude, c1_altitude_norm_to_metres, c1_metres_to_altitude_norm,
+    };
+    let dir = output_dir().join("sea_unify_accept");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let half = 1.13f32;
+    let cfg = FbmUpscaleConfig::c1_hd_production(1024);
+    // norm→m contract anchors (independent of any seed).
+    eprintln!("#155 Maillon 2 — norm→m contract: sea(0.5)={:.1}m  norm1.0={:.0}m  norm0.0={:.0}m  roundtrip(2772m)={:.4}",
+        c1_altitude_norm_to_metres(0.5, &ss), c1_altitude_norm_to_metres(1.0, &ss),
+        c1_altitude_norm_to_metres(0.0, &ss), c1_metres_to_altitude_norm(2772.0, &ss));
+    for &seed in &[42u64, 1988, 2026] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        // coarse production altitude (sea-centred metres/scale). Continental
+        // sea-level cells should be ~0 → offset (alt+1.13)/2.26 = 0.5 exactly.
+        let coarse = c1_production_altitude(&state.s, &state.age, &state.plate_type, &iso, &ss);
+        // continental cells: min |alt| ≈ the coast (alt≈0); land = alt>0.
+        let mut cont_land = 0usize; let mut cont = 0usize; let mut min_abs = f32::INFINITY;
+        for j in 0..grid { for i in 0..grid {
+            if matches!(state.plate_type.get(i,j), PlateType::Continental) {
+                cont += 1;
+                let a = coarse.get(i as i32, j as i32);
+                min_abs = min_abs.min(a.abs());
+                if a > 0.0 { cont_land += 1; }
+            }
+        }}
+        // production HD render.
+        let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        let off = |a: f32| ((a + half) / (2.0*half)).clamp(0.0,1.0);
+        let coast_norm = off(0.0); // continental sea (alt 0) under the offset
+        let land_max_norm = up.heightmap.data.iter().cloned().fold(0.0f32, f32::max);
+        eprintln!("  seed {seed}: continental coast alt(coarse) min|alt|={min_abs:.4} (→0) | coast→norm {coast_norm:.4} (want 0.5) | HD land-max norm={land_max_norm:.3} = {:.0}m | cont land {cont_land}/{cont}",
+            c1_altitude_norm_to_metres(land_max_norm, &ss));
+        save_heightmap01(&up.heightmap, &dir.join(format!("seed{seed:05}_hypso.png")));
+        save_hillshade_crop(&up.heightmap, 0, 0, up.heightmap.width, &dir.join(format!("seed{seed:05}_hillshade.png")));
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/docs/reports/c1_continental_buoyancy/stage_vertical_scale_contract.md
+++ b/docs/reports/c1_continental_buoyancy/stage_vertical_scale_contract.md
@@ -105,6 +105,78 @@ in S̃, not capped by EH.
 
 ---
 
+---
+
+## Maillon 2 — sea-level unification + the norm→m contract (FIX)
+
+The diagnostic above left TWO repairs. Maillon 1 (land-ceiling, merged) fixed the
+phantom peak. **Maillon 2 unifies the scale end-to-end and exposes the norm→m
+function** — the prerequisite for rivers/biome/climate.
+
+### W7 verdict (read before coding)
+- **500 vs 5000 is NOT a conflict — two physical regimes.** `max_depth_m=500` =
+  submerged **continental shelf** (~200-500 m, physical); Stein-Stein
+  `depth_scale_m=5000` = **deep oceanic** lithosphere (~5000 m, physical). The S-S
+  param doc states 5000 was chosen "consistent with the isostatic convention" — the
+  intent was always a shared sea-zero. Unify on a common **sea=0, uniform
+  metres/5000 nondim**; 500 stays as the shelf anchor for continental-submerged cells.
+- **The 0.549 origin.** Isostasy outputs `[0,1]` with continental sea at
+  `sea_norm≈0.111`; S-S writes oceanic sea-centred (sea=0). The fixed upscale
+  `(v+1.13)/2.26` maps S-S-sea(0)→0.5 but isostasy-sea(0.111)→0.549. Two stages, two
+  sea anchors.
+- **The re-offset is NOT a bug.** `ALTITUDE_NORM_HALF_RANGE=1.13 ≈ 5651/5000` (S-S
+  deepest ocean) + sea→0.5 is a deliberate **resolution-invariance** constant (#151).
+  It stays fixed; the other stages align to it.
+
+### The fix
+`c1_production_altitude` now **sea-centres** the continental altitude to
+metres/`depth_scale_m` (sea→0), matching the S-S oceanic convention. Both consumers
+(viz render + `upscale_from_c1`) keep their fixed `(alt+1.13)/2.26`, which now maps
+**sea→0.5 exactly** (0.549 gone) and the FBM coast logic (sea_level=0.5) finally
+aligns with the real coastline. v2/export untouched (they use `compute_isostasy`
+`[0,1]` + their own `upscale_with_fbm` sea_level — C1-specific path).
+
+### The unified vertical scale (the contract)
+`c1_altitude_norm_to_metres` (+ inverse `c1_metres_to_altitude_norm`):
+
+```text
+    metres = (norm − 0.5) · 2 · ALTITUDE_NORM_HALF_RANGE · depth_scale_m
+           = (norm − 0.5) · 11300       [defaults 1.13, 5000]
+```
+
+| norm | metres | what |
+|-----:|-------:|------|
+| 1.0  | +5650  | scale ceiling (unreachable: `max_elevation_m=4000` caps land at norm ~0.85) |
+| ~0.73| ~2300-2600 | **measured highest mountains** (seeds 42/1988/2026) |
+| 0.5  | 0      | **sea level** (exact, all seeds) |
+| 0.0  | −5650  | S-S ocean asymptote (~5651 m) |
+
+**Single linear scale, no piecewise seam** — land AND ocean on one inverse-able
+relation; rivers/biome/climate read metres without knowing the regime. Land occupies
+`[0.5, ~0.73]` (≤0.85 maxed); ocean `[0, 0.5]`. The headroom `~0.73→1.0` is RESERVED
+for the separate critical-wedge high-mountain chantier — the scale tells the truth,
+and the gap it reveals is the diagnostic of the relief not yet produced.
+
+### Acceptance (probe `probe_sea_unification_acceptance`)
+1. Continental coast → norm **0.5000 exactly** (was 0.549), all 3 seeds. ✓
+2. norm→m exposed + round-trips; anchors as table above. The craton/orogen heights
+   (the Jordan caveat + the high-mountain gap) are now **defined metres**
+   (2265-2596 m highest). ✓
+3. Resolution invariance preserved BY CONSTRUCTION — sea-centring is on the 64²
+   coarse, before upscale (the fixed 1.13/sea→0.5 untouched). ✓
+4. Render re-judged (2-3 seeds): coast at 0.5 aligned (shelf band renders), land
+   legible, no re-conversion artifact → improvement (coherent + aligned coast).
+5. v2/export byte-identical (C1-only path); isostasy 13/13, lib 446/0, all C1 green,
+   only pre-existing v2 `rectangular_simulation` red.
+
+### Frontier (NOT done here — distinct chantiers)
+- **Submarine relief**: unifying the scale ≠ creating ocean-floor structure. Oceans
+  stay flat (IQR≈0) at the −5650 m scale; ridges/trenches = a separate chantier.
+- **High mountains** (the norm `0.73→1.0` headroom): the critical-wedge orogen lift —
+  a relief chantier, independent of the scale.
+
+---
+
 ## Discipline notes
 - Volet 1 = reading; the scale is what the model encodes (two-scale, phantom peak) — not
   tuned toward a target height. Pinning the scale does not create relief.


### PR DESCRIPTION
Completes the vertical-scale contract begun by the land-ceiling repair (#161). 
`c1_production_altitude` now sea-centres continental altitude to metres/5000 (sea→0), 
matching Stein-Stein's oceanic convention. Both consumers (viz + upscale) keep the 
fixed `(alt+1.13)/2.26` (the #151 resolution-invariance constant, 1.13≈5651/5000) → 
sea now maps to exactly 0.5, and the FBM coast logic finally aligns with the real 
coastline.

## W7 (decided before coding)
- 500 vs 5000 = not a conflict, two physical regimes: max_depth_m=500 (continental 
  shelf) vs depth_scale=5000 (deep oceanic). S-S's 5000 was always meant "consistent 
  with the isostatic convention" (shared sea=0).
- The 0.549 desync = isostasy-sea (+0.111) vs S-S-sea (0). The re-offset is NOT a bug 
  (the #151 invariance constant) — kept fixed; the others align to it.

## The contract (the deliverable that unblocks rivers)
`c1_altitude_norm_to_metres`: **metres = (norm − 0.5) · 11300** (+ inverse). One linear 
scale, no seam: sea(0.5)=0 m, norm 1.0=+5650 m, norm 0=−5650 m.

## Acceptance
- Coast → norm 0.5000 exact (all seeds); the dual sea level (0.5 vs 0.549) is gone.
- Highest mountains now in defined metres (2265–2596 m); the craton-height (Jordan 
  caveat) and the high-mountain gap are now numbers on a firm scale.
- Resolution invariance preserved by construction (the upscale keeps its fixed scale).
- Render re-judged an improvement: coast aligned, shelf band renders, no artifact. 
  (Land tops ~0.745 — its true metre fraction; the headroom to 1.0 is the 
  critical-wedge's room, not a regression.)
- isostasy 13/13, lib 446/0, C1 green; v2 byte-identical (uses compute_isostasy + its 
  own upscale path).

## Frontier held (distinct chantiers, NOT in this PR)
- Submarine relief: oceans are flat at the −5650 scale (the scale has the room; the 
  relief is a separate chantier).
- High mountains: the 0.745→1.0 headroom is the critical-wedge over-thickening 
  chantier (orogens equilibrate at S̃ 1.3-1.5, not EH-bound — the gap is force, not 
  ceiling).

## Commits
- `03bdf29` FEAT (sea-centre c1_production_altitude + expose c1_altitude_norm_to_metres)
- `c0d6306` TEST (sea-unification acceptance probe)

## Refs
#155 (not closed — submarine + critical-wedge remain). Builds on #161.