### PR TITLE
Issue #155 — C1 critical-wedge: lift orogens to the 70km taper + field-independent land elevation

### DIFF
--- a/crates/ymir-core/src/tectonics/isostasy.rs
+++ b/crates/ymir-core/src/tectonics/isostasy.rs
@@ -92,6 +92,19 @@ pub struct IsostasyConfig {
     /// is the S̃ order). Thickness ratio (1.25) stays anchored.
     #[serde(default)]
     pub craton_rho_crust: Option<f32>,
+    /// #155 critical-wedge — FIXED land-elevation reference (S̃ thickness). When
+    /// `Some(rt)`, the LAND ramp normalises against `rt · buoyancy` (a FIXED raw
+    /// height) instead of the field's `h_max`/`land_cap`, and `peak_altitude_m =
+    /// max_elevation_m`. This DECOUPLES the rendered land elevation from the
+    /// field's own relief: a given S̃ thickness renders the SAME metres in every
+    /// seed and after every closure (no more field-dependent ~0.74-0.80 fraction
+    /// that shifts as the orogen grows). `rt = h_eq = 2.0` (= ~70 km, the EH cap
+    /// = the physical max crustal thickness) is the single anchor the whole
+    /// relief converges on (the critical-wedge targets it, EH caps it, the scale
+    /// references it). Cells above `rt` clamp to norm 1.0 = `max_elevation_m`.
+    /// `None` → the field-relative `land_cap` behaviour (byte-identical; v2/export).
+    #[serde(default)]
+    pub land_ref_thickness: Option<f32>,
 }
 
 impl Default for IsostasyConfig {
@@ -106,6 +119,7 @@ impl Default for IsostasyConfig {
             altitude_smoothing_sigma: 2.0,
             sea_level_mode: SeaLevelMode::MinMaxFraction,
             craton_rho_crust: None,
+            land_ref_thickness: None,
         }
     }
 }
@@ -153,6 +167,20 @@ impl IsostasyConfig {
             // orogens (2950 over-lowers). Default keeps None (v2/export
             // bit-compat). Anchored — not tuned to a target.
             craton_rho_crust: Some(2900.0),
+            // #155 critical-wedge — land elevation anchor = the contract norm-1.0
+            // (5650 m). With `land_ref_thickness=Some(2.0)`, norm 1.0 ↔ S̃=2.0
+            // (~70 km, the EH cap) ↔ max_elevation_m ↔ the vertical contract max:
+            // ONE coherent anchor. An S̃=2.0 orogen renders 5650 m, S̃≈1.9 renders
+            // ~5.3 km, FIELD-INDEPENDENTLY (no re-pin; rendered ≤ contract). Default
+            // keeps 4000 (v2/export byte-identical). 8000 m Everest POINT peaks
+            // exceed the contract + C1's mean-field resolution → out of scope.
+            max_elevation_m: 5650.0,
+            // #155 critical-wedge — fix the land reference to S̃=2.0 (h_eq=70 km,
+            // EH cap): decouples rendered orogen height from the field's own
+            // relief (the ~0.78 field-dependent fraction → field-INDEPENDENT). The
+            // single anchor the relief converges on (wedge targets 2.0, EH caps
+            // 2.0, scale references 2.0). Default None (v2/export field-relative).
+            land_ref_thickness: Some(2.0),
             ..Default::default()
         }
     }
@@ -283,6 +311,17 @@ fn compute_isostasy_inner(
         None => h_max,
     };
 
+    // 2c. #155 critical-wedge — the LAND-ramp ceiling. With `land_ref_thickness`
+    // it is a FIXED raw height `rt · buoyancy` (rt = S̃ reference, the EH cap 2.0
+    // = 70 km), NOT the field's `land_cap`: this decouples the rendered land
+    // elevation from the field's own relief (a given S̃ → the same metres in every
+    // seed / after every closure). Cells above it clamp to norm 1.0. `None` →
+    // the field-relative `land_cap` (byte-identical).
+    let land_ceiling = match config.land_ref_thickness {
+        Some(rt) => rt * buoyancy,
+        None => land_cap,
+    };
+
     // 3. Map to normalized [0, 1] with sea level at a known position
     // sea_norm = max_depth / (max_depth + max_elevation)
     let sea_norm = config.max_depth_m / (config.max_depth_m + config.max_elevation_m);
@@ -296,9 +335,10 @@ fn compute_isostasy_inner(
             let t = (h - h_min) / (h_sea - h_min).max(1e-10);
             t * sea_norm
         } else {
-            // #155 land ramp tops at land_cap (continental summit, not the
-            // phantom oceanic h_max). Cells above land_cap clamp to 1.0 below.
-            let t = (h - h_sea) / (land_cap - h_sea).max(1e-10);
+            // #155 land ramp tops at `land_ceiling` (fixed S̃-reference when
+            // land_ref_thickness is set, else the continental land_cap). Cells
+            // above it clamp to 1.0 below.
+            let t = (h - h_sea) / (land_ceiling - h_sea).max(1e-10);
             sea_norm + t * (1.0 - sea_norm)
         };
         data[k] = normalized.clamp(0.0, 1.0);
@@ -310,11 +350,17 @@ fn compute_isostasy_inner(
 
     let land_ratio = land_count as f32 / (nx * ny) as f32;
 
-    // 4. Compute actual peak altitude and depth for metadata. #155: the peak
-    // is the real continental summit (land_cap), not the phantom oceanic h_max
-    // — so peak_altitude_m describes an actual land cell (None path: land_cap
-    // == h_max, byte-identical).
-    let peak_altitude_m = (land_cap - h_sea) / (land_cap - h_min).max(1e-10) * config.max_elevation_m;
+    // 4. Compute actual peak altitude and depth for metadata. #155 critical-wedge:
+    // with a fixed land reference, norm 1.0 ↔ `land_ceiling` (S̃=rt) ↔
+    // `max_elevation_m` directly — so `peak_altitude_m = max_elevation_m`,
+    // field-INDEPENDENT (a cell at the reference thickness renders the same metres
+    // in every field). Without it, the field-relative continental-summit fraction
+    // (byte-identical None path).
+    let peak_altitude_m = if config.land_ref_thickness.is_some() {
+        config.max_elevation_m
+    } else {
+        (land_cap - h_sea) / (land_cap - h_min).max(1e-10) * config.max_elevation_m
+    };
     let actual_depth_m = (h_sea - h_min) / (h_max - h_min).max(1e-10) * config.max_depth_m;
 
     let heightmap = GridF32::from_vec(nx, ny, data);
@@ -519,7 +565,14 @@ mod tests {
         let d = IsostasyConfig::default();
         let c = IsostasyConfig::c1_default();
         assert_eq!(d.sea_level_fraction, c.sea_level_fraction);
-        assert_eq!(d.max_elevation_m, c.max_elevation_m);
+        // #155 critical-wedge: c1_default max_elevation_m = 5650 (= contract
+        // norm-1.0) + land_ref_thickness Some(2.0) (fixed S̃=70 km reference, so
+        // rendered orogen height is field-independent); Default keeps 4000 + None
+        // (field-relative, v2/export bit-compat).
+        assert_eq!(d.max_elevation_m, 4000.0);
+        assert_eq!(c.max_elevation_m, 5650.0);
+        assert_eq!(d.land_ref_thickness, None);
+        assert_eq!(c.land_ref_thickness, Some(2.0));
         assert_eq!(d.altitude_smoothing_sigma, 2.0);
         assert_eq!(c.altitude_smoothing_sigma, 0.5);
     }

--- a/crates/ymir-core/src/tectonics_c1/closures/davis_suppe/source_term.rs
+++ b/crates/ymir-core/src/tectonics_c1/closures/davis_suppe/source_term.rs
@@ -82,6 +82,21 @@ pub struct DavisSuppeParams {
     /// wedge distance field upstream — both come from the SAME
     /// [`DavisSuppeParams::scaled_to_grid`] result.
     pub max_distance: f64,
+    /// #155 critical-wedge — deposition-RATE boost on O-C convergent-margin
+    /// orogens (only the `oc_wedge` cells of the routed step). The #155
+    /// diagnostic showed orogens equilibrate at S̃ ≈ 1.3-1.5, well below their
+    /// margin-peaked critical-taper target `h_crit ≈ 1.95` (≈ 2× normal crust =
+    /// the ~70 km Tibetan plateau, = `h_eq`): the LIMITER is the deposition rate
+    /// (the erosion sink + advective smear hold the equilibrium below the
+    /// target), NOT the EH ceiling (which is a no-op below 2.0). This multiplies
+    /// the O-C `coupling` so deposition overcomes the sink and the orogen
+    /// reaches its critical taper, and clamps the per-step result to `h_crit`
+    /// (the critical taper is the physical cap — no forward-Euler overshoot). The
+    /// THICKNESS target stays anchored in `h_crit` (the 1b-i 2× ridge); this only
+    /// supplies the rate to reach it. `None` → byte-identical (effective
+    /// coupling = `coupling`, no clamp). Calibrated by the achieved equilibrium
+    /// (not the term), see `probe_orogen_equilibrium`.
+    pub oc_coupling_boost: Option<f64>,
 }
 
 /// Reference resolution at which the Davis-Suppe length scales
@@ -123,6 +138,7 @@ impl Default for DavisSuppeParams {
             l_taper: 4.0,
             l_decay: 6.0,
             max_distance: 30.0, // = 5 × l_decay
+            oc_coupling_boost: None,
         }
     }
 }
@@ -248,9 +264,18 @@ fn apply_davis_suppe_step_inner(
             let v_mag = (vx * vx + vy * vy).sqrt();
             // Decay envelope.
             let envelope = (-d / l_decay).exp();
+            // #155 critical-wedge: boost the O-C deposition RATE so the orogen
+            // reaches its critical taper (the diagnostic limiter is the rate, not
+            // the target/EH). None → byte-identical (factor 1.0, no clamp).
+            let boost = if is_oc { params.oc_coupling_boost } else { None };
+            let eff_coupling = coupling * boost.unwrap_or(1.0);
             // Forward-Euler step.
-            let ds_dt = coupling * v_mag * driving * envelope;
-            s.set(i, j, h_now + ds_dt * dt);
+            let ds_dt = eff_coupling * v_mag * driving * envelope;
+            let raw = h_now + ds_dt * dt;
+            // Clamp the boosted O-C step to the critical taper h_crit (its
+            // physical cap) — no overshoot from the larger rate.
+            let s_new = if boost.is_some() { raw.min(h_crit) } else { raw };
+            s.set(i, j, s_new);
         }
     }
 }

--- a/crates/ymir-core/src/tectonics_c1/time_loop.rs
+++ b/crates/ymir-core/src/tectonics_c1/time_loop.rs
@@ -322,7 +322,13 @@ pub struct C1Closures {
 impl Default for C1Closures {
     fn default() -> Self {
         Self {
-            davis_suppe: DavisSuppeParams::default(),
+            // #155 critical-wedge — canonical C1 boosts the O-C convergent-margin
+            // deposition RATE so orogens reach their critical-taper target (S̃≈
+            // h_crit≈2.0 = ~70 km Tibetan plateau = 2× normal crust), instead of
+            // stalling at S̃≈1.5 (the diagnostic limiter is the rate, not the EH
+            // ceiling). Calibrated by the achieved equilibrium. DavisSuppeParams::
+            // default() keeps None (off) for the phase-1.2/1.3 imprint tests + v2.
+            davis_suppe: DavisSuppeParams { oc_coupling_boost: Some(6.0), ..DavisSuppeParams::default() },
             equilibrium_height: EquilibriumHeightParams::default(),
             // #155 A′ — canonical C1 activates craton erosion-resistance
             // (anchored mid-band ~5×). Pairs with the init thickness

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -4527,3 +4527,34 @@ fn probe_clean_product_2048() {
     }
     eprintln!("  out = {}", dir.display());
 }
+
+/// #155 elucidate the 0.78 orogen-render fraction: is it a normalization coupling
+/// (peak_altitude_m ties land height to the GLOBAL range incl ocean h_min) or
+/// correct? Reconstruct the isostasy raw-h internals at 64² (the sim grid).
+#[test]
+#[ignore]
+fn probe_orogen_fraction() {
+    let iso = IsostasyConfig::c1_default(); let grid=64usize;
+    let buoy=1.0-iso.rho_crust/iso.rho_mantle;
+    let buoy_c=match iso.craton_rho_crust { Some(r)=>1.0-r/iso.rho_mantle, None=>buoy };
+    let pct=|v:&[f32],q:f32|->f32{let mut s=v.to_vec();s.sort_by(|a,b|a.partial_cmp(b).unwrap());s[((q*(s.len()-1)as f32)as usize).min(s.len()-1)]};
+    eprintln!("#155 orogen-render fraction elucidation (64²)");
+    for &seed in &[1988u64,2026,42]{
+        let mut state=init_c1_state_phase_2_r7(grid,seed,&Phase2InitParams::default());
+        let mut kin=PlateKinematics::preset_phase_1_1(state.num_plates);
+        let config=C1TimeLoopConfig{rigid_continental_crust:true,n_steps:300,dx:1.0/64.0,dy:1.0/64.0,iso_config:iso.clone(),drainage_max_distance:30};
+        run_with_closures(&mut state,&mut kin,&config,&C1Closures::default(),|_,_|{});
+        let mut raw=vec![0.0f32;grid*grid]; let mut raw_cont=Vec::new();
+        for j in 0..grid{for i in 0..grid{let k=j*grid+i;let b=if state.cratonic_mask.data()[k]{buoy_c}else{buoy};let h=(state.s.get(i,j) as f32)*b;raw[k]=h;if matches!(state.plate_type.get(i,j),PlateType::Continental){raw_cont.push(h);}}}
+        let h_min_g=raw.iter().cloned().fold(f32::INFINITY,f32::min);
+        let h_min_c=raw_cont.iter().cloned().fold(f32::INFINITY,f32::min);
+        let land_cap=raw_cont.iter().cloned().fold(f32::NEG_INFINITY,f32::max);
+        let h_cap=pct(&raw,0.92); let h_range=(h_cap-h_min_g).max(1e-10); let h_sea=h_min_g+0.4*h_range;
+        let frac_g=(land_cap-h_sea)/(land_cap-h_min_g);
+        let frac_c=(land_cap-h_sea)/(land_cap-h_min_c).max(1e-10);
+        // fixed-Airy alternative: orogen elevation = (land_cap - h_sea) directly (raw above sea),
+        // vs the range-normalized fraction.
+        eprintln!("  seed {seed}: land_cap={land_cap:.3} h_sea={h_sea:.3} h_min global={h_min_g:.3} continental={h_min_c:.3}",);
+        eprintln!("    fraction (land_cap-h_sea)/(land_cap-h_min): GLOBAL={frac_g:.3}  CONTINENTAL={frac_c:.3}  (global<continental ⇒ ocean h_min drives the <1)");
+    }
+}

--- a/crates/ymir-core/tests/c1_phase_2_bathymetry_acceptance.rs
+++ b/crates/ymir-core/tests/c1_phase_2_bathymetry_acceptance.rs
@@ -103,9 +103,7 @@ use ymir_core::erosion::hydraulic::{run_erosion, ErosionConfig};
 use ymir_core::seed::WorldSeed;
 use ymir_core::tectonics::isostasy::{compute_isostasy, IsostasyConfig};
 use ymir_core::tectonics_c1::closures::accretion::AccretionParams;
-use ymir_core::tectonics_c1::closures::davis_suppe::source_term::DavisSuppeParams;
 use ymir_core::tectonics_c1::closures::equilibrium_height::params::EquilibriumHeightParams;
-use ymir_core::tectonics_c1::closures::erosion::params::ErosionParams;
 use ymir_core::tectonics_c1::closures::oceanic_bathymetry::params::SteinSteinParams;
 use ymir_core::tectonics_c1::closures::rifting::RiftingParams;
 use ymir_core::tectonics_c1::closures::subduction::SubductionParams;
@@ -407,7 +405,13 @@ fn disabled_matches_phase_1_4() {
     // semantic content as Path A.
     let (mut state_b, mut kinematics_b, config_b) = setup();
     let closures_b = C1Closures {
-        davis_suppe: DavisSuppeParams::default(),
+        // #155 critical-wedge: track the canonical davis_suppe (now
+        // oc_coupling_boost=Some in C1Closures::default) rather than hardcoding
+        // DavisSuppeParams::default (boost None) — Path B must match Path A's
+        // `..C1Closures::default()`. The boost is orthogonal to the S-S-off
+        // contract this test verifies (S-S does not touch S̃); same precedent
+        // as the A′ erosion fix below.
+        davis_suppe: C1Closures::default().davis_suppe,
         equilibrium_height: EquilibriumHeightParams::default(),
         // #155 A′: track the canonical erosion (now craton_resist=0.2 in
         // C1Closures::default) rather than hardcoding ErosionParams::default

--- a/docs/reports/c1_continental_buoyancy/stage_critical_wedge_diagnostic.md
+++ b/docs/reports/c1_continental_buoyancy/stage_critical_wedge_diagnostic.md
@@ -1,0 +1,77 @@
+# #155 relief — critical-wedge / high-mountain ceiling diagnostic
+
+Target: high mountains (Himalaya/Tibet). Current orogens render ~2265-2596 m (the
+metric scale, `probe_sea_unification_acceptance`); the goal is the Tibetan-plateau
+scale. This finishes terrestrial relief BEFORE climate (which depends on orography).
+Diagnostic only — the mechanism follows the verdict.
+
+## 1. EH exonerated (re-confirmed on current terrain)
+
+`probe_orogen_equilibrium` (current code): margin orogen S̃ p95 = **1.30 / 1.47 / 1.35**
+(seeds 42/1988/2026), erosion-OFF **1.59 / 1.73 / 1.59**. `probe_prominence_attribution`:
+**0 %** of margin cells above `h_eq` (0/481, 0/909, 0/461). EH (`apply_equilibrium_height_step`)
+collapses S̃ quadratically ONLY above `h_eq=2.0` — a no-op below 2.0, so it does
+NOTHING to orogens stuck at 1.5. **Raising `h_eq` would have zero effect.** (The old
+"EH-bound at 2.0" was the oceanic advective spike, not the continental orogen.)
+
+## 2. The thickening mechanism + what limits it
+
+Davis-Suppe source (`apply_davis_suppe_step`):
+`∂S̃/∂t = coupling·|v|·max(0, h_crit(d) − S̃)·exp(−d/L_decay)`, defaults `coupling=2.0`,
+`h_max=2.5`, `l_taper=4`, `l_decay=6`; O-C margin-peaked profile (1b-i) `h_crit =
+h_max·exp(−d/l_taper)` peaks ~1.95 at the margin. The source deposits TOWARD `h_crit`
+and halts as `S̃ → h_crit`. **Achieved S̃ (1.3-1.5) sits well below the target (1.95)**:
+the equilibrium is where the source balances (a) the in-loop stream-power EROSION sink
+(removes ~0.2-0.25: 1.5 baseline vs 1.7 erosion-OFF) and (b) ADVECTIVE smear (erosion-OFF
+still 1.7 < 1.95 target) over the 300-step run. **The limiter is the deposition RATE
+(coupling) vs erosion+advection removal — NOT the EH ceiling.**
+
+## 3. Critical-wedge — the anchored target is S̃≈2.0 (= h_eq)
+
+Himalayan crust ~70 km vs normal ~35 km = **2×** (TDD §11: S̃=1.0 = 35 km normal
+continental). So **S̃=2.0 = 70 km = the Tibetan-plateau thickness — which is EXACTLY
+`h_eq=2.0`.** EH=2.0 is therefore the CORRECT Himalayan-plateau cap; the orogens should
+reach ~2.0 but the force only gets them to 1.5. **Critical-wedge fix = stronger
+convergent-margin deposition to reach S̃≈2.0** (the EH cap = 70 km Himalayan), NOT
+raising EH. The unused headroom 1.5→2.0 IS the missing thickening. Levers (anchored,
+for the fix maillon): raise DS `coupling` (deposition rate) at active convergent margins
+and/or reduce the margin erosion sink, targeting S̃≈2.0 (= 70 km, the existing h_eq). The
+ratio is the craton precedent (craton 1.25×; orogen 2×), physically anchored, not a knob.
+
+## 4. The codomain tension (decide BEFORE coding)
+
+Even at S̃=2.0, the altitude is bounded:
+- **Isostasy** `peak_altitude_m ≤ max_elevation_m = 4000 m` — a hard codomain ceiling.
+  An S̃=2.0 (70 km) orogen renders ≤4000 m, but Airy of 70 km vs 35 km ≈ **5.4 km** — so
+  `max_elevation_m=4000` UNDER-represents the 70 km thickness. Raise to ~5500 m (Airy of
+  70 km).
+- **Vertical contract** `norm→m = (norm−0.5)·11300`, norm 1.0 = **+5650 m**. Land
+  currently caps at norm 0.854 (the 4000 m max_elev). So raising `max_elevation_m` to
+  ~5500 uses the EXISTING contract headroom (5500 < 5650) — **no re-pin needed**.
+- **8000 m (Everest peaks) > 5650 m contract max** → would require RE-PINNING the
+  vertical contract (raise `depth_scale`/half-range), which is COUPLED to the S-S ocean
+  scale (half-range = 5651/5000). TENSION.
+
+**VERDICT on the target:** C1 is a 64²→2048² MEAN field. The right C1 target is the
+**Tibetan-PLATEAU scale ~5-5.5 km** (Airy of 70 km crust, S̃=2.0) — reachable by
+(force → S̃≈2.0) + (raise `max_elevation_m` to ~5500, within the contract, NO re-pin).
+**8000 m Everest POINT peaks are sub-grid erosion-sharpening beyond C1's mean-field
+resolution AND beyond the vertical contract — out of scope / defer.** Targeting the
+plateau (~5.5 km) avoids re-pinning the vertical contract (and its ocean coupling).
+
+## 5. Orographic effect (for the climate ordering)
+
+The critical-wedge AMPLIFIES the existing convergent-margin orogens (raises their S̃ →
+higher coastal cordilleras), it does not create new chains. So higher orographic
+barriers at the existing margins → confirms doing the critical-wedge BEFORE climate is
+the right order (the barriers will shape precipitation).
+
+## Output / scope for the fix maillon
+1. **Force:** raise DS convergent-margin deposition (coupling / margin-erosion balance)
+   to lift orogen S̃ from ~1.5 toward **S̃≈2.0** (= 70 km Himalayan = the existing h_eq).
+   Do NOT raise `h_eq` (2.0 is correct). Anchored on the 2× crustal ratio.
+2. **Codomain:** raise `max_elevation_m` 4000 → ~5500 (Airy of 70 km crust), within the
+   vertical contract (no re-pin).
+3. **Target = Tibetan plateau ~5.5 km** (mean field), NOT 8000 m Everest peaks (sub-grid
+   + beyond contract → defer). This resolves the codomain tension without a vertical re-pin.
+4. EH untouched; the vertical/horizontal coordinate contract untouched.


### PR DESCRIPTION
Closes terrestrial relief (high mountains) — the last C1 relief maillon, before
climate. Builds on the merged interior-relief + coordinate-contract + drainage arc.

## Diagnostic (5f2c361)
- **EH exonerated** (re-confirmed on current terrain): orogen margin S̃ equilibrates
  at **1.3–1.5**, **0%** of margin cells above `h_eq=2.0`. EH collapses only *above*
  2.0 → a no-op on orogens at 1.5. Raising `h_eq` does nothing.
- **Limiter = the Davis-Suppe deposition RATE** (the erosion sink + advective smear
  hold the equilibrium below the ~1.95 critical-taper target), not the ceiling.
- **Anchor:** S̃=2.0 = ~70 km crust = Tibetan plateau = exactly `h_eq` (TDD §11:
  S̃=1.0 = 35 km). The whole relief converges on this one anchor.

## Fix (396fba2) — two gated parts, both byte-identical when off
1. **Force** — `DavisSuppeParams.oc_coupling_boost` (None = byte-identical;
   `C1Closures::default` = `Some(6.0)`). Boosts the O-C convergent-margin deposition
   *rate* so orogens reach their critical taper (~1.9–1.95 = 70 km), clamped to
   `h_crit` (no overshoot). **`h_eq` untouched** — it's the correct cap; the fix
   *reaches* it. Calibrated by the achieved equilibrium.
2. **Field-independent elevation** — `IsostasyConfig.land_ref_thickness` (None =
   byte-identical; `c1_default` = `Some(2.0)`) + `max_elevation_m` 4000→5650. The land
   ramp + `peak_altitude_m` normalise against a **fixed reference** (S̃=2.0=70km=EH
   cap), not the field's `land_cap`. Elucidated by measurement (`probe_orogen_fraction`):
   the prior ~0.78 render fraction was **field-dependent** (`= 1 − h_sea/land_cap`,
   varied 0.74–0.80/seed, *not* ocean-driven — `h_min=0`); dividing the metre scale by
   the field's own max meant every closure shifted the scale — the re-calculability
   instability at its root. Now a given S̃ renders the **same metres in every seed /
   after every closure**: `norm 1.0 ↔ S̃=2.0 ↔ max_elevation_m 5650 ↔ contract norm-1.0`,
   one coherent anchor (the land-ceiling #161 family, finished).

## Result
Orogens render **3.1–4.65 km** (franc seed 1988 = 4653 m, up from 2.3–2.6 km); the
per-seed variation is now **physical** (the orogen S̃), not normalization. Visual: bold
high cordilleras along the O-C margins — strong orography for the climate phase.

## Safety
All three gated default-off → **v2/export byte-identical** (the phase-1.2/1.3 imprint
tests build `DavisSuppeParams::default()` directly → unaffected). EH + the vertical/
horizontal coordinate contract **untouched** (rendered ≤ contract 5650, no re-pin).
One contained test move: `disabled_matches_phase_1_4` Path B now tracks the canonical
`C1Closures::default().davis_suppe` (the boost is orthogonal to the S-S-off contract —
same precedent as the A′ erosion fix). lib **450/0**, all C1 green, only the
pre-existing v2 `rectangular_simulation` red.

## Honest limits (deferred, documented)
- Franc crest sits at ~1.9 (not 2.0) → ~4.65 km (not 5.5 km). The last push needs
  raising the O-C `h_crit` cap (the 1b-i margin-peak ~1.95) — deferred calibration.
- 8000 m Everest *point* peaks: sub-grid (C1 is a 64²→2048² mean field) + beyond the
  vertical contract (5650 m) — out of scope.