### PR TITLE
C1 drainage: horizontal coordinate pin + rivers/lakes with unified water model

### DIFF
--- a/crates/ymir-core/src/lakes/detection.rs
+++ b/crates/ymir-core/src/lakes/detection.rs
@@ -185,6 +185,44 @@ pub fn detect_lakes(
         }
     }
 
+    // #155 lake margin — grow each surviving lake over its connected FLOODED
+    // cells (filled > eroded, i.e. flooded up to the sill) that fell below the
+    // `min_depth` lake-NAMING threshold. Such a cell sits AT the lake's sill =
+    // its water surface, so it is shallow water (shoreline shallows), not part
+    // of the drainage network — the `min_depth`/`min_area` cut classifies which
+    // depressions are NAMED lakes, it must NOT leave the lake's own shallow
+    // margin rendering as land-drainage (the #155 "sill-shelf" classification
+    // gap). Surface level is unchanged (margins are at the sill); only the
+    // lake's extent/area grows to the true shoreline. Expansion stops at the
+    // shoreline naturally (cells above the sill are not flooded), so lakes do
+    // not merge across terrain.
+    let flood_eps = 1e-6f32;
+    let mut area_delta = vec![0usize; lakes.len()];
+    let mut queue: VecDeque<usize> = (0..n).filter(|&k| lake_map[k] != 0).collect();
+    while let Some(cur) = queue.pop_front() {
+        let lid = lake_map[cur];
+        let cx = cur % w;
+        let cy = cur / w;
+        for dy in -1i32..=1 {
+            for dx in -1i32..=1 {
+                if dx == 0 && dy == 0 {
+                    continue;
+                }
+                let nx = ((cx as i32 + dx) % w as i32 + w as i32) as usize % w;
+                let ny = ((cy as i32 + dy) % h as i32 + h as i32) as usize % h;
+                let nidx = ny * w + nx;
+                if lake_map[nidx] == 0 && (filled.data[nidx] - eroded.data[nidx]) > flood_eps {
+                    lake_map[nidx] = lid;
+                    area_delta[(lid - 1) as usize] += 1;
+                    queue.push_back(nidx);
+                }
+            }
+        }
+    }
+    for (lk, d) in lakes.iter_mut().zip(area_delta.iter()) {
+        lk.area += *d;
+    }
+
     LakeResult { lake_map, lakes, width: w, height: h }
 }
 

--- a/crates/ymir-core/src/lakes/detection.rs
+++ b/crates/ymir-core/src/lakes/detection.rs
@@ -10,9 +10,14 @@ use crate::terrain::flow::DIR_NONE;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct LakeConfig {
-    /// Minimum depth (filled - original) to classify as lake. Default: 0.001.
+    /// #155: the deep-vs-SHALLOW TYPE threshold (max depth, filled − eroded), NOT
+    /// the water-vs-land gate. A water body whose max depth ≥ `min_depth` is a
+    /// deep lake (`shallow = false`); below it, shallow water (`shallow = true`,
+    /// lake-vs-marsh deferred to climate). Water itself = ANY flooded cell
+    /// (`filled > eroded`); see [`detect_lakes`]. Default: 0.001.
     pub min_depth: f32,
-    /// Minimum area in pixels to keep a lake. Default: 20.
+    /// Minimum water-body area in cells to keep (filters sub-resolution noise
+    /// pits). Default: 20.
     pub min_area: usize,
 }
 
@@ -30,6 +35,12 @@ pub struct Lake {
     pub area: usize,
     pub basin_id: u32,
     pub outlet: (u32, u32),
+    /// #155: `true` when `max_depth < config.min_depth` — a SHALLOW water body
+    /// (large flooded depression too shallow to be a deep lake). It is still
+    /// WATER (flooded to the sill), not terrain; the lake-vs-marsh distinction
+    /// is deferred to a future hydroclimate layer (geometry alone cannot decide
+    /// it). `false` = a deep (named) lake.
+    pub shallow: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -40,7 +51,17 @@ pub struct LakeResult {
     pub height: usize,
 }
 
-/// Detect lakes by comparing eroded heightmap with pit-filled heightmap.
+/// Detect WATER BODIES from the eroded vs pit-filled heightmaps.
+///
+/// #155 model: a cell is WATER iff it is FLOODED to the sill (`filled > eroded`)
+/// — that is decidable by geometry and is the water-vs-land classification.
+/// Connected flooded components with area ≥ `min_area` are water bodies (the
+/// `min_area` cut removes sub-resolution noise pits). `min_depth` is now only the
+/// deep-vs-shallow TYPE threshold (`Lake::shallow`), NOT a water gate: a large
+/// SHALLOW flooded basin is water (shallow), not terrain — leaving it as terrain
+/// was the #155 misclassification (vast flooded basins whose deep core fell below
+/// `min_area` were dropped entirely). The lake-vs-marsh label for shallow water
+/// is deferred to climate (see [`Lake::shallow`]).
 pub fn detect_lakes(
     eroded: &GridF32,
     filled: &GridF32,
@@ -52,9 +73,12 @@ pub fn detect_lakes(
     let h = eroded.height;
     let n = w * h;
 
-    // Step 1: identify potential lake cells
+    // Step 1: identify WATER cells = flooded to the sill (filled > eroded). NOT
+    // gated by min_depth (that is now only the deep/shallow TYPE threshold): a
+    // shallow flooded basin is still water. FLOOD_EPS rejects float-noise fill.
+    const FLOOD_EPS: f32 = 1e-6;
     let is_lake_cell: Vec<bool> =
-        (0..n).map(|i| (filled.data[i] - eroded.data[i]) > config.min_depth).collect();
+        (0..n).map(|i| (filled.data[i] - eroded.data[i]) > FLOOD_EPS).collect();
 
     // Step 2: connected component labeling (BFS, 8-connectivity, periodic)
     let mut lake_map = vec![0u32; n];
@@ -173,6 +197,7 @@ pub fn detect_lakes(
             area: areas[idx],
             basin_id: basin_ids[idx],
             outlet,
+            shallow: max_depth < config.min_depth,
         });
         new_id += 1;
     }
@@ -185,43 +210,11 @@ pub fn detect_lakes(
         }
     }
 
-    // #155 lake margin — grow each surviving lake over its connected FLOODED
-    // cells (filled > eroded, i.e. flooded up to the sill) that fell below the
-    // `min_depth` lake-NAMING threshold. Such a cell sits AT the lake's sill =
-    // its water surface, so it is shallow water (shoreline shallows), not part
-    // of the drainage network — the `min_depth`/`min_area` cut classifies which
-    // depressions are NAMED lakes, it must NOT leave the lake's own shallow
-    // margin rendering as land-drainage (the #155 "sill-shelf" classification
-    // gap). Surface level is unchanged (margins are at the sill); only the
-    // lake's extent/area grows to the true shoreline. Expansion stops at the
-    // shoreline naturally (cells above the sill are not flooded), so lakes do
-    // not merge across terrain.
-    let flood_eps = 1e-6f32;
-    let mut area_delta = vec![0usize; lakes.len()];
-    let mut queue: VecDeque<usize> = (0..n).filter(|&k| lake_map[k] != 0).collect();
-    while let Some(cur) = queue.pop_front() {
-        let lid = lake_map[cur];
-        let cx = cur % w;
-        let cy = cur / w;
-        for dy in -1i32..=1 {
-            for dx in -1i32..=1 {
-                if dx == 0 && dy == 0 {
-                    continue;
-                }
-                let nx = ((cx as i32 + dx) % w as i32 + w as i32) as usize % w;
-                let ny = ((cy as i32 + dy) % h as i32 + h as i32) as usize % h;
-                let nidx = ny * w + nx;
-                if lake_map[nidx] == 0 && (filled.data[nidx] - eroded.data[nidx]) > flood_eps {
-                    lake_map[nidx] = lid;
-                    area_delta[(lid - 1) as usize] += 1;
-                    queue.push_back(nidx);
-                }
-            }
-        }
-    }
-    for (lk, d) in lakes.iter_mut().zip(area_delta.iter()) {
-        lk.area += *d;
-    }
+    // (The earlier separate "lake margin" expansion is no longer needed: with
+    // the water = `filled > eroded` criterion above, a lake's shallow shore is
+    // flooded → already in the same connected component as its deep core, and a
+    // vast shallow basin is its own component ≥ min_area. Both are captured by
+    // Step 1 + the min_area filter, in one place.)
 
     LakeResult { lake_map, lakes, width: w, height: h }
 }

--- a/crates/ymir-core/src/tectonics_c1/drainage.rs
+++ b/crates/ymir-core/src/tectonics_c1/drainage.rs
@@ -1,0 +1,300 @@
+//! C1-product drainage extraction (#155 complétude).
+//!
+//! **This does NOT re-implement drainage.** The hydraulic-erosion closure has
+//! already carved the river network into the terrain; the geometry here READS
+//! that network deterministically. It composes the existing, unit-tested
+//! [`crate::terrain::flow`] (priority-flood pit-fill → D8 → flow accumulation →
+//! Strahler river extraction) and [`crate::lakes::detection`] (sill-level lakes,
+//! `surface_elevation = outlet level` — the physical rule) on the C1 HD product,
+//! wired to the C1 **coordinate contract**:
+//!
+//! - **sea level = 0.5** ([`C1_SEA_LEVEL_NORM`], the Maillon-2 unified scale) —
+//!   NOT the legacy 0.1 default the viz hydrology still carries.
+//! - **km² network thresholds** (horizontal pin `C1_DOMAIN_KM` →
+//!   [`crate::tectonics_c1::production_upscale::c1_cell_area_km2`]) — drainage
+//!   area in km², resolution-INdependent, where raw accumulation cell-counts
+//!   break across grid sizes.
+//! - **lake stats in metres** (vertical pin
+//!   [`crate::tectonics_c1::production_upscale::c1_altitude_norm_to_metres`]).
+//!
+//! The viz hydrology phase runs the same stack on the *v2* interactive erosion
+//! cache (a different path); rewiring it to consume this C1-product entry is a
+//! DISTINCT maillon (not done here).
+
+use serde::{Deserialize, Serialize};
+
+use crate::grid::GridF32;
+use crate::lakes::detection::{detect_lakes, Lake, LakeConfig};
+use crate::terrain::flow::{
+    compute_flow, extract_rivers, FlowConfig, FlowResult, RiverConfig, RiverNetwork, D8_DX, D8_DY,
+    DIR_NONE,
+};
+
+use super::closures::oceanic_bathymetry::params::SteinSteinParams;
+use super::production_upscale::{c1_altitude_norm_to_metres, c1_cell_area_km2};
+
+/// The C1 unified sea level (Maillon 2): continental sea maps to 0.5.
+pub const C1_SEA_LEVEL_NORM: f32 = 0.5;
+
+/// River navigability class (TDD §9.2), assigned by **upstream drainage area in
+/// km²** — the discharge proxy until climate/runoff couples (a larger basin
+/// carries more water). NOT raw cell-counts (those break across resolutions).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Navigability {
+    /// Below the small-boat threshold (creeks / minor streams).
+    NonNavigable,
+    /// Small craft (canoe / skiff).
+    SmallBoat,
+    /// Barge / riverboat.
+    Barge,
+    /// Ocean-going ship up-river.
+    Ship,
+}
+
+/// Drainage classification of a lake by its drainage relationship to the sea.
+///
+/// **Honest placeholder.** Priority-flood pit-filling routes every depression to
+/// an overflow sill that ultimately spills to the ocean, so PURE GEOMETRY yields
+/// `Exorheic` for all lakes. A TRUE endorheic (terminal) lake — where evaporation
+/// balances inflow so it never overflows — is a CLIMATE phenomenon (precip vs
+/// evaporation), not geometry; this field will carry `Endorheic` only once a
+/// hydroclimate layer couples. Computed honestly here (trace the outlet
+/// downstream): if it reaches the sea → `Exorheic`, else `Endorheic`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LakeType {
+    /// Drains to the sea (the geometric default).
+    Exorheic,
+    /// Terminal — no path to the sea (requires climate to actually occur).
+    Endorheic,
+}
+
+/// km² drainage-area thresholds for the navigability classes + the minimal
+/// mapped channel. **Anchored on real-world river navigability** (drainage area
+/// as the discharge proxy), NOT tuned — revisable by visual density review.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DrainageThresholds {
+    /// Minimal mapped channel (a cell is part of the river network at/above this
+    /// upstream area). ~20 km² ≈ a small perennial stream's catchment.
+    pub stream_km2: f32,
+    /// Small-boat navigable from this drainage area up. ~500 km².
+    pub small_boat_km2: f32,
+    /// Barge navigable. ~5 000 km².
+    pub barge_km2: f32,
+    /// Ship navigable. ~50 000 km².
+    pub ship_km2: f32,
+}
+
+impl Default for DrainageThresholds {
+    fn default() -> Self {
+        Self { stream_km2: 20.0, small_boat_km2: 500.0, barge_km2: 5_000.0, ship_km2: 50_000.0 }
+    }
+}
+
+impl DrainageThresholds {
+    fn classify(&self, drainage_km2: f32) -> Navigability {
+        if drainage_km2 >= self.ship_km2 {
+            Navigability::Ship
+        } else if drainage_km2 >= self.barge_km2 {
+            Navigability::Barge
+        } else if drainage_km2 >= self.small_boat_km2 {
+            Navigability::SmallBoat
+        } else {
+            Navigability::NonNavigable
+        }
+    }
+}
+
+/// C1 drainage configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct C1DrainageConfig {
+    /// Network / navigability thresholds in km².
+    pub thresholds: DrainageThresholds,
+    /// Minimum lake depth in METRES (filled − eroded) to classify as a lake.
+    pub lake_min_depth_m: f32,
+    /// Minimum lake surface area in km² to keep.
+    pub lake_min_area_km2: f32,
+}
+
+impl Default for C1DrainageConfig {
+    fn default() -> Self {
+        // 10 m min lake depth, 5 km² min lake area — plausible mappable lakes.
+        Self { thresholds: DrainageThresholds::default(), lake_min_depth_m: 10.0, lake_min_area_km2: 5.0 }
+    }
+}
+
+/// A lake enriched with the C1 coordinate contract (metres + area km² + type).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct C1Lake {
+    /// The underlying geometric lake (norm-space surface/depth, outlet, basin).
+    pub base: Lake,
+    /// Surface (outlet sill) elevation in metres.
+    pub level_m: f32,
+    /// Maximum depth in metres.
+    pub depth_m: f32,
+    /// Surface area in km².
+    pub area_km2: f32,
+    /// Drainage type (Exorheic geometric default; Endorheic needs climate).
+    pub lake_type: LakeType,
+}
+
+/// Full C1 drainage product: flow field, rivers (+ per-segment navigability /
+/// drainage area), and lakes (in metres / km² / typed).
+pub struct C1DrainageResult {
+    pub flow: FlowResult,
+    pub rivers: RiverNetwork,
+    /// Per-segment upstream drainage area in km² (parallel to `rivers.segments`).
+    pub segment_drainage_km2: Vec<f32>,
+    /// Per-segment navigability class (parallel to `rivers.segments`).
+    pub segment_navigability: Vec<Navigability>,
+    pub lakes: Vec<C1Lake>,
+    pub lake_map: Vec<u32>,
+    pub width: usize,
+    pub height: usize,
+}
+
+/// Extract the drainage network (rivers + lakes) from the C1 HD product
+/// `heightmap` (the post-erosion `upscale_from_c1` output), at the C1 unified
+/// sea level (0.5) with km² thresholds and metre lake stats.
+///
+/// `ss` supplies the vertical scale (`depth_scale_m`) for the norm→metre lake
+/// stats. The km² scale comes from the heightmap's own resolution
+/// (`c1_cell_area_km2(width)`).
+pub fn c1_drainage(
+    heightmap: &GridF32,
+    cfg: &C1DrainageConfig,
+    ss: &SteinSteinParams,
+) -> C1DrainageResult {
+    let (w, h) = (heightmap.width, heightmap.height);
+    let cell_km2 = c1_cell_area_km2(w);
+    // metres per unit of normalised altitude (the linear vertical scale slope).
+    let metres_per_norm = c1_altitude_norm_to_metres(1.0, ss) - c1_altitude_norm_to_metres(0.0, ss);
+
+    // 1. Flow at the unified sea level (NOT the legacy 0.1).
+    let flow = compute_flow(heightmap, &FlowConfig { sea_level: C1_SEA_LEVEL_NORM });
+
+    // 2. Rivers — km² thresholds → accumulation cell-counts for THIS resolution.
+    let to_cells = |km2: f32| (km2 / cell_km2).max(1.0);
+    let river_cfg = RiverConfig {
+        stream_threshold: to_cells(cfg.thresholds.stream_km2),
+        // river/major are display tiers in terrain::flow; keep them at the
+        // small-boat / barge km² tiers so the existing consumers stay coherent.
+        river_threshold: to_cells(cfg.thresholds.small_boat_km2),
+        major_river_threshold: to_cells(cfg.thresholds.barge_km2),
+    };
+    let rivers = extract_rivers(&flow, &river_cfg, w, h);
+
+    // Per-segment drainage area (km²) from the segment's max accumulation, and
+    // the navigability class.
+    let segment_drainage_km2: Vec<f32> =
+        rivers.segments.iter().map(|s| s.max_flow * cell_km2).collect();
+    let segment_navigability: Vec<Navigability> =
+        segment_drainage_km2.iter().map(|&km2| cfg.thresholds.classify(km2)).collect();
+
+    // 3. Lakes — min_depth (m → norm), min_area (km² → cells).
+    let lake_cfg = LakeConfig {
+        min_depth: cfg.lake_min_depth_m / metres_per_norm,
+        min_area: (cfg.lake_min_area_km2 / cell_km2).ceil().max(1.0) as usize,
+    };
+    let lake_result =
+        detect_lakes(heightmap, &flow.filled, &flow.direction, &flow.basins, &lake_cfg);
+
+    // Enrich lakes: metres, km², type (trace outlet → sea?).
+    let lakes: Vec<C1Lake> = lake_result
+        .lakes
+        .iter()
+        .map(|lk| {
+            let level_m = c1_altitude_norm_to_metres(lk.surface_elevation, ss);
+            let floor_m = c1_altitude_norm_to_metres(lk.surface_elevation - lk.max_depth, ss);
+            let lake_type = if outlet_reaches_sea(lk, &flow, heightmap, w, h) {
+                LakeType::Exorheic
+            } else {
+                LakeType::Endorheic
+            };
+            C1Lake {
+                base: lk.clone(),
+                level_m,
+                depth_m: level_m - floor_m,
+                area_km2: lk.area as f32 * cell_km2,
+                lake_type,
+            }
+        })
+        .collect();
+
+    C1DrainageResult {
+        flow,
+        rivers,
+        segment_drainage_km2,
+        segment_navigability,
+        lakes,
+        lake_map: lake_result.lake_map,
+        width: w,
+        height: h,
+    }
+}
+
+/// Trace a lake's outlet downstream via D8; does it reach the sea (≤ 0.5)?
+/// (With priority-flood this is always true — the honest computation that would
+/// flag `Endorheic` if a future terminal basin ever existed.)
+fn outlet_reaches_sea(
+    lake: &Lake,
+    flow: &FlowResult,
+    heightmap: &GridF32,
+    w: usize,
+    h: usize,
+) -> bool {
+    let (mut x, mut y) = (lake.outlet.0 as usize, lake.outlet.1 as usize);
+    let max_steps = w * h;
+    for _ in 0..=max_steps {
+        let k = y * w + x;
+        if heightmap.data[k] <= C1_SEA_LEVEL_NORM {
+            return true;
+        }
+        let d = flow.direction[k];
+        if d == DIR_NONE {
+            return false;
+        }
+        x = ((x as i32 + D8_DX[d as usize]).rem_euclid(w as i32)) as usize;
+        y = ((y as i32 + D8_DY[d as usize]).rem_euclid(h as i32)) as usize;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A tilted plane draining to an ocean edge: the stack runs at sea=0.5,
+    /// produces rivers, and km² drainage areas are finite + monotone with
+    /// max_flow.
+    #[test]
+    fn c1_drainage_runs_on_tilted_plane() {
+        let n = 64;
+        let mut hm = GridF32::new(n, n, 0.0);
+        for j in 0..n {
+            for i in 0..n {
+                // land on the left (>0.5), ocean on the right (<0.5).
+                let t = i as f32 / n as f32;
+                hm.set(i, j, 0.85 - t * 0.6);
+            }
+        }
+        let out = c1_drainage(&hm, &C1DrainageConfig::default(), &SteinSteinParams::default());
+        assert_eq!(out.width, n);
+        assert_eq!(out.segment_drainage_km2.len(), out.rivers.segments.len());
+        assert!(out.segment_drainage_km2.iter().all(|v| v.is_finite() && *v >= 0.0));
+        // All lakes (if any) carry finite metre stats.
+        for lk in &out.lakes {
+            assert!(lk.level_m.is_finite() && lk.depth_m.is_finite() && lk.depth_m >= 0.0);
+            assert!(lk.area_km2 > 0.0);
+        }
+    }
+
+    /// Navigability classification is monotone in drainage area.
+    #[test]
+    fn navigability_thresholds_monotone() {
+        let t = DrainageThresholds::default();
+        assert_eq!(t.classify(10.0), Navigability::NonNavigable);
+        assert_eq!(t.classify(1_000.0), Navigability::SmallBoat);
+        assert_eq!(t.classify(8_000.0), Navigability::Barge);
+        assert_eq!(t.classify(80_000.0), Navigability::Ship);
+    }
+}

--- a/crates/ymir-core/src/tectonics_c1/mod.rs
+++ b/crates/ymir-core/src/tectonics_c1/mod.rs
@@ -78,6 +78,7 @@
 pub mod boundary_classification;
 pub mod closures;
 pub mod distance_field;
+pub mod drainage;
 pub mod init;
 pub mod init_r7;
 pub mod kinematics;

--- a/crates/ymir-core/src/tectonics_c1/production_upscale.rs
+++ b/crates/ymir-core/src/tectonics_c1/production_upscale.rs
@@ -206,6 +206,42 @@ pub fn c1_metres_to_altitude_norm(metres: f32, ss: &SteinSteinParams) -> f32 {
     metres / (2.0 * ALTITUDE_NORM_HALF_RANGE * ss.depth_scale_m as f32) + 0.5
 }
 
+/// #155 — **THE C1 HORIZONTAL scale (the coordinate contract's other half).**
+/// The km side-length the unit (`1 × 1`) tectonic domain represents. This is the
+/// pendant of the vertical `c1_altitude_norm_to_metres`: the metadata.json
+/// coordinate contract (§9.3) lists meters-per-pixel ALONGSIDE the elevation
+/// scale — both are ONE coordinate system, and a defined horizontal scale is the
+/// shared prerequisite for every metric consumer (rivers' drainage-area
+/// thresholds, biome zones, climate orographic distance, village spacing).
+///
+/// **Derivation (anchored, not arbitrary).** TDD §11 "Implicit physical scales"
+/// states the C1 domain is regional (~1000-5000 km) with dx ≈ "~2 km at 512²".
+/// Pinning the lower-end TDD anchor `2.0 km/cell × 512 = 1024 km` makes that
+/// implicit statement explicit. dx then = 16 km @64² (tectonic), 0.5 km @2048²
+/// (HD). Consistent with the §2.2 gameplay scale (a dense playable region —
+/// cités, riverside villages, navigable valleys — i.e. "large region", not a
+/// stretched whole continent). **Revisable product choice**: a "whole continent"
+/// intent would set ~3000 km; change this ONE constant and every consumer
+/// follows (nothing else encodes the horizontal scale).
+pub const C1_DOMAIN_KM: f32 = 1024.0;
+
+/// Kilometres per cell at the given grid resolution (the `1×1` domain is
+/// [`C1_DOMAIN_KM`] on a side). Resolution-INdependent contract: the domain km
+/// is fixed; km/cell = `C1_DOMAIN_KM / grid_size`. E.g. 2.0 km @512², 0.5 km
+/// @2048².
+pub fn c1_km_per_cell(grid_size: usize) -> f32 {
+    C1_DOMAIN_KM / grid_size as f32
+}
+
+/// Cell area in km² at the given grid resolution — the unit for
+/// resolution-independent drainage-area thresholds (flow accumulation × this =
+/// upstream area in km², which does NOT change with grid_size for the same
+/// physical catchment).
+pub fn c1_cell_area_km2(grid_size: usize) -> f32 {
+    let s = c1_km_per_cell(grid_size);
+    s * s
+}
+
 /// Upscale a C1 simulation state to a detailed heightmap via the
 /// anisotropic-FBM upscale, **through the robustness-preserving
 /// altitude path** (Issue #147 FOLLOWUPS-#6 — see module docs).
@@ -291,5 +327,30 @@ mod tests {
         assert_eq!(out.heightmap.width, 128);
         assert_eq!(out.heightmap.height, 128);
         assert!(out.heightmap.data.iter().all(|v| v.is_finite()));
+    }
+
+    /// #155 horizontal contract — the TDD §11 anchor (2.0 km/cell @512²) +
+    /// resolution-independence (domain km fixed; km/cell = domain/grid).
+    #[test]
+    fn horizontal_scale_contract() {
+        assert_eq!(C1_DOMAIN_KM, 1024.0);
+        assert!((c1_km_per_cell(512) - 2.0).abs() < 1e-6, "TDD §11 anchor: 2 km/cell @512²");
+        assert!((c1_km_per_cell(64) - 16.0).abs() < 1e-6);
+        assert!((c1_km_per_cell(2048) - 0.5).abs() < 1e-6);
+        // cell area = (km/cell)²; a fixed physical catchment is resolution-invariant:
+        // accumulation(cells) × cell_area_km2 = upstream area in km².
+        assert!((c1_cell_area_km2(512) - 4.0).abs() < 1e-6);
+        assert!((c1_cell_area_km2(2048) - 0.25).abs() < 1e-6);
+    }
+
+    /// #155 vertical contract — anchors + round-trip (Maillon 2).
+    #[test]
+    fn vertical_scale_contract() {
+        let ss = SteinSteinParams::default();
+        assert!((c1_altitude_norm_to_metres(0.5, &ss)).abs() < 1e-3, "sea = 0 m");
+        assert!((c1_altitude_norm_to_metres(1.0, &ss) - 5650.0).abs() < 5.0);
+        assert!((c1_altitude_norm_to_metres(0.0, &ss) + 5650.0).abs() < 5.0);
+        let rt = c1_metres_to_altitude_norm(c1_altitude_norm_to_metres(0.73, &ss), &ss);
+        assert!((rt - 0.73).abs() < 1e-5, "round-trip");
     }
 }

--- a/crates/ymir-core/src/terrain/flow.rs
+++ b/crates/ymir-core/src/terrain/flow.rs
@@ -118,14 +118,26 @@ pub fn compute_flow(heightmap: &GridF32, config: &FlowConfig) -> FlowResult {
         is_ocean[i] = heightmap.data[i] <= config.sea_level;
     }
 
-    // Step 2: priority flood pit filling
+    // Step 2: priority flood pit filling (fills depressions to the EXACT sill —
+    // no epsilon increment, so flats are truly flat for the Garbrecht-Martz step).
     let filled = pit_fill(heightmap, &is_ocean, w, h);
 
-    // Step 3: D8 flow direction
-    let direction = compute_d8(&filled, &is_ocean, w, h);
+    // Step 2b: flat resolution (Garbrecht-Martz 1997). Replaces the old eps-fill
+    // micro-gradient (which followed the flood TREE → parallel-bar / 45°-fan
+    // artifacts on flat interiors, #155 diagnostic 2ec0348). Imposes a convergent
+    // drainage gradient on the EXACT-equal flats (= the pit-filled depressions;
+    // native FBM-textured plateaus are never exactly flat, so they keep their
+    // real micro-gradient and are untouched). Returns a per-cell `flat_grad`
+    // (f64, 0 on non-flat cells) used ONLY for routing — `filled` keeps the exact
+    // sill so lake levels are unchanged.
+    let flat_grad = resolve_flats(&filled, &is_ocean, w, h);
 
-    // Step 4: flow accumulation
-    let accumulation = compute_accumulation(&filled, &direction, &is_ocean, w, h);
+    // Step 3: D8 flow direction (steepest descent on `filled`; flat cells routed
+    // down the `flat_grad` toward the outlet).
+    let direction = compute_d8(&filled, &flat_grad, &is_ocean, w, h);
+
+    // Step 4: flow accumulation (topological order by filled, then flat_grad).
+    let accumulation = compute_accumulation(&filled, &flat_grad, &direction, &is_ocean, w, h);
 
     // Step 5: basin labeling
     let (basins, num_basins) = compute_basins(&direction, &is_ocean, w, h);
@@ -138,7 +150,6 @@ fn pit_fill(heightmap: &GridF32, is_ocean: &[bool], w: usize, h: usize) -> GridF
     let mut filled = heightmap.clone();
     let mut processed = vec![false; n];
     let mut pq = BinaryHeap::new();
-    let eps: f32 = 1e-7;
 
     // Seed: ocean cells and land cells adjacent to ocean
     for j in 0..h {
@@ -174,7 +185,10 @@ fn pit_fill(heightmap: &GridF32, is_ocean: &[bool], w: usize, h: usize) -> GridF
                 continue;
             }
 
-            let fill_h = heightmap.data[nidx].max(filled.data[cell.idx] + eps);
+            // Fill to the exact sill (no epsilon): a depression becomes a TRUE
+            // flat, which the Garbrecht-Martz step then drains. (Was `+ eps`, the
+            // flood-tree micro-gradient that caused the flat-routing artifact.)
+            let fill_h = heightmap.data[nidx].max(filled.data[cell.idx]);
             filled.data[nidx] = fill_h;
             processed[nidx] = true;
             pq.push(PqCell { height: fill_h, idx: nidx });
@@ -184,7 +198,7 @@ fn pit_fill(heightmap: &GridF32, is_ocean: &[bool], w: usize, h: usize) -> GridF
     filled
 }
 
-fn compute_d8(filled: &GridF32, is_ocean: &[bool], w: usize, h: usize) -> Vec<u8> {
+fn compute_d8(filled: &GridF32, flat_grad: &[f64], is_ocean: &[bool], w: usize, h: usize) -> Vec<u8> {
     let n = w * h;
     let mut direction = vec![DIR_NONE; n];
 
@@ -199,6 +213,8 @@ fn compute_d8(filled: &GridF32, is_ocean: &[bool], w: usize, h: usize) -> Vec<u8
             let mut best_dir = DIR_NONE;
             let mut best_slope = 0.0f32;
 
+            // Pass 1 — steepest descent on `filled` (real terrain + the sill exits
+            // of flats). Unchanged from the original; slopes/real drainage untouched.
             for d in 0..8 {
                 let ni = ((i as i32 + D8_DX[d]) % w as i32 + w as i32) as usize % w;
                 let nj = ((j as i32 + D8_DY[d]) % h as i32 + h as i32) as usize % h;
@@ -211,6 +227,27 @@ fn compute_d8(filled: &GridF32, is_ocean: &[bool], w: usize, h: usize) -> Vec<u8
                 }
             }
 
+            // Pass 2 — flat resolution. Only reached when no strictly-lower
+            // neighbour exists (a pit-filled flat interior). Route to the
+            // EQUAL-elevation neighbour with the smallest `flat_grad` (down the
+            // Garbrecht-Martz gradient toward the outlet). `flat_grad` is 0 on
+            // non-flat cells, so the flat's spill cells (which DO drain via pass 1)
+            // attract the flow. Guaranteed to descend (the toward-lower term
+            // dominates `flat_grad`), so no spurious sink is introduced.
+            if best_dir == DIR_NONE {
+                let my_g = flat_grad[idx];
+                let mut best_g = my_g;
+                for d in 0..8 {
+                    let ni = ((i as i32 + D8_DX[d]) % w as i32 + w as i32) as usize % w;
+                    let nj = ((j as i32 + D8_DY[d]) % h as i32 + h as i32) as usize % h;
+                    let nidx = nj * w + ni;
+                    if !is_ocean[nidx] && filled.data[nidx] == my_h && flat_grad[nidx] < best_g {
+                        best_g = flat_grad[nidx];
+                        best_dir = d as u8;
+                    }
+                }
+            }
+
             direction[idx] = best_dir;
         }
     }
@@ -218,8 +255,143 @@ fn compute_d8(filled: &GridF32, is_ocean: &[bool], w: usize, h: usize) -> Vec<u8
     direction
 }
 
+/// Garbrecht-Martz 1997 flat resolution. Imposes a convergent drainage gradient
+/// over the TRULY-flat regions (cells whose `filled` value exactly equals a
+/// neighbour's and which have no strictly-lower neighbour = the pit-filled
+/// depression interiors). Returns a per-cell `flat_grad` (0 on non-flat cells);
+/// a flat cell drains to the equal-elevation neighbour with the smallest value.
+///
+/// The gradient combines two distance transforms over the flat:
+/// - **toward-lower** `tl`: graph distance from the flat's spill cells (the
+///   equal-elevation cells adjacent to lower terrain / ocean). 0 at the spill,
+///   growing inward.
+/// - **away-from-higher** `fh`: graph distance from the flat's high edges (cells
+///   adjacent to HIGHER terrain — where inflow enters). 0 at the high edge.
+///
+/// `flat_grad = tl·(fhmax+1) + (fhmax − fh)`. The `tl` term DOMINATES (weight
+/// `fhmax+1` exceeds the `(fhmax − fh)` range), so every flat cell has a
+/// strictly-smaller-`flat_grad` neighbour toward a spill → guaranteed drainage,
+/// no interior minimum. The `(fhmax − fh)` term breaks ties between equal-`tl`
+/// neighbours toward the convergent (away-from-inflow) direction — this is what
+/// dissolves the parallel-bar / fan pattern the old eps-fill produced.
+///
+/// Native FBM-textured plateaus are never EXACTLY flat (micro-relief gives a
+/// strictly-lower neighbour), so they are not classified as flat here and keep
+/// their real diffuse drainage — the fix touches only the pit-filled flats.
+fn resolve_flats(filled: &GridF32, is_ocean: &[bool], w: usize, h: usize) -> Vec<f64> {
+    use std::collections::VecDeque;
+    let n = w * h;
+    let f = &filled.data;
+    let nb = |i: usize, j: usize, d: usize| -> usize {
+        let ni = ((i as i32 + D8_DX[d]) % w as i32 + w as i32) as usize % w;
+        let nj = ((j as i32 + D8_DY[d]) % h as i32 + h as i32) as usize % h;
+        nj * w + ni
+    };
+
+    // 1. Classify flat cells: land, exact-equal to a neighbour, no lower neighbour.
+    let mut needs = vec![false; n];
+    for j in 0..h {
+        for i in 0..w {
+            let c = j * w + i;
+            if is_ocean[c] {
+                continue;
+            }
+            let (mut has_lower, mut has_equal) = (false, false);
+            for d in 0..8 {
+                let m = nb(i, j, d);
+                if is_ocean[m] || f[m] < f[c] {
+                    has_lower = true;
+                } else if f[m] == f[c] {
+                    has_equal = true;
+                }
+            }
+            needs[c] = !has_lower && has_equal;
+        }
+    }
+
+    // 2. toward-lower BFS — seeds: flat cells adjacent to a spill (ocean, lower,
+    //    or an equal NON-flat cell that itself drains).
+    let mut tl = vec![-1i32; n];
+    let mut q = VecDeque::new();
+    for j in 0..h {
+        for i in 0..w {
+            let c = j * w + i;
+            if !needs[c] {
+                continue;
+            }
+            let mut is_spill = false;
+            for d in 0..8 {
+                let m = nb(i, j, d);
+                if is_ocean[m] || f[m] < f[c] || (f[m] == f[c] && !needs[m]) {
+                    is_spill = true;
+                }
+            }
+            if is_spill {
+                tl[c] = 0;
+                q.push_back(c);
+            }
+        }
+    }
+    while let Some(c) = q.pop_front() {
+        let (ci, cj) = (c % w, c / w);
+        for d in 0..8 {
+            let m = nb(ci, cj, d);
+            if needs[m] && f[m] == f[c] && tl[m] < 0 {
+                tl[m] = tl[c] + 1;
+                q.push_back(m);
+            }
+        }
+    }
+
+    // 3. away-from-higher BFS — seeds: flat cells adjacent to higher terrain.
+    let mut fh = vec![-1i32; n];
+    let mut q2 = VecDeque::new();
+    for j in 0..h {
+        for i in 0..w {
+            let c = j * w + i;
+            if !needs[c] {
+                continue;
+            }
+            let mut is_high = false;
+            for d in 0..8 {
+                let m = nb(i, j, d);
+                if !is_ocean[m] && f[m] > f[c] {
+                    is_high = true;
+                }
+            }
+            if is_high {
+                fh[c] = 0;
+                q2.push_back(c);
+            }
+        }
+    }
+    while let Some(c) = q2.pop_front() {
+        let (ci, cj) = (c % w, c / w);
+        for d in 0..8 {
+            let m = nb(ci, cj, d);
+            if needs[m] && f[m] == f[c] && fh[m] < 0 {
+                fh[m] = fh[c] + 1;
+                q2.push_back(m);
+            }
+        }
+    }
+    let fhmax = fh.iter().copied().max().unwrap_or(0).max(0) as f64;
+
+    // 4. Combined gradient (tl dominant → guaranteed descent; fh breaks bars).
+    let mut flat_grad = vec![0.0f64; n];
+    for c in 0..n {
+        if needs[c] {
+            let t = if tl[c] < 0 { 0 } else { tl[c] } as f64;
+            let hh = if fh[c] < 0 { fhmax } else { fh[c] as f64 };
+            flat_grad[c] = t * (fhmax + 1.0) + (fhmax - hh);
+        }
+    }
+    flat_grad
+}
+
 fn compute_accumulation(
     filled: &GridF32,
+    flat_grad: &[f64],
     direction: &[u8],
     is_ocean: &[bool],
     w: usize,
@@ -227,10 +399,15 @@ fn compute_accumulation(
 ) -> GridF32 {
     let n = w * h;
 
-    // Sort land cells by decreasing height
+    // Sort land cells by decreasing height, then decreasing flat_grad so flat
+    // cells are processed from the inflow side down to the outlet (correct
+    // topological order on flats where `filled` ties).
     let mut land_cells: Vec<usize> = (0..n).filter(|&i| !is_ocean[i]).collect();
     land_cells.sort_unstable_by(|&a, &b| {
-        filled.data[b].partial_cmp(&filled.data[a]).unwrap_or(CmpOrd::Equal)
+        filled.data[b]
+            .partial_cmp(&filled.data[a])
+            .unwrap_or(CmpOrd::Equal)
+            .then(flat_grad[b].partial_cmp(&flat_grad[a]).unwrap_or(CmpOrd::Equal))
     });
 
     let mut acc = GridF32::new(w, h, 0.0);

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -4388,3 +4388,44 @@ fn probe_ladder_reconcile() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155 yellow-fan mechanism — zoom the largest NON-LAKE resolved-flat (the
+/// "yellow triangle"), colour by D8 direction, to see WHY it's rectilinear
+/// (diamond iso-lines of the tl-dominant distance transform?). Confirm before
+/// re-tuning the GM weighting.
+#[test]
+#[ignore]
+fn probe_yellow_fan_mechanism() {
+    use ymir_core::terrain::flow::{DIR_NONE, D8_DX, D8_DY};
+    use ymir_core::tectonics_c1::drainage::{c1_drainage, C1DrainageConfig};
+    let dir = output_dir().join("yellow_fan"); std::fs::create_dir_all(&dir).unwrap();
+    let iso=IsostasyConfig::c1_default(); let ss=SteinSteinParams::default(); let dcfg=C1DrainageConfig::default(); let grid=64usize;
+    let huecol=|d:u8|->[u8;3]{match d{0=>[230,30,30],1=>[230,140,20],2=>[220,220,30],3=>[60,200,40],4=>[30,200,200],5=>[40,90,230],6=>[150,40,220],7=>[230,40,150],_=>[110,110,110]}};
+    for &seed in &[1988u64,2026]{
+        let mut state=init_c1_state_phase_2_r7(grid,seed,&Phase2InitParams::default());
+        let mut kin=PlateKinematics::preset_phase_1_1(state.num_plates);
+        let config=C1TimeLoopConfig{rigid_continental_crust:true,n_steps:300,dx:1.0/64.0,dy:1.0/64.0,iso_config:iso.clone(),drainage_max_distance:30};
+        run_with_closures(&mut state,&mut kin,&config,&C1Closures::default(),|_,_|{});
+        let up=upscale_from_c1(&state,&iso,&ss,&WorldSeed::new(seed),&FbmUpscaleConfig::c1_hd_production(2048));
+        let h=&up.heightmap;let(w,ht)=(h.width,h.height);let dr=c1_drainage(h,&dcfg,&ss);
+        let f=&dr.flow.filled.data; let dirf=&dr.flow.direction;
+        let nb=|i:usize,j:usize,d:usize|{let ni=((i as i32+D8_DX[d]).rem_euclid(w as i32))as usize;let nj=((j as i32+D8_DY[d]).rem_euclid(ht as i32))as usize;nj*w+ni};
+        // exact-flat NON-lake cells.
+        let mut ef=vec![false;w*ht];
+        for j in 0..ht{for i in 0..w{let k=j*w+i;if h.data[k]<=0.5||dr.lake_map[k]!=0{continue}let(mut hl,mut he)=(false,false);for d in 0..8{let m=nb(i,j,d);if f[m]<f[k]{hl=true}else if f[m]==f[k]{he=true}}ef[k]=!hl&&he;}}
+        // largest connected ef cluster.
+        let mut seen=vec![false;w*ht];let(mut bn,mut bx,mut by,mut bw,mut bh,mut bi,mut bj)=(0usize,0usize,0usize,0usize,0usize,0usize,0usize);
+        for s0 in 0..w*ht{if !ef[s0]||seen[s0]{continue}let mut q=std::collections::VecDeque::new();q.push_back(s0);seen[s0]=true;let(mut c,mut sx,mut sy,mut mni,mut mxi,mut mnj,mut mxj)=(0u64,0u64,0u64,w,0usize,ht,0usize);
+            while let Some(z)=q.pop_front(){c+=1;let(zi,zj)=(z%w,z/w);sx+=zi as u64;sy+=zj as u64;mni=mni.min(zi);mxi=mxi.max(zi);mnj=mnj.min(zj);mxj=mxj.max(zj);for d in 0..8{let m=nb(zi,zj,d);if ef[m]&&!seen[m]{seen[m]=true;q.push_back(m)}}}
+            if c as usize>bn{bn=c as usize;bx=(sx/c)as usize;by=(sy/c)as usize;bw=mxi-mni+1;bh=mxj-mnj+1;bi=mni;bj=mnj;}}
+        eprintln!("  seed {seed}: largest non-lake resolved-flat = {bn} cells, bbox {bw}x{bh} @({bi},{bj}), centroid ({bx},{by})");
+        let sz=128usize;let x0=(bx as i64-64).max(0).min(w as i64-sz as i64)as usize;let y0=(by as i64-64).max(0).min(ht as i64-sz as i64)as usize;
+        let mut buf=image::ImageBuffer::new(sz as u32,sz as u32);
+        for jj in 0..sz{for ii in 0..sz{let(i,j)=(x0+ii,y0+jj);let k=j*w+i;
+            let c= if h.data[k]<=0.5{[30,50,90]} else if dr.lake_map[k]!=0{[60,200,220]} else if ef[k]{huecol(dirf[k])} else {[235,235,235]};
+            buf.put_pixel(ii as u32,(sz-1-jj)as u32,image::Rgb(c));
+        }}
+        buf.save(dir.join(format!("seed{seed:05}_yellowfan_dir.png"))).unwrap();
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -4183,3 +4183,97 @@ fn probe_flat_fix_validation() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155 quasi-flat residual DIAGNOSTIC — measure the EXTENT and NATURE of the
+/// ladder/parallel residual on near-flat cells NOT resolved by resolve_flats
+/// (non-exact-equal, so GM skipped them). The local gradient is the instrument
+/// the hillshade lacked: it separates a quasi-flat defect (grad≈0) from natural
+/// D8-on-planar-slope parallelism (grad low but franc). Quantify, don't fix.
+#[test]
+#[ignore]
+fn probe_quasi_flat_residual() {
+    use ymir_core::terrain::flow::{compute_flow, FlowConfig, RiverConfig, DIR_NONE, D8_DX, D8_DY};
+    use ymir_core::tectonics_c1::drainage::{c1_drainage, C1DrainageConfig};
+    use ymir_core::tectonics_c1::production_upscale::{c1_cell_area_km2, c1_altitude_norm_to_metres, C1_DOMAIN_KM};
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    // gradient bins in norm/cell; converted to m/km via the contracts.
+    let bins = [0.0f32, 1e-5, 1e-4, 1e-3, 1e-2, f32::INFINITY];
+    let binname = ["<1e-5","1e-5..1e-4","1e-4..1e-3","1e-3..1e-2",">=1e-2"];
+    // local directional coherence: fraction of drainage-neighbours (5x5) sharing dir.
+    let coherence = |dir:&[u8], acc:&GridF32, stream:f32, w:usize, ht:usize, k:usize| -> f32 {
+        let d=dir[k]; if d==DIR_NONE {return 0.0}
+        let (ci,cj)=(k%w,k/w); let (mut same,mut tot)=(0u32,0u32);
+        for dj in -2i32..=2 { for di in -2i32..=2 {
+            if di==0&&dj==0 {continue}
+            let ni=(ci as i32+di).rem_euclid(w as i32) as usize; let nj=(cj as i32+dj).rem_euclid(ht as i32) as usize;
+            let m=nj*w+ni; if acc.data[m]>=stream && dir[m]!=DIR_NONE { tot+=1; if dir[m]==d {same+=1} }
+        }}
+        if tot==0 {0.0} else {same as f32/tot as f32}
+    };
+    // --- counterfactual: synthetic uniform slopes (parallel-on-planar baseline) ---
+    eprintln!("#155 quasi-flat residual — synthetic uniform-slope counterfactual (parallel baseline):");
+    for &sg in &[1e-4f32, 1e-3, 5e-3] {
+        let n=512usize; let mut hm=GridF32::new(n,n,0.0);
+        for j in 0..n { for i in 0..n { hm.set(i,j, (0.75 - i as f32*sg).max(0.2)); }}
+        let fl=compute_flow(&hm,&FlowConfig{sea_level:0.5});
+        let stream=RiverConfig::default().stream_threshold;
+        let (mut cs,mut cn)=(0.0f32,0u32);
+        for k in 0..n*n { if hm.data[k]>0.5 && fl.accumulation.data[k]>=stream { cs+=coherence(&fl.direction,&fl.accumulation,stream,n,n,k); cn+=1; }}
+        eprintln!("  slope {sg:.0e} norm/cell (~{:.1} m/km): mean dir-coherence over drainage = {:.2} (1.0 = fully parallel)",
+            sg*c1_altitude_norm_to_metres_delta(&ss)/(C1_DOMAIN_KM/n as f32), if cn>0 {cs/cn as f32} else {0.0});
+    }
+    // --- real terrain ---
+    let grid=64usize; let dcfg=C1DrainageConfig::default();
+    for &seed in &[1988u64, 2026] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg_2048());
+        let h=&up.heightmap; let (w,ht)=(h.width,h.height);
+        let dr=c1_drainage(h,&dcfg,&ss);
+        let f=&dr.flow.filled.data;
+        let stream=(dcfg.thresholds.stream_km2/c1_cell_area_km2(w)).max(1.0);
+        let m_per_km = c1_altitude_norm_to_metres_delta(&ss)/(C1_DOMAIN_KM/w as f32);
+        // recompute exact-flat (GM-resolved) membership on filled.
+        let nb=|i:usize,j:usize,d:usize|{let ni=((i as i32+D8_DX[d]).rem_euclid(w as i32))as usize;let nj=((j as i32+D8_DY[d]).rem_euclid(ht as i32))as usize;nj*w+ni};
+        let mut bin_tot=[0u64;5]; let mut bin_nonexact=[0u64;5]; let mut bin_coh=[0.0f64;5];
+        let (mut drain,mut land)=(0u64,0u64);
+        let (mut resid,mut resid_fringe)=(0u64,0u64);
+        for j in 0..ht { for i in 0..w { let k=j*w+i;
+            if h.data[k]<=0.5 {continue} land+=1;
+            if dr.flow.accumulation.data[k] < stream {continue} drain+=1;
+            let (gx,gy)=h.gradient_at(i,j); let g=(gx*gx+gy*gy).sqrt();
+            let mut b=4; for t in 0..5 { if g>=bins[t]&&g<bins[t+1]{b=t;break} }
+            bin_tot[b]+=1; bin_coh[b]+=coherence(&dr.flow.direction,&dr.flow.accumulation,stream,w,ht,k) as f64;
+            // exact-flat? no strictly-lower filled neighbour AND an exact-equal one.
+            let (mut hl,mut he)=(false,false);
+            for d in 0..8 { let mm=nb(i,j,d); if f[mm]<f[k]{hl=true} else if f[mm]==f[k]{he=true} }
+            let exact_flat = !hl && he;
+            if !exact_flat { bin_nonexact[b]+=1; }
+            // residual band = low-gradient (<1e-4) AND not exact-flat (GM skipped it).
+            if g<1e-4 && !exact_flat {
+                resid+=1;
+                // fringe: adjacent to a filled cell (filled>h → partially-filled depression edge)?
+                let mut fr=false; for d in 0..8 { let mm=nb(i,j,d); if dr.flow.filled.data[mm]-h.data[mm]>1e-5 {fr=true} }
+                if fr {resid_fringe+=1;}
+            }
+        }}
+        eprintln!("  seed {seed} @2048² (m/km factor {m_per_km:.0}): drainage cells {drain} ({:.1}% of land)", 100.0*drain as f64/land.max(1) as f64);
+        for b in 0..5 {
+            let coh = if bin_tot[b]>0 {bin_coh[b]/bin_tot[b] as f64} else {0.0};
+            eprintln!("    grad {:>10} ({:>6.1} m/km lo): {:>7} drainage ({:>4.1}%), non-exact {:>7} ({:>4.1}%), coherence {:.2}",
+                binname[b], bins[b]*m_per_km, bin_tot[b], 100.0*bin_tot[b] as f64/drain.max(1) as f64,
+                bin_nonexact[b], 100.0*bin_nonexact[b] as f64/bin_tot[b].max(1) as f64, coh);
+        }
+        eprintln!("    RESIDUAL band (grad<1e-4 & non-exact-flat): {resid} cells = {:.2}% of drainage, {:.3}% of land | fringe-of-depression {:.0}%",
+            100.0*resid as f64/drain.max(1) as f64, 100.0*resid as f64/land.max(1) as f64, 100.0*resid_fringe as f64/resid.max(1) as f64);
+    }
+}
+fn cfg_2048() -> FbmUpscaleConfig { FbmUpscaleConfig::c1_hd_production(2048) }
+fn c1_altitude_norm_to_metres_delta(ss:&SteinSteinParams)->f32 {
+    use ymir_core::tectonics_c1::production_upscale::c1_altitude_norm_to_metres;
+    c1_altitude_norm_to_metres(1.0,ss)-c1_altitude_norm_to_metres(0.0,ss)
+}

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -4101,3 +4101,85 @@ fn probe_flat_routing_fix_render() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155 flat-routing fix VALIDATION — zoomed overlays on the flat interiors
+/// (the decisive zone). Per seed @2048²: (1) crop on the FILLED-depression
+/// interior (where bars/fans were) → must be dendritic-convergent now;
+/// (2) crop on a NATIVE plateau → must stay diffuse (no invented channels);
+/// (3) full lakes/hypso (invariance). 1337 = slope control. Origin-bottom,
+/// rivers masked under lakes (product convention). Same c1_drainage config.
+#[test]
+#[ignore]
+fn probe_flat_fix_validation() {
+    use ymir_core::tectonics_c1::drainage::{c1_drainage, C1DrainageConfig, Navigability};
+    let dir = output_dir().join("flat_fix_validation");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let dcfg = C1DrainageConfig::default();
+    let grid = 64usize;
+    let shade = |h: &GridF32, i: usize, j: usize| -> u8 {
+        let z=60.0_f64; let (lx,ly,lz)={let(a,b,c)=(1.0_f64,1.0,2.0);let nn=(a*a+b*b+c*c).sqrt();(a/nn,b/nn,c/nn)};
+        let dzdx=(h.get(i as i32+1,j as i32)-h.get(i as i32-1,j as i32)) as f64*z;
+        let dzdy=(h.get(i as i32,j as i32+1)-h.get(i as i32,j as i32-1)) as f64*z;
+        let n=(dzdx*dzdx+dzdy*dzdy+1.0).sqrt(); (((-dzdx*lx-dzdy*ly+lz)/n).clamp(0.0,1.0)*255.0) as u8
+    };
+    // crop render: hillshade + navigable rivers (masked under lakes), origin-bottom.
+    let render_crop = |h:&GridF32, dr:&ymir_core::tectonics_c1::drainage::C1DrainageResult, x0:usize,y0:usize,sz:usize, path:&std::path::Path| {
+        let w=h.width;
+        let mut buf=image::ImageBuffer::new(sz as u32, sz as u32);
+        // base
+        for jj in 0..sz { for ii in 0..sz {
+            let (i,j)=(x0+ii,y0+jj); let k=j*w+i;
+            let c = if h.data[k]<=0.5 {[40,70,120]} else if dr.lake_map[k]!=0 {[35,80,160]} else {let g=shade(h,i,j);[g,g,g]};
+            buf.put_pixel(ii as u32,(sz-1-jj) as u32, image::Rgb(c));
+        }}
+        // navigable rivers (skip lake cells), thicker for higher tiers
+        for (si,seg) in dr.rivers.segments.iter().enumerate() {
+            let (col,th)=match dr.segment_navigability[si]{Navigability::Ship=>([10u8,50,170],1i32),Navigability::Barge=>([30,90,210],0),Navigability::SmallBoat=>([90,150,235],0),Navigability::NonNavigable=>([140,180,215],0)};
+            for &(px,py) in &seg.points {
+                let (px,py)=(px as usize,py as usize);
+                if px<x0||py<y0||px>=x0+sz||py>=y0+sz {continue}
+                for dj in -th..=th { for di in -th..=th {
+                    let (ii,jj)=((px as i32-x0 as i32+di),(py as i32-y0 as i32+dj));
+                    if ii<0||jj<0||ii>=sz as i32||jj>=sz as i32 {continue}
+                    let k=py*w+px; if dr.lake_map[k]!=0 {continue}
+                    buf.put_pixel(ii as u32,(sz as i32-1-jj) as u32, image::Rgb(col));
+                }}
+            }
+        }
+        buf.save(path).unwrap();
+    };
+    for &seed in &[1988u64, 2026, 1337] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let cfg = FbmUpscaleConfig::c1_hd_production(2048);
+        let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        let h=&up.heightmap; let (w,ht)=(h.width,h.height);
+        let dr=c1_drainage(h,&dcfg,&ss);
+        let sz=512usize;
+        // centroids: filled-depression flats vs native flats (land, low orig grad, not filled).
+        let (mut fx,mut fy,mut fn_,mut nx,mut ny,mut nn)=(0u64,0u64,0u64,0u64,0u64,0u64);
+        let mut lg=Vec::new();
+        for j in 0..ht { for i in 0..w { if h.data[j*w+i]>0.5 { let (gx,gy)=h.gradient_at(i,j); lg.push((gx*gx+gy*gy).sqrt()); }}}
+        lg.sort_by(|a,b|a.partial_cmp(b).unwrap()); let med=lg[lg.len()/2]; let flat_thr=0.15*med;
+        for j in 0..ht { for i in 0..w { let k=j*w+i; if h.data[k]<=0.5 {continue}
+            let raised=dr.flow.filled.data[k]-h.data[k];
+            let (gx,gy)=h.gradient_at(i,j); let g=(gx*gx+gy*gy).sqrt();
+            if raised>1e-5 { fx+=i as u64; fy+=j as u64; fn_+=1; }
+            else if g<flat_thr { nx+=i as u64; ny+=j as u64; nn+=1; }
+        }}
+        let clamp=|c:i64,sz:usize,max:usize| (c-(sz as i64)/2).max(0).min(max as i64-sz as i64) as usize;
+        if fn_>0 { let (cx,cy)=((fx/fn_) as i64,(fy/fn_) as i64); render_crop(h,&dr,clamp(cx,sz,w),clamp(cy,sz,ht),sz,&dir.join(format!("seed{seed:05}_filled_interior.png"))); }
+        if nn>0 { let (cx,cy)=((nx/nn) as i64,(ny/nn) as i64); render_crop(h,&dr,clamp(cx,sz,w),clamp(cy,sz,ht),sz,&dir.join(format!("seed{seed:05}_native_plateau.png"))); }
+        // full lakes/hypso (invariance)
+        let mut buf=image::ImageBuffer::new(w as u32, ht as u32);
+        for j in 0..ht { for i in 0..w { let k=j*w+i; let c= if dr.lake_map[k]!=0 {[40,90,190]} else {hypsometric(h.data[k].clamp(0.0,1.0),0.5)}; buf.put_pixel(i as u32,(ht-1-j) as u32, image::Rgb(c)); }}
+        buf.save(dir.join(format!("seed{seed:05}_lakes_hypso_full.png"))).unwrap();
+        eprintln!("  seed {seed}: filled-flat {fn_} cells, native-flat {nn} cells, {} lakes", dr.lakes.len());
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -4277,3 +4277,65 @@ fn c1_altitude_norm_to_metres_delta(ss:&SteinSteinParams)->f32 {
     use ymir_core::tectonics_c1::production_upscale::c1_altitude_norm_to_metres;
     c1_altitude_norm_to_metres(1.0,ss)-c1_altitude_norm_to_metres(0.0,ss)
 }
+
+/// #155 ladder-residual LOCATOR — confirm the mechanism on the WORST flagged
+/// feature before any fix. Finds the largest cluster of (drainage, grad<1e-4,
+/// non-exact-flat, high coherence) cells, hard-zooms it (96px) coloring each
+/// drainage cell by D8 DIRECTION (8 hues) over faint hillshade: a rectilinear
+/// ladder = regular same-hue blocks; correct convergent drainage = mixed hues.
+/// Reports those cells: gradient, raised-by-fill?, adjacent-to-resolved-flat?.
+#[test]
+#[ignore]
+fn probe_ladder_locator() {
+    use ymir_core::terrain::flow::{DIR_NONE, D8_DX, D8_DY};
+    use ymir_core::tectonics_c1::drainage::{c1_drainage, C1DrainageConfig};
+    use ymir_core::tectonics_c1::production_upscale::c1_cell_area_km2;
+    let dir = output_dir().join("ladder_locator");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default(); let ss = SteinSteinParams::default();
+    let dcfg = C1DrainageConfig::default(); let grid=64usize;
+    // 8 distinct hues for D8 directions.
+    let huecol = |d:u8| -> [u8;3] { match d {0=>[230,30,30],1=>[230,140,20],2=>[220,220,30],3=>[60,200,40],4=>[30,200,200],5=>[40,90,230],6=>[150,40,220],7=>[230,40,150],_=>[120,120,120]} };
+    let shade=|h:&GridF32,i:usize,j:usize|->u8{let z=40.0_f64;let(lx,ly,lz)={let(a,b,c)=(1.0_f64,1.0,2.0);let nn=(a*a+b*b+c*c).sqrt();(a/nn,b/nn,c/nn)};let dx=(h.get(i as i32+1,j as i32)-h.get(i as i32-1,j as i32))as f64*z;let dy=(h.get(i as i32,j as i32+1)-h.get(i as i32,j as i32-1))as f64*z;let n=(dx*dx+dy*dy+1.0).sqrt();(((-dx*lx-dy*ly+lz)/n).clamp(0.0,1.0)*200.0+30.0)as u8};
+    for &seed in &[1988u64, 2026] {
+        let mut state=init_c1_state_phase_2_r7(grid,seed,&Phase2InitParams::default());
+        let mut kin=PlateKinematics::preset_phase_1_1(state.num_plates);
+        let config=C1TimeLoopConfig{rigid_continental_crust:true,n_steps:300,dx:1.0/64.0,dy:1.0/64.0,iso_config:iso.clone(),drainage_max_distance:30};
+        run_with_closures(&mut state,&mut kin,&config,&C1Closures::default(),|_,_|{});
+        let up=upscale_from_c1(&state,&iso,&ss,&WorldSeed::new(seed),&FbmUpscaleConfig::c1_hd_production(2048));
+        let h=&up.heightmap; let(w,ht)=(h.width,h.height); let dr=c1_drainage(h,&dcfg,&ss);
+        let f=&dr.flow.filled.data; let dirf=&dr.flow.direction; let acc=&dr.flow.accumulation;
+        let stream=(dcfg.thresholds.stream_km2/c1_cell_area_km2(w)).max(1.0);
+        let nb=|i:usize,j:usize,d:usize|{let ni=((i as i32+D8_DX[d]).rem_euclid(w as i32))as usize;let nj=((j as i32+D8_DY[d]).rem_euclid(ht as i32))as usize;nj*w+ni};
+        let coh=|k:usize|->f32{let d=dirf[k];if d==DIR_NONE{return 0.0}let(ci,cj)=(k%w,k/w);let(mut s,mut t)=(0u32,0u32);for dj in -2i32..=2{for di in -2i32..=2{if di==0&&dj==0{continue}let ni=(ci as i32+di).rem_euclid(w as i32)as usize;let nj=(cj as i32+dj).rem_euclid(ht as i32)as usize;let m=nj*w+ni;if acc.data[m]>=stream&&dirf[m]!=DIR_NONE{t+=1;if dirf[m]==d{s+=1}}}}if t==0{0.0}else{s as f32/t as f32}};
+        // suspect mask: drainage, low grad, non-exact-flat, high coherence.
+        let mut suspect=vec![false;w*ht];
+        for j in 0..ht{for i in 0..w{let k=j*w+i;if h.data[k]<=0.5||acc.data[k]<stream{continue}
+            let(gx,gy)=h.gradient_at(i,j);let g=(gx*gx+gy*gy).sqrt();if g>=1e-4{continue}
+            let(mut hl,mut he)=(false,false);for d in 0..8{let m=nb(i,j,d);if f[m]<f[k]{hl=true}else if f[m]==f[k]{he=true}}
+            let exact=!hl&&he; if exact{continue}
+            if coh(k)>=0.7{suspect[k]=true}
+        }}
+        // largest suspect cluster (BFS), get centroid.
+        let mut seen=vec![false;w*ht]; let(mut best_n,mut bx,mut by)=(0usize,0usize,0usize);
+        for s0 in 0..w*ht{if !suspect[s0]||seen[s0]{continue}let mut q=std::collections::VecDeque::new();q.push_back(s0);seen[s0]=true;let(mut cnt,mut sx,mut sy)=(0u64,0u64,0u64);
+            while let Some(c)=q.pop_front(){cnt+=1;sx+=(c%w)as u64;sy+=(c/w)as u64;let(ci,cj)=(c%w,c/w);for d in 0..8{let m=nb(ci,cj,d);if suspect[m]&&!seen[m]{seen[m]=true;q.push_back(m)}}}
+            if cnt as usize>best_n{best_n=cnt as usize;bx=(sx/cnt)as usize;by=(sy/cnt)as usize}}
+        let total_suspect:usize=suspect.iter().filter(|&&x|x).count();
+        eprintln!("  seed {seed}: suspect cells {total_suspect} ({:.3}% land-ish), largest cluster {best_n} cells @ ({bx},{by})",100.0*total_suspect as f64/(w*ht)as f64);
+        if best_n==0 {eprintln!("    no high-coherence low-grad non-exact cluster → ladder NOT a coherent parallel artifact"); continue;}
+        // hard zoom 96px on the worst cluster, color drainage by D8 dir.
+        let sz=96usize; let x0=(bx as i64-48).max(0).min(w as i64-sz as i64)as usize; let y0=(by as i64-48).max(0).min(ht as i64-sz as i64)as usize;
+        let mut buf=image::ImageBuffer::new(sz as u32,sz as u32);
+        let(mut raised,mut adj_flat)=(0u64,0u64); let mut cnt=0u64;
+        for jj in 0..sz{for ii in 0..sz{let(i,j)=(x0+ii,y0+jj);let k=j*w+i;
+            let c= if h.data[k]<=0.5 {[40,70,120]}
+                else if acc.data[k]>=stream && dirf[k]!=DIR_NONE { if suspect[k]{cnt+=1; if f[k]-h.data[k]>1e-5{raised+=1} let mut af=false;for d in 0..8{let m=nb(i,j,d);let(mut hl2,mut he2)=(false,false);for e in 0..8{let mm=nb(m%w,m/w,e);if f[mm]<f[m]{hl2=true}else if f[mm]==f[m]{he2=true}}if !hl2&&he2{af=true}}if af{adj_flat+=1}} huecol(dirf[k]) }
+                else {let g=shade(h,i,j);[g,g,g]};
+            buf.put_pixel(ii as u32,(sz-1-jj)as u32,image::Rgb(c));
+        }}
+        buf.save(dir.join(format!("seed{seed:05}_ladder_dirhue.png"))).unwrap();
+        eprintln!("    zoom @({x0},{y0}) 96px: suspect-in-crop {cnt}, raised-by-fill {raised}, adjacent-to-resolved-flat {adj_flat}");
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -3697,3 +3697,173 @@ fn probe_sea_unification_acceptance() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155→complétude W7 DRAINAGE — measure what the EXISTING drainage stack
+/// (terrain::flow + lakes::detection, already built) produces on the CURRENT
+/// C1 HD product (unified scale, sea=0.5, post-erosion). Grounds the W7:
+/// rivers by Strahler order, lakes (area/depth/level in METRES via the Maillon-2
+/// contract), and the endorheic-vs-exorheic question (trace each lake outlet
+/// downstream → reaches sea?). NOT the implementation — a measurement probe.
+#[test]
+#[ignore]
+fn probe_drainage_etat_des_lieux() {
+    use ymir_core::terrain::flow::{compute_flow, extract_rivers, FlowConfig, RiverConfig, DIR_NONE, D8_DX, D8_DY};
+    use ymir_core::lakes::detection::{detect_lakes, LakeConfig};
+    use ymir_core::tectonics_c1::production_upscale::c1_altitude_norm_to_metres;
+    let dir = output_dir().join("drainage_etat");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let grid = 64usize;
+    let target = 512usize;
+    let cfg = FbmUpscaleConfig::c1_hd_production(target);
+    eprintln!("#155 W7 drainage état-des-lieux — existing stack on C1 HD product ({target}², sea=0.5)");
+    for &seed in &[42u64, 1988, 2026] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        let h = &up.heightmap;
+        let (w, ht) = (h.width, h.height);
+
+        // The unified scale puts sea at 0.5.
+        let flow = compute_flow(h, &FlowConfig { sea_level: 0.5 });
+        let rivers = extract_rivers(&flow, &RiverConfig::default(), w, ht);
+        let lakes = detect_lakes(h, &flow.filled, &flow.direction, &flow.basins, &LakeConfig::default());
+
+        // Strahler histogram.
+        let mut strahler = [0usize; 12];
+        for s in &rivers.segments { strahler[(s.strahler_order as usize).min(11)] += 1; }
+        let max_acc = flow.accumulation.data.iter().cloned().fold(0.0f32, f32::max);
+
+        // Endorheic vs exorheic: trace each lake outlet downstream; reaches sea?
+        let is_sea = |k: usize| h.data[k] <= 0.5;
+        let mut endorheic = 0; let mut exorheic = 0;
+        for lk in &lakes.lakes {
+            let (mut x, mut y) = (lk.outlet.0 as usize, lk.outlet.1 as usize);
+            let mut steps = 0; let mut reached_sea = false;
+            loop {
+                let k = y*w + x;
+                if is_sea(k) { reached_sea = true; break; }
+                let d = flow.direction[k];
+                if d == DIR_NONE || steps > w*ht { break; }
+                x = ((x as i32 + D8_DX[d as usize]).rem_euclid(w as i32)) as usize;
+                y = ((y as i32 + D8_DY[d as usize]).rem_euclid(ht as i32)) as usize;
+                steps += 1;
+            }
+            if reached_sea { exorheic += 1; } else { endorheic += 1; }
+        }
+        // Lake levels/depths in metres (Maillon-2 contract).
+        let (mut max_area, mut deepest_m, mut highest_lake_m) = (0usize, 0.0f32, f32::MIN);
+        for lk in &lakes.lakes {
+            max_area = max_area.max(lk.area);
+            deepest_m = deepest_m.max(c1_altitude_norm_to_metres(lk.surface_elevation, &ss) - c1_altitude_norm_to_metres(lk.surface_elevation - lk.max_depth, &ss));
+            highest_lake_m = highest_lake_m.max(c1_altitude_norm_to_metres(lk.surface_elevation, &ss));
+        }
+        let land = h.data.iter().filter(|&&v| v > 0.5).count();
+        eprintln!("  seed {seed}: land {:.1}% | basins {} max_acc {max_acc:.0} | rivers {} segs, Strahler {:?}",
+            100.0*land as f64/(w*ht) as f64, flow.num_basins, rivers.segments.len(), &strahler[1..7]);
+        eprintln!("    lakes {} (exorheic {exorheic} / endorheic {endorheic}) | max area {max_area} cells | deepest {deepest_m:.0} m | highest level {highest_lake_m:.0} m",
+            lakes.lakes.len());
+
+        // Render overlay (hypso + rivers blue + lakes).
+        let mut img = vec![0u8; w*ht*3];
+        for k in 0..w*ht {
+            let v = h.data[k].clamp(0.0,1.0);
+            let (r,g,b) = if v <= 0.5 { (30,60,(120.0+200.0*v) as u8) } else { let t=(v-0.5)*2.0; (((60.0+150.0*t) as u8),((120.0+80.0*t) as u8),60) };
+            img[k*3]=r; img[k*3+1]=g; img[k*3+2]=b;
+        }
+        let stream = RiverConfig::default().stream_threshold;
+        for k in 0..w*ht {
+            if lakes.lake_map[k] != 0 { img[k*3]=30; img[k*3+1]=90; img[k*3+2]=180; }
+            else if flow.accumulation.data[k] >= stream && h.data[k] > 0.5 { img[k*3]=40; img[k*3+1]=110; img[k*3+2]=230; }
+        }
+        // Origin-bottom (data row j → image row ht-1-j), matching the
+        // product-wide convention (save_heightmap01/binarymap/hillshade_crop +
+        // viz hydrology). The extraction reads the same GridF32 indexing as
+        // every consumer; only this render's orientation was the Y-flip.
+        let mut buf = image::ImageBuffer::new(w as u32, ht as u32);
+        for j in 0..ht { for i in 0..w {
+            let k = j*w + i;
+            buf.put_pixel(i as u32, (ht - 1 - j) as u32, image::Rgb([img[k*3],img[k*3+1],img[k*3+2]]));
+        }}
+        buf.save(dir.join(format!("seed{seed:05}_drainage.png"))).unwrap();
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
+/// #155 drainage maillon ACCEPTANCE — validate the PRODUCT (c1_drainage) on the
+/// real C1 terrain, not the algorithm (that has unit tests). Checks: navigability
+/// classes (km² thresholds), lake stats in metres, and RESOLUTION-INDEPENDENCE
+/// (512² vs 1024²: km²-anchored network density comparable, where cell-count
+/// thresholds would break). Renders the drainage overlay (origin-bottom) for the
+/// geometric-coherence re-judge (rivers in valleys / lakes in basins).
+#[test]
+#[ignore]
+fn probe_c1_drainage_acceptance() {
+    use ymir_core::tectonics_c1::drainage::{c1_drainage, C1DrainageConfig, Navigability, LakeType};
+    use ymir_core::tectonics_c1::production_upscale::c1_cell_area_km2;
+    let dir = output_dir().join("drainage_accept");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let dcfg = C1DrainageConfig::default();
+    let grid = 64usize;
+    eprintln!("#155 drainage acceptance — c1_drainage on C1 product, km² thresholds {:?}", dcfg.thresholds);
+    for &seed in &[42u64, 1988, 2026] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+        // Resolution-independence: 512² and 1024², compare km²-normalised metrics.
+        for &target in &[512usize, 1024] {
+            let cfg = FbmUpscaleConfig::c1_hd_production(target);
+            let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+            let dr = c1_drainage(&up.heightmap, &dcfg, &ss);
+            let (w, _h) = (dr.width, dr.height);
+            let land_km2 = up.heightmap.data.iter().filter(|&&v| v > 0.5).count() as f32 * c1_cell_area_km2(w);
+            let mut nav = [0usize; 4];
+            for n in &dr.segment_navigability { nav[match n { Navigability::NonNavigable=>0, Navigability::SmallBoat=>1, Navigability::Barge=>2, Navigability::Ship=>3 }] += 1; }
+            let max_drain = dr.segment_drainage_km2.iter().cloned().fold(0.0f32, f32::max);
+            let exo = dr.lakes.iter().filter(|l| l.lake_type==LakeType::Exorheic).count();
+            let endo = dr.lakes.iter().filter(|l| l.lake_type==LakeType::Endorheic).count();
+            let (deepest, highest, biggest) = dr.lakes.iter().fold((0.0f32,f32::MIN,0.0f32), |(d,h,a),l| (d.max(l.depth_m), h.max(l.level_m), a.max(l.area_km2)));
+            eprintln!("  seed {seed} @{target}²: land {land_km2:.0} km² | rivers {} (nonNav {} smallBoat {} barge {} ship {}) maxDrain {max_drain:.0} km²",
+                dr.rivers.segments.len(), nav[0], nav[1], nav[2], nav[3]);
+            eprintln!("    lakes {} (exo {exo}/endo {endo}) deepest {deepest:.0} m, highest level {highest:.0} m, biggest {biggest:.0} km²", dr.lakes.len());
+
+            if target == 1024 {
+                // render overlay (origin-bottom, the product convention). Base
+                // hypso + lakes + NAVIGABLE rivers by tier (the mappable network:
+                // small-boat→barge→ship), NOT every headwater (the full
+                // hydrography at stream_km2 is the dense texture, consumer-filtered).
+                let mut img = vec![0u8; w*dr.height*3];
+                for k in 0..w*dr.height {
+                    let v = up.heightmap.data[k].clamp(0.0,1.0);
+                    let (r,g,b) = if v <= 0.5 { (30,60,(120.0+200.0*v) as u8) } else { let t=(v-0.5)*2.0; (((60.0+150.0*t) as u8),((120.0+80.0*t) as u8),60) };
+                    img[k*3]=r; img[k*3+1]=g; img[k*3+2]=b;
+                }
+                for (si, seg) in dr.rivers.segments.iter().enumerate() {
+                    let col = match dr.segment_navigability[si] {
+                        Navigability::Ship => [20u8, 70, 200],
+                        Navigability::Barge => [40, 110, 230],
+                        Navigability::SmallBoat => [90, 160, 240],
+                        Navigability::NonNavigable => continue,
+                    };
+                    for &(px, py) in &seg.points { let k = py as usize * w + px as usize; img[k*3]=col[0]; img[k*3+1]=col[1]; img[k*3+2]=col[2]; }
+                }
+                for k in 0..w*dr.height {
+                    if dr.lake_map[k]!=0 { img[k*3]=30; img[k*3+1]=90; img[k*3+2]=180; }
+                }
+                let mut buf = image::ImageBuffer::new(w as u32, dr.height as u32);
+                for j in 0..dr.height { for i in 0..w { let k=j*w+i; buf.put_pixel(i as u32,(dr.height-1-j) as u32, image::Rgb([img[k*3],img[k*3+1],img[k*3+2]])); }}
+                buf.save(dir.join(format!("seed{seed:05}_drainage.png"))).unwrap();
+            }
+        }
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -4053,3 +4053,51 @@ fn probe_flat_routing_diagnostic() {
         }
     }
 }
+
+/// #155 flat-routing FIX acceptance — re-render the FULL accumulation network
+/// (unmasked, directly comparable to the pre-fix blocky image) at 2048² on the
+/// artifact seeds 1988/2026, + 1337 control (slope-dominant). After Garbrecht-
+/// Martz: the parallel-bars/fans on filled flats should be replaced by
+/// convergent drainage to the outlet; slopes unchanged.
+#[test]
+#[ignore]
+fn probe_flat_routing_fix_render() {
+    use ymir_core::tectonics_c1::drainage::{c1_drainage, C1DrainageConfig};
+    use ymir_core::tectonics_c1::production_upscale::c1_cell_area_km2;
+    let dir = output_dir().join("flat_fix");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let dcfg = C1DrainageConfig::default();
+    let grid = 64usize;
+    let shade = |h: &GridF32, i: usize, j: usize| -> f64 {
+        let z=60.0_f64; let (lx,ly,lz)={let(a,b,c)=(1.0_f64,1.0,2.0);let nn=(a*a+b*b+c*c).sqrt();(a/nn,b/nn,c/nn)};
+        let dzdx=(h.get(i as i32+1,j as i32)-h.get(i as i32-1,j as i32)) as f64*z;
+        let dzdy=(h.get(i as i32,j as i32+1)-h.get(i as i32,j as i32-1)) as f64*z;
+        let n=(dzdx*dzdx+dzdy*dzdy+1.0).sqrt(); ((-dzdx*lx-dzdy*ly+lz)/n).clamp(0.0,1.0)
+    };
+    for &(seed, target) in &[(1988u64,2048usize),(2026,2048),(1337,1024)] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        let cfg = FbmUpscaleConfig::c1_hd_production(target);
+        let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+        let h = &up.heightmap; let (w, ht) = (h.width, h.height);
+        let dr = c1_drainage(h, &dcfg, &ss);
+        let stream = (dcfg.thresholds.stream_km2 / c1_cell_area_km2(w)).max(1.0);
+        // FULL accumulation network over hillshade, UNMASKED (so bars would show).
+        let mut buf = image::ImageBuffer::new(w as u32, ht as u32);
+        for j in 0..ht { for i in 0..w {
+            let k=j*w+i;
+            let c = if h.data[k] <= 0.5 { [40,70,120] }
+                else if dr.flow.accumulation.data[k] >= stream { [40,110,230] }
+                else { let g=(shade(h,i,j)*255.0) as u8; [g,g,g] };
+            buf.put_pixel(i as u32,(ht-1-j) as u32, image::Rgb(c));
+        }}
+        buf.save(dir.join(format!("seed{seed:05}_{target}_accum.png"))).unwrap();
+        eprintln!("  seed {seed} @{target}²: {} rivers, {} lakes", dr.rivers.segments.len(), dr.lakes.len());
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -3959,3 +3959,97 @@ fn probe_drainage_overlays() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155 flat-routing DIAGNOSTIC — characterise the parallel-bar / 45° fan
+/// artifact on flat interiors at 2048². Confirms the root (D8 follows the
+/// pit_fill epsilon-tree, NOT real terrain) by a NON-INVASIVE eps=0
+/// counterfactual: steepest-descent on the ORIGINAL (unfilled) heightmap =
+/// eps=0; flat cells that get a direction ONLY from the eps-fill are the
+/// artifact. Splits the artifact: filled depressions (legit drainage to sill)
+/// vs native plateaus (cratonic, physically diffuse — channels here are FALSE).
+#[test]
+#[ignore]
+fn probe_flat_routing_diagnostic() {
+    use ymir_core::tectonics_c1::drainage::{c1_drainage, C1DrainageConfig};
+    use ymir_core::tectonics_c1::production_upscale::c1_cell_area_km2;
+    use ymir_core::terrain::flow::{D8_DX, D8_DY, DIR_NONE};
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let dcfg = C1DrainageConfig::default();
+    let grid = 64usize;
+    // steepest-descent direction on a given heightmap (eps=0 semantics): NONE if
+    // no strictly-lower neighbour.
+    let d8_eps0 = |h: &GridF32, i: usize, j: usize, w: usize, ht: usize| -> u8 {
+        let my = h.data[j*w+i];
+        let mut best = 0.0f32; let mut dir = DIR_NONE;
+        for d in 0..8 {
+            let ni = ((i as i32 + D8_DX[d]).rem_euclid(w as i32)) as usize;
+            let nj = ((j as i32 + D8_DY[d]).rem_euclid(ht as i32)) as usize;
+            let dist = if d % 2 == 0 { 1.0 } else { 1.414 };
+            let s = (my - h.data[nj*w+ni]) / dist;
+            if s > best { best = s; dir = d as u8; }
+        }
+        dir
+    };
+    let pct = |v: &[f32], q: f32| -> f32 { if v.is_empty() {return f32::NAN;} let mut s=v.to_vec(); s.sort_by(|a,b| a.partial_cmp(b).unwrap()); s[((q*(s.len()-1) as f32) as usize).min(s.len()-1)] };
+    eprintln!("#155 flat-routing diagnostic — eps=0 counterfactual + filled/native split");
+    for &seed in &[1988u64, 2026] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+        for &target in &[1024usize, 2048] {
+            let cfg = FbmUpscaleConfig::c1_hd_production(target);
+            let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+            let h = &up.heightmap; let (w, ht) = (h.width, h.height);
+            let dr = c1_drainage(h, &dcfg, &ss);
+            let cell_km2 = c1_cell_area_km2(w);
+            let stream_cells = (dcfg.thresholds.stream_km2 / cell_km2).max(1.0);
+
+            // land gradient distribution → flat threshold (15% of median land grad).
+            let mut grads = vec![0.0f32; w*ht];
+            let mut land_grads = Vec::new();
+            for j in 0..ht { for i in 0..w {
+                let (gx, gy) = h.gradient_at(i, j); let g = (gx*gx+gy*gy).sqrt();
+                grads[j*w+i] = g;
+                if h.data[j*w+i] > 0.5 { land_grads.push(g); }
+            }}
+            let med = pct(&land_grads, 0.5);
+            let flat_thr = 0.15 * med;
+
+            let (mut land, mut flat, mut filled_flat, mut native_flat) = (0usize,0usize,0usize,0usize);
+            let (mut eps_driven, mut eps_filled, mut eps_native) = (0usize,0usize,0usize);
+            let (mut native_above_stream, mut native_flat_total) = (0usize, 0usize);
+            for j in 0..ht { for i in 0..w {
+                let k = j*w+i;
+                if h.data[k] <= 0.5 { continue; }
+                land += 1;
+                if grads[k] >= flat_thr { continue; }
+                flat += 1;
+                let raised = dr.flow.filled.data[k] - h.data[k];
+                let is_filled = raised > 1e-5;
+                if is_filled { filled_flat += 1; } else { native_flat += 1; }
+                // eps-driven: compute_flow gave a direction, eps=0 gives NONE.
+                let dir_filled = dr.flow.direction[k];
+                let dir_orig = d8_eps0(h, i, j, w, ht);
+                if dir_filled != DIR_NONE && dir_orig == DIR_NONE {
+                    eps_driven += 1;
+                    if is_filled { eps_filled += 1; } else { eps_native += 1; }
+                }
+                // native plateau: does flow accumulation exceed the stream threshold
+                // (→ FALSE channels) or stay diffuse (correct)?
+                if !is_filled {
+                    native_flat_total += 1;
+                    if dr.flow.accumulation.data[k] >= stream_cells { native_above_stream += 1; }
+                }
+            }}
+            eprintln!("  seed {seed} @{target}²: land {land} | flat {flat} ({:.1}% land, thr={flat_thr:.2e}) = filled {filled_flat} + native {native_flat}",
+                100.0*flat as f64/land.max(1) as f64);
+            eprintln!("    eps-driven (dir from fill, NONE at eps=0): {eps_driven} ({:.1}% of flat) = filled {eps_filled} + native {eps_native}",
+                100.0*eps_driven as f64/flat.max(1) as f64);
+            eprintln!("    native plateau flats above stream-threshold (FALSE channels): {native_above_stream}/{native_flat_total} ({:.1}%)",
+                100.0*native_above_stream as f64/native_flat_total.max(1) as f64);
+        }
+    }
+}

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -4339,3 +4339,52 @@ fn probe_ladder_locator() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155 ladder reconcile — render the two candidate identities of the flagged
+/// "triangle" so it can be attributed: LAKES (cyan, outlined) vs GM-RESOLVED
+/// flats / their convergent fans (yellow tint) vs rivers (blue), over hillshade,
+/// 2048², origin-bottom. The triangle's colour identifies it.
+#[test]
+#[ignore]
+fn probe_ladder_reconcile() {
+    use ymir_core::terrain::flow::{DIR_NONE, D8_DX, D8_DY};
+    use ymir_core::tectonics_c1::drainage::{c1_drainage, C1DrainageConfig};
+    use ymir_core::tectonics_c1::production_upscale::c1_cell_area_km2;
+    let dir = output_dir().join("ladder_reconcile");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default(); let ss = SteinSteinParams::default();
+    let dcfg = C1DrainageConfig::default(); let grid=64usize;
+    let shade=|h:&GridF32,i:usize,j:usize|->u8{let z=50.0_f64;let(lx,ly,lz)={let(a,b,c)=(1.0_f64,1.0,2.0);let nn=(a*a+b*b+c*c).sqrt();(a/nn,b/nn,c/nn)};let dx=(h.get(i as i32+1,j as i32)-h.get(i as i32-1,j as i32))as f64*z;let dy=(h.get(i as i32,j as i32+1)-h.get(i as i32,j as i32-1))as f64*z;let n=(dx*dx+dy*dy+1.0).sqrt();(((-dx*lx-dy*ly+lz)/n).clamp(0.0,1.0)*200.0+40.0)as u8};
+    for &seed in &[1988u64, 2026] {
+        let mut state=init_c1_state_phase_2_r7(grid,seed,&Phase2InitParams::default());
+        let mut kin=PlateKinematics::preset_phase_1_1(state.num_plates);
+        let config=C1TimeLoopConfig{rigid_continental_crust:true,n_steps:300,dx:1.0/64.0,dy:1.0/64.0,iso_config:iso.clone(),drainage_max_distance:30};
+        run_with_closures(&mut state,&mut kin,&config,&C1Closures::default(),|_,_|{});
+        let up=upscale_from_c1(&state,&iso,&ss,&WorldSeed::new(seed),&FbmUpscaleConfig::c1_hd_production(2048));
+        let h=&up.heightmap;let(w,ht)=(h.width,h.height);let dr=c1_drainage(h,&dcfg,&ss);
+        let f=&dr.flow.filled.data; let acc=&dr.flow.accumulation;
+        let stream=(dcfg.thresholds.stream_km2/c1_cell_area_km2(w)).max(1.0);
+        let nb=|i:usize,j:usize,d:usize|{let ni=((i as i32+D8_DX[d]).rem_euclid(w as i32))as usize;let nj=((j as i32+D8_DY[d]).rem_euclid(ht as i32))as usize;nj*w+ni};
+        // exact-flat (GM-resolved) membership.
+        let mut exact=vec![false;w*ht];
+        for j in 0..ht{for i in 0..w{let k=j*w+i;if h.data[k]<=0.5{continue}let(mut hl,mut he)=(false,false);for d in 0..8{let m=nb(i,j,d);if f[m]<f[k]{hl=true}else if f[m]==f[k]{he=true}}exact[k]=!hl&&he;}}
+        let mut buf=image::ImageBuffer::new(w as u32,ht as u32);
+        for j in 0..ht{for i in 0..w{let k=j*w+i;
+            let lake=dr.lake_map[k]!=0;
+            // lake outline: lake cell adjacent to non-lake.
+            let lake_edge= lake && (0..8).any(|d|{let m=nb(i,j,d);dr.lake_map[m]==0});
+            let c= if h.data[k]<=0.5 {[25,45,90]}
+                else if lake_edge {[180,240,255]}
+                else if lake {[60,200,220]}
+                else if acc.data[k]>=stream {[40,110,235]}      // rivers
+                else if exact[k] {let g=shade(h,i,j);[ (g as u16*9/10+60) as u8, (g as u16*9/10+50) as u8, (g/3) as u8 ]} // resolved-flat = yellow tint
+                else {let g=shade(h,i,j);[g,g,g]};
+            buf.put_pixel(i as u32,(ht-1-j)as u32,image::Rgb(c));
+        }}
+        buf.save(dir.join(format!("seed{seed:05}_reconcile.png"))).unwrap();
+        let nlake:usize=dr.lake_map.iter().filter(|&&x|x!=0).count();
+        let nexact:usize=exact.iter().filter(|&&x|x).count();
+        eprintln!("  seed {seed}: lake cells {nlake} ({:.2}%), resolved-flat cells {nexact} ({:.2}%) [yellow], rivers blue", 100.0*nlake as f64/(w*ht)as f64, 100.0*nexact as f64/(w*ht)as f64);
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -4429,3 +4429,101 @@ fn probe_yellow_fan_mechanism() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155 non-lake flooded zones DIAGNOSTIC — characterise the residual yellow
+/// (flooded to sill, filled>eroded, but NOT in any named lake → depressions
+/// whose max depth never reached the 10 m lake-naming threshold). Measure size
+/// (km², natural cutoff vs continuum?), depth (m, real water vs films?), shape
+/// (compact basin vs filiform artifact), terrain fraction; + marked maps.
+#[test]
+#[ignore]
+fn probe_nonlake_flooded_zones() {
+    use ymir_core::tectonics_c1::drainage::{c1_drainage, C1DrainageConfig};
+    use ymir_core::tectonics_c1::production_upscale::{c1_cell_area_km2, c1_altitude_norm_to_metres};
+    let dir = output_dir().join("nonlake_flooded"); std::fs::create_dir_all(&dir).unwrap();
+    let iso=IsostasyConfig::c1_default(); let ss=SteinSteinParams::default(); let dcfg=C1DrainageConfig::default(); let grid=64usize;
+    let m_per_norm = c1_altitude_norm_to_metres(1.0,&ss)-c1_altitude_norm_to_metres(0.0,&ss);
+    for &seed in &[1988u64,2026,42,1337]{
+        let mut state=init_c1_state_phase_2_r7(grid,seed,&Phase2InitParams::default());
+        let mut kin=PlateKinematics::preset_phase_1_1(state.num_plates);
+        let config=C1TimeLoopConfig{rigid_continental_crust:true,n_steps:300,dx:1.0/64.0,dy:1.0/64.0,iso_config:iso.clone(),drainage_max_distance:30};
+        run_with_closures(&mut state,&mut kin,&config,&C1Closures::default(),|_,_|{});
+        let up=upscale_from_c1(&state,&iso,&ss,&WorldSeed::new(seed),&FbmUpscaleConfig::c1_hd_production(2048));
+        let h=&up.heightmap;let(w,ht)=(h.width,h.height);let dr=c1_drainage(h,&dcfg,&ss);
+        let cell_km2=c1_cell_area_km2(w);
+        let depth=|k:usize|->f32{(dr.flow.filled.data[k]-h.data[k]).max(0.0)};
+        // residual flooded non-lake cells.
+        let mut res=vec![false;w*ht]; let mut nres=0u64;
+        for k in 0..w*ht{ if h.data[k]>0.5 && dr.lake_map[k]==0 && depth(k)>1e-6 {res[k]=true;nres+=1;} }
+        // connected components.
+        let mut seen=vec![false;w*ht]; let mut comps:Vec<(u64,f32,f32,usize,usize,usize,usize)>=Vec::new(); // area,maxd_norm,sumd,mni,mxi,mnj,mxj
+        for s0 in 0..w*ht{ if !res[s0]||seen[s0]{continue}
+            let mut q=std::collections::VecDeque::new();q.push_back(s0);seen[s0]=true;
+            let(mut a,mut md,mut sd,mut mni,mut mxi,mut mnj,mut mxj)=(0u64,0.0f32,0.0f32,w,0usize,ht,0usize);
+            while let Some(c)=q.pop_front(){a+=1;let d=depth(c);md=md.max(d);sd+=d;let(ci,cj)=(c%w,c/w);mni=mni.min(ci);mxi=mxi.max(ci);mnj=mnj.min(cj);mxj=mxj.max(cj);
+                for dy in -1i32..=1{for dx in -1i32..=1{if dx==0&&dy==0{continue}let ni=((ci as i32+dx).rem_euclid(w as i32))as usize;let nj=((cj as i32+dy).rem_euclid(ht as i32))as usize;let m=nj*w+ni;if res[m]&&!seen[m]{seen[m]=true;q.push_back(m)}}}}
+            comps.push((a,md,sd,mni,mxi,mnj,mxj));
+        }
+        comps.sort_by(|x,y|y.0.cmp(&x.0));
+        // size histogram (km²) + depth-of-max histogram (m) + shape.
+        let szbins=[0.0,1.0,10.0,100.0,1000.0,f32::INFINITY]; let mut szh=[0u64;5]; let mut szarea=[0.0f64;5];
+        let dpbins=[0.0,1.0,3.0,6.0,10.0,f32::INFINITY]; let mut dph=[0u64;5];
+        for &(a,md,_,mni,mxi,mnj,mxj) in &comps{
+            let km2=a as f32*cell_km2; let mdm=md*m_per_norm;
+            for t in 0..5{if km2>=szbins[t]&&km2<szbins[t+1]{szh[t]+=1;szarea[t]+=a as f64*cell_km2 as f64;break}}
+            for t in 0..5{if mdm>=dpbins[t]&&mdm<dpbins[t+1]{dph[t]+=1;break}}
+            let _=(mni,mxi,mnj,mxj);
+        }
+        let land:u64=(0..w*ht).filter(|&k|h.data[k]>0.5).count() as u64;
+        let lake_cells:u64=dr.lake_map.iter().filter(|&&x|x!=0).count() as u64;
+        eprintln!("  seed {seed} @2048²: residual non-lake flooded {nres} cells ({:.2}% land, {:.0} km²) in {} components | named-lake cells {} ({:.2}% land)",
+            100.0*nres as f64/land.max(1)as f64, nres as f64*cell_km2 as f64, comps.len(), lake_cells, 100.0*lake_cells as f64/land.max(1)as f64);
+        eprintln!("    size km² [<1 |1-10|10-100|100-1k|>1k]: count {:?} area {:?}", szh, szarea.iter().map(|x|*x as u64).collect::<Vec<_>>());
+        eprintln!("    max-depth m [<1|1-3|3-6|6-10|>=10]: {:?}", dph);
+        // top 5 components: area km², max depth m, fill ratio (compact vs filiform).
+        for (r,&(a,md,sd,mni,mxi,mnj,mxj)) in comps.iter().take(5).enumerate(){
+            let bbox=((mxi-mni+1)*(mxj-mnj+1)) as f32; let fill=a as f32/bbox.max(1.0);
+            eprintln!("    #{r}: {:.1} km², max {:.1} m, mean {:.1} m, fill-ratio {:.2} ({}x{})", a as f32*cell_km2, md*m_per_norm, (sd/a as f32)*m_per_norm, fill, mxi-mni+1, mxj-mnj+1);
+        }
+        // marked map: hypso + residual in magenta.
+        let mut buf=image::ImageBuffer::new(w as u32,ht as u32);
+        for j in 0..ht{for i in 0..w{let k=j*w+i; let c= if res[k]{[230,40,200]} else if dr.lake_map[k]!=0{[40,90,190]} else {hypsometric(h.data[k].clamp(0.0,1.0),0.5)}; buf.put_pixel(i as u32,(ht-1-j)as u32,image::Rgb(c));}}
+        buf.save(dir.join(format!("seed{seed:05}_nonlake_marked.png"))).unwrap();
+    }
+    eprintln!("  out = {}", dir.display());
+}
+
+/// #155 clean PRODUCT render @2048² (no diagnostic coloring) — to check whether
+/// the residual non-lake flooded speckle is even VISIBLE in the product (where
+/// it renders as terrain, not lake/river), vs only in the diagnostic marking.
+/// Side-by-side with the marked map (probe_nonlake_flooded_zones) settles it.
+#[test]
+#[ignore]
+fn probe_clean_product_2048() {
+    use ymir_core::tectonics_c1::drainage::{c1_drainage, C1DrainageConfig};
+    use ymir_core::tectonics_c1::production_upscale::c1_cell_area_km2;
+    let dir = output_dir().join("clean_product"); std::fs::create_dir_all(&dir).unwrap();
+    let iso=IsostasyConfig::c1_default(); let ss=SteinSteinParams::default(); let dcfg=C1DrainageConfig::default(); let grid=64usize;
+    let shade=|h:&GridF32,i:usize,j:usize|->u8{let z=55.0_f64;let(lx,ly,lz)={let(a,b,c)=(1.0_f64,1.0,2.0);let nn=(a*a+b*b+c*c).sqrt();(a/nn,b/nn,c/nn)};let dx=(h.get(i as i32+1,j as i32)-h.get(i as i32-1,j as i32))as f64*z;let dy=(h.get(i as i32,j as i32+1)-h.get(i as i32,j as i32-1))as f64*z;let n=(dx*dx+dy*dy+1.0).sqrt();(((-dx*lx-dy*ly+lz)/n).clamp(0.0,1.0)*255.0)as u8};
+    for &seed in &[1988u64,2026]{
+        let mut state=init_c1_state_phase_2_r7(grid,seed,&Phase2InitParams::default());
+        let mut kin=PlateKinematics::preset_phase_1_1(state.num_plates);
+        let config=C1TimeLoopConfig{rigid_continental_crust:true,n_steps:300,dx:1.0/64.0,dy:1.0/64.0,iso_config:iso.clone(),drainage_max_distance:30};
+        run_with_closures(&mut state,&mut kin,&config,&C1Closures::default(),|_,_|{});
+        let up=upscale_from_c1(&state,&iso,&ss,&WorldSeed::new(seed),&FbmUpscaleConfig::c1_hd_production(2048));
+        let h=&up.heightmap;let(w,ht)=(h.width,h.height);let dr=c1_drainage(h,&dcfg,&ss);
+        let stream=(dcfg.thresholds.stream_km2/c1_cell_area_km2(w)).max(1.0);
+        // PRODUCT convention: ocean, lakes, rivers (acc>=stream masked under lakes), else hillshade.
+        let mut buf=image::ImageBuffer::new(w as u32,ht as u32);
+        for j in 0..ht{for i in 0..w{let k=j*w+i;
+            let c= if h.data[k]<=0.5 {[30,60,(120.0+200.0*h.data[k]) as u8]}
+                else if dr.lake_map[k]!=0 {[40,90,190]}
+                else if dr.flow.accumulation.data[k]>=stream {[40,110,230]}
+                else {let g=shade(h,i,j);[g,g,g]};
+            buf.put_pixel(i as u32,(ht-1-j)as u32,image::Rgb(c));
+        }}
+        buf.save(dir.join(format!("seed{seed:05}_clean_product.png"))).unwrap();
+        eprintln!("  seed {seed}: clean product written");
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -3867,3 +3867,95 @@ fn probe_c1_drainage_acceptance() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155 drainage VISUAL validation — overlays of the (numbers-validated)
+/// c1_drainage product on the relief, origin-bottom (the Y-flip lesson). Per
+/// seed: (1) rivers on HILLSHADE (navigability-tiered: do they sit in valleys?
+/// do navigable trunks drain interior→coast?), (2) lakes on HYPSO (are they in
+/// real basins, not perched?). Same default c1_drainage config — no re-tuning,
+/// this RENDERS the validated product for the eye. 1024² (+ 2048² spot-check).
+#[test]
+#[ignore]
+fn probe_drainage_overlays() {
+    use ymir_core::tectonics_c1::drainage::{c1_drainage, C1DrainageConfig, Navigability};
+    let dir = output_dir().join("drainage_overlays");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let dcfg = C1DrainageConfig::default();
+    let grid = 64usize;
+
+    // hillshade grayscale for one cell (same lighting as save_hillshade_crop).
+    let shade_at = |h: &GridF32, i: usize, j: usize| -> f64 {
+        let z = 60.0_f64;
+        let (lx, ly, lz) = { let (a,b,c)=(1.0_f64,1.0,2.0); let n=(a*a+b*b+c*c).sqrt(); (a/n,b/n,c/n) };
+        let (gx, gy) = (i as i32, j as i32);
+        let dzdx = (h.get(gx+1, gy) - h.get(gx-1, gy)) as f64 * z;
+        let dzdy = (h.get(gx, gy+1) - h.get(gx, gy-1)) as f64 * z;
+        let nn = (dzdx*dzdx + dzdy*dzdy + 1.0).sqrt();
+        ((-dzdx*lx - dzdy*ly + lz)/nn).clamp(0.0, 1.0)
+    };
+
+    for &seed in &[2026u64, 1988, 42, 1337] {
+        let mut state = init_c1_state_phase_2_r7(grid, seed, &Phase2InitParams::default());
+        let mut kin = PlateKinematics::preset_phase_1_1(state.num_plates);
+        let closures = C1Closures::default();
+        let config = C1TimeLoopConfig { rigid_continental_crust: true, n_steps: 300, dx: 1.0/64.0, dy: 1.0/64.0, iso_config: iso.clone(), drainage_max_distance: 30 };
+        run_with_closures(&mut state, &mut kin, &config, &closures, |_, _| {});
+
+        let targets: &[usize] = &[1024];
+        for &target in targets {
+            let cfg = FbmUpscaleConfig::c1_hd_production(target);
+            let up = upscale_from_c1(&state, &iso, &ss, &WorldSeed::new(seed), &cfg);
+            let h = &up.heightmap;
+            let (w, ht) = (h.width, h.height);
+            let dr = c1_drainage(h, &dcfg, &ss);
+
+            // ---- (1) rivers on hillshade ----
+            let mut riv = vec![0u8; w*ht*3];
+            for j in 0..ht { for i in 0..w {
+                let k = j*w+i;
+                let g = if h.data[k] <= 0.5 { 70u8 } else { (shade_at(h, i, j)*255.0) as u8 };
+                let c = if h.data[k] <= 0.5 { [40,70,120] } else { [g,g,g] };
+                riv[k*3]=c[0]; riv[k*3+1]=c[1]; riv[k*3+2]=c[2];
+            }}
+            // Lakes drawn first (the filled flat basins) — rivers are then MASKED
+            // under lakes (the viz convention): a flat filled basin is a lake, not
+            // a blocky fill-front "river". This separates real valley rivers from
+            // the D8-on-flats artifact.
+            let put = |img: &mut [u8], k: usize, c: [u8;3]| { img[k*3]=c[0]; img[k*3+1]=c[1]; img[k*3+2]=c[2]; };
+            for k in 0..w*ht { if dr.lake_map[k]!=0 { put(&mut riv, k, [35,80,160]); } }
+            // navigable tiers + faint non-navigable streams, NOT over lake cells.
+            for (si, seg) in dr.rivers.segments.iter().enumerate() {
+                let (col, thick) = match dr.segment_navigability[si] {
+                    Navigability::Ship => ([10u8,50,170], 2i32),
+                    Navigability::Barge => ([30,90,210], 1),
+                    Navigability::SmallBoat => ([80,150,235], 0),
+                    Navigability::NonNavigable => ([120,170,210], 0), // faint, shows valley-following
+                };
+                for &(px, py) in &seg.points {
+                    for dj in -thick..=thick { for di in -thick..=thick {
+                        let ni=(px as i32+di).rem_euclid(w as i32) as usize; let nj=(py as i32+dj).rem_euclid(ht as i32) as usize;
+                        let k = nj*w+ni;
+                        if dr.lake_map[k]==0 { put(&mut riv, k, col); }
+                    }}
+                }
+            }
+            let mut buf = image::ImageBuffer::new(w as u32, ht as u32);
+            for j in 0..ht { for i in 0..w { let k=j*w+i; buf.put_pixel(i as u32,(ht-1-j) as u32, image::Rgb([riv[k*3],riv[k*3+1],riv[k*3+2]])); }}
+            buf.save(dir.join(format!("seed{seed:05}_{target}_rivers_hillshade.png"))).unwrap();
+
+            // ---- (2) lakes on hypso ----
+            let mut buf2 = image::ImageBuffer::new(w as u32, ht as u32);
+            for j in 0..ht { for i in 0..w {
+                let k=j*w+i;
+                let c = if dr.lake_map[k]!=0 { [40,90,190] } else { hypsometric(h.data[k].clamp(0.0,1.0), 0.5) };
+                buf2.put_pixel(i as u32,(ht-1-j) as u32, image::Rgb(c));
+            }}
+            buf2.save(dir.join(format!("seed{seed:05}_{target}_lakes_hypso.png"))).unwrap();
+
+            eprintln!("  seed {seed} @{target}²: {} rivers, {} lakes → overlays written", dr.rivers.segments.len(), dr.lakes.len());
+        }
+    }
+    eprintln!("  out = {}", dir.display());
+}

--- a/docs/reports/c1_continental_buoyancy/stage_drainage_flat_routing.md
+++ b/docs/reports/c1_continental_buoyancy/stage_drainage_flat_routing.md
@@ -1,0 +1,67 @@
+# #155 drainage — flat-routing artifact diagnostic
+
+The drainage visual validation confirmed geometrically-true rivers on slopes (all
+seeds) but revealed an artifact on FLAT interiors at 2048² (invisible at 1024²,
+grows with resolution): combs of parallel bars + 45° fans/diamonds in the flat
+interiors (cratonic plateaus, basin floors) of 1988 / 2026.
+
+Probe: `c1_closure_morphology::probe_flat_routing_diagnostic` (`#[ignore]`).
+
+## Root — confirmed by counterfactual (not presumed)
+
+`terrain::flow::pit_fill` raises a filled flat by `filled[parent] + eps` (eps=1e-7),
+so a flat receives a micro-gradient following the **flood tree** (the BFS order from
+the outlet), NOT real geometry. `compute_d8` then routes steepest-descent along that
+eps-gradient → parallel bars (flood-tree fronts) + 45° fans (D8 diagonals of the tree).
+
+**eps=0 counterfactual (non-invasive):** steepest-descent on the ORIGINAL (unfilled)
+heightmap = eps=0 semantics. Flat cells that get a direction from `compute_flow` but
+`DIR_NONE` at eps=0 are purely eps-fill-routed = the artifact. Measured:
+
+| seed @res | flat (% land) | eps-driven (% flat) | filled / native (eps-driven) |
+|-----------|---------------|---------------------|------------------------------|
+| 1988@1024 | 10.9k (≈9%)   | 1291 (10.9%)        | 1269 / 22                    |
+| 1988@2048 | 48156 (5.2%)  | 5256 (10.9%)        | 5056 / 200                   |
+| 2026@1024 | 10732 (3.8%)  | 1042 (9.7%)         | 1037 / 5                     |
+| 2026@2048 | 43621 (3.9%)  | 4674 (10.7%)        | 4547 / 127                   |
+
+→ **~11% of flat cells are eps-driven** (direction vanishes at eps=0). Root confirmed.
+
+## Family split — the artifact is ~96% on FILLED depressions
+
+Flat cells are ~half filled (pit-filled) / half native (plateau). But the eps-driven
+ARTIFACT is **~96% on FILLED depressions** (the pit-filled basins around lakes), only
+~4% on native cratonic plateaus. The bars/fans are a **filled-depression phenomenon**.
+
+**Native plateaus** drain via real FBM micro-relief (only ~4% eps-driven); ~13–18% of
+native-flat cells exceed the stream km² threshold (minor FBM-driven streams, NOT the
+eps artifact). They do NOT need false channels invented — they already drain, and the
+threshold keeps most diffuse. **A flat plateau has DIFFUSE drainage by nature** (that's
+why it's flat); the fix must not carve fake channels there.
+
+**Resolution growth:** flat fraction ~4–5% of land at both 1024 and 2048 (stable %);
+eps-driven ~11% of flat at both. The artifact VISIBILITY grows because absolute pixel
+counts scale with grid² — enough pixels at 2048 to see the bar pattern.
+
+## Fix scope (Garbrecht-Martz / Barnes flat resolution — for the next maillon)
+
+Replace the `pit_fill` epsilon increment with a proper, deterministic, knob-free flat
+resolution (Garbrecht-Martz 1997, or the Barnes-Lehman-Mulla 2014 priority-flood flat
+routing): impose a flat gradient combining **distance-away-from-higher** (the inflow
+cells spilling into the flat) + **distance-toward-lower** (the outlet the flat drains
+to) → convergent natural drainage to the sill, deterministic, replacing the eps tree.
+
+- **Filled depressions (~96% of artifact):** the main beneficiary — convergent
+  drainage to the outlet sill instead of BFS bars.
+- **Native plateaus (~4%):** no special handling — already diffuse via FBM; the km²
+  threshold gates channels, so GM routing won't carve fake rivers (it makes the routing
+  coherent, the threshold decides what's a channel).
+
+**Render-side mitigation already in hand** (NOT the deep fix): the filled depressions
+are largely LAKES, so masking rivers under lake cells (the viz convention, applied in
+`probe_drainage_overlays`) hides most of the artifact visually. But the underlying D8
+directions / accumulation on filled flats are still BFS-tree-wrong — flat resolution is
+the correctness fix (matters for accumulation, and for shallow filled flats not deep
+enough to register as lakes).
+
+Diagnostic only — the fix follows this verdict.

--- a/docs/reports/c1_continental_buoyancy/stage_drainage_flat_routing.md
+++ b/docs/reports/c1_continental_buoyancy/stage_drainage_flat_routing.md
@@ -92,3 +92,31 @@ native FBM-textured plateaus are never exactly flat → untouched (no invented c
    product's lake-masking) — not the systematic artifact.
 
 This CLOSES the drainage maillon.
+
+---
+
+## Quasi-flat residual — measured MARGINAL, documented (probe_quasi_flat_residual)
+
+The visual flagged a faint ladder/parallel residual on QUASI-flats (low gradient but
+NOT exactly at the sill → not exact-equal → `resolve_flats` skips them by design). The
+local gradient (the instrument the hillshade lacked) quantifies extent + nature:
+
+**Extent (grad <1e-4 norm/cell AND non-exact-flat):** 1988 **0.281 % of land** (3.0 % of
+drainage); 2026 **0.141 % of land** (1.4 %). Marginal.
+
+**Nature — no systematic defect:** directional coherence (fraction of drainage
+neighbours sharing D8 direction, 5×5) is **~0.50, flat across ALL gradient bins**
+(0.40–0.58), including the quasi-flat bins. A parallel/ladder artifact would spike the
+low-gradient bins toward the planar baseline (synthetic 0.6 m/km slope → **0.92**); they
+don't → drainage is dendritic at every gradient. 88 % of drainage is at franc gradient
+(≥2.3 m/km). The synthetic counterfactual also showed planar-slope parallel flow
+doesn't accumulate above the stream threshold (so it barely renders as channels).
+
+**Type:** ~50 % of the residual is fringe-of-depression (sill edges just above the
+exact-equal flat), ~50 % very-gentle plains (natural D8-planar parallelism).
+
+**Verdict: DOCUMENT, do not fix.** 0.14–0.28 % of land, no gradient-localised defect,
+half of it natural parallelism. Extending the criterion (near-sill fringes / a gradient
+band) would risk over-correcting correct gentle slopes for a ~0.1 % gain — the
+anti-over-correction discipline: the number doesn't justify it. A future flat-routing
+refinement (fringe inclusion) is logged but NOT blocking. Drainage maillon stays closed.

--- a/docs/reports/c1_continental_buoyancy/stage_drainage_flat_routing.md
+++ b/docs/reports/c1_continental_buoyancy/stage_drainage_flat_routing.md
@@ -65,3 +65,30 @@ the correctness fix (matters for accumulation, and for shallow filled flats not 
 enough to register as lakes).
 
 Diagnostic only — the fix follows this verdict.
+
+---
+
+## FIX LANDED — Garbrecht-Martz flat resolution (FEAT 0278119, TEST 7d54afc)
+
+`pit_fill` now fills to the EXACT sill (no `+eps`); `resolve_flats()` imposes the
+convergent gradient: `flat_grad = tl·(fhmax+1) + (fhmax − fh)` (toward-lower BFS `tl`
+dominant → guaranteed descent, no interior minimum; away-from-higher `fh` breaks the
+bar-forming ties). `compute_d8` pass 1 = steepest descent on `filled` (real slopes
+unchanged), pass 2 = flat cells route down `flat_grad` to the outlet.
+
+**Self-targeting:** only EXACT-equal flats (pit-filled depressions) are resolved;
+native FBM-textured plateaus are never exactly flat → untouched (no invented channels).
+`filled` keeps the exact sill → lake levels unchanged.
+
+**Acceptance (probe_flat_routing_fix_render, 2048²):**
+1. **Artifact dissolved** — 1988/2026 interiors: parallel-bars/fans → dendritic networks.
+2. **Native plateaus intact** — diffuse FBM drainage, no false straight channels.
+3. **Slopes unchanged** — 1337 control + margins of 1988/2026 (steepest-descent path
+   untouched; eps removal doesn't affect cells with a real lower neighbour).
+4. **All resolutions / deterministic** — BFS, no RNG; the resolution-dependent artifact
+   is gone at 2048² (the worst case); lib 450/0, all C1 green, only pre-existing v2 red.
+5. **Lakes unchanged** — `filled` = exact sill; the fix changes routing, not filling.
+6. Residual: convergent fill only in the LARGEST basins (= lakes, hidden by the
+   product's lake-masking) — not the systematic artifact.
+
+This CLOSES the drainage maillon.

--- a/docs/reports/c1_continental_buoyancy/stage_drainage_flat_routing.md
+++ b/docs/reports/c1_continental_buoyancy/stage_drainage_flat_routing.md
@@ -93,6 +93,30 @@ native FBM-textured plateaus are never exactly flat → untouched (no invented c
 
 This CLOSES the drainage maillon.
 
+### Lake-margin fix + the "non-lake yellow" verdict (FEAT 0b07360, probes)
+
+After the GM fix, diagnostic renders that COLOURED resolved-flat cells showed yellow
+bands. Two populations, both chased to ground:
+
+1. **Lake-adjacent sill shelves** → real classification gap (flooded to the sill but
+   below the 10 m lake-naming threshold). FIX `detect_lakes` (0b07360): a cell is WATER
+   if `filled>eroded`; grow each named lake over its connected flooded cells to the true
+   shoreline. Levels unchanged, extent +12-15%. The shelf bands → water.
+
+2. **Non-lake-adjacent flooded zones** (`probe_nonlake_flooded_zones`): measured ~14 000
+   tiny components (<1 km²) + ~20 larger shallow basins (10-274 km², mean 2-5 m) per
+   seed, ~3-4 % of land, rough size cutoff ~10 km². **VERDICT: NOT a product defect.**
+   These render "yellow" ONLY under the diagnostic colouring (exact-flat marked to LOCATE
+   them); in the clean product (`probe_clean_product_2048`: ocean/lakes/rivers/hillshade)
+   they are neither lake nor river → terrain, and being tiny+shallow they are INVISIBLE.
+   Both 2048² clean renders are dendritic rivers + lakes + relief, no artifact. The tiny
+   ones are noise pits (FBM/erosion minima, product-invisible); the ~20 larger shallow
+   basins are wetland-territory (lake-vs-marsh needs climate → defer, like endorheic).
+   Do NOT fix — coding a treatment would be an over-correction for a defect absent from
+   the product. (The "yellow triangle" escalation dissolved under measurement: ladder →
+   3-cell fragments → sill-shelf classification gap (fixed) → diagnostic-colouring
+   artifact. The clean product render is the ground truth.)
+
 ---
 
 ## Quasi-flat residual — measured MARGINAL, documented (probe_quasi_flat_residual)

--- a/docs/reports/c1_continental_buoyancy/stage_vertical_scale_contract.md
+++ b/docs/reports/c1_continental_buoyancy/stage_vertical_scale_contract.md
@@ -177,6 +177,38 @@ and the gap it reveals is the diagnostic of the relief not yet produced.
 
 ---
 
+## Maillon 3 — the HORIZONTAL scale (coordinate contract's other half)
+
+Surfaced while scoping drainage: km² river thresholds need a **km/cell**, and the
+C1 product had **no pinned horizontal scale** — a ~5× ambiguity, the exact pendant
+of the vertical gap:
+- Legacy `GenerationConfig`: `continent_size_km=300`, `meters_per_pixel=40`.
+- C1 TDD §11: domain `1×1` = "~1000-5000 km regional", dx ≈ "~2 km at 512²".
+
+These disagree, and the C1 figure is itself a 5× range → km² thresholds would rest
+on a disguised extent knob. Pinned as its own mini-maillon (the coordinate contract
+is a shared foundation — biomes/climate/villages, not just rivers — like the
+vertical, done as its own chantier, not slipped into the first consumer).
+
+**The pin (anchored, revisable):** `C1_DOMAIN_KM = 1024` — the TDD §11 lower anchor
+`2.0 km/cell × 512`, making its implicit "~2 km at 512²" explicit. dx = 16 km @64²,
+0.5 km @2048². Consistent with §2.2's dense playable-region gameplay (not a stretched
+whole continent). A "whole continent" product intent → set ~3000 km; **one constant,
+every consumer follows** (nothing else encodes the horizontal scale).
+
+Exposed: `c1_km_per_cell(grid)` = `C1_DOMAIN_KM/grid` (resolution-independent — domain
+km fixed); `c1_cell_area_km2(grid)` — the unit for resolution-independent
+drainage-area thresholds (`accumulation × cell_area_km2` = upstream km², invariant for
+a fixed physical catchment). Pure additive functions → byte-identical (no existing path
+changed). Unit test asserts the §11 anchor (2.0 km/cell @512²) + resolution-independence.
+
+**The coordinate contract is now complete**: vertical (`c1_altitude_norm_to_metres`,
+sea=0.5→0 m, ±5650 m) + horizontal (`C1_DOMAIN_KM=1024`, `c1_km_per_cell`). metadata.json
+§9.3 (meters-per-pixel beside elevation) = these two together. Drainage (the first
+consumer) can now anchor thresholds in km².
+
+---
+
 ## Discipline notes
 - Volet 1 = reading; the scale is what the model encodes (two-scale, phantom peak) — not
   tuned toward a target height. Pinning the scale does not create relief.


### PR DESCRIPTION
Completes the coordinate contract (horizontal pin — vertical landed in #162) and delivers 
the first reliable drainage map (rivers + lakes) on the eroded C1 product, with a unified 
water classification.

**Horizontal pin** (`4e36f5c`): `C1_DOMAIN_KM = 1024` (TDD §11 anchor), exposing 
`c1_km_per_cell` + `c1_cell_area_km2`. Coordinate contract now complete: vertical 
(norm→m, #162) + horizontal (km/cell).

**Drainage** (`7adc2ad`,`285fc76`,`fa06c99`): `c1_drainage()` composes `terrain::flow` 
(priority-flood + D8 + accumulation + Strahler) and `lakes::detection` on the 
c1_hd_production output — sea=0.5, km² navigability thresholds (resolution-independent 
via c1_cell_area_km2), lake stats in metres (via c1_altitude_norm_to_metres), honest 
LakeType. Both coordinate pins pay off here (first consumer).

**Flat-routing** (`2ec0348` diag, `0278119`+`7d54afc`+`945ce6e` GM fix, `1f841a6` 
validation, `3423a3e` residual measurement): visual validation found a resolution-
dependent artifact (parallel bars + 45° fans on flats at 2048²) the numeric acceptance 
missed. Diagnosed by counterfactual (eps=0): pit_fill `+eps` followed the flood-tree 
order, not geometry. Fixed with Garbrecht-Martz flat resolution; self-targeting by exact 
equality keeps native plateaus diffuse by construction.

**Unified water model** (`0b07360` lake margins, `9001eef` vast shallow basins): visual 
validation found shallow flooded cells misclassified as terrain (rendered as rectilinear 
yellow drainage). Resolved by unifying the water model in `detect_lakes`: a cell is water 
iff flooded (`filled > eroded`); `min_depth` now only sets deep-vs-shallow type 
(`Lake.shallow`), not the water gate. Water-vs-land is decided geometrically now; 
lake-vs-marsh defers to climate via `Lake.shallow` — but indeterminate sub-type never 
justifies the wrong label (terrain).

## Acceptance (validated on the data + a render that distinguishes water/land)
- Drainage geometrically true (visually validated, multiple seeds): rivers in valleys, 
  lakes in basins, dendritic, interior→coast.
- Resolution-independence: km² thresholds stable across 512²/1024²/2048²; flat artifact 
  eliminated (not deferred); residual flat = measured marginal (gentle-plain parallelism, 
  no systematic defect).
- Water classification correct in the data: residual flooded components ≥10 km² = 0 (all 
  vast basins are water); residual = only <min_area noise pits (no over-inclusion).
- Lake stats in metres; named lakes preserved (grew to true shoreline); slopes/rivers 
  unchanged.
- lib 450/0, deterministic; only the pre-existing v2 rectangular_simulation red.

## Scope / follow-ups (#155 stays open)
NOT in this PR: viz-rewire to c1_drainage (viz still on v2 erosion cache); export §9 
infra (deferred to reloop); lake-vs-marsh sub-typing (needs climate, like endorheic); 
critical-wedge / high-mountain ceiling; submarine relief.

## Refs
#155 (not closed). Builds on the merged vertical contract (#162) and relief arc (#156–#160).

## Manual create steps (gh unavailable)
1. **FIRST: `git fetch` and compare to milestone HEAD.** The local commit count has been 
   stale throughout this arc (recounting already-merged commits). Sync the branch onto 
   the current milestone HEAD, then confirm the PR contains ONLY the unmerged 
   pin-horizontal + drainage arc (~12 commits: 4e36f5c, 7adc2ad, 285fc76, fa06c99, 
   2ec0348, 0278119, 7d54afc, 945ce6e, 1f841a6, 3423a3e, 0b07360, 9001eef) — NOT the 
   already-merged #162 vertical Maillon 2 or relief commits.
2. Push the synced branch.
3. Open PR against milestone/c1-lightweight-dynamic-tectonics with the title/body above.