### PR TITLE
FEAT : Issue #165 climate - latitude slider expressiveness + subtropical desert (Hadley subsidence)

### DIFF
--- a/crates/ymir-core/src/climate/precipitation.rs
+++ b/crates/ymir-core/src/climate/precipitation.rs
@@ -92,6 +92,33 @@ pub struct PrecipParams {
     /// desert floor). A SEPARATE synoptic source (moisture from elsewhere in the
     /// belt) → additive, NOT part of the orographic conservation budget.
     pub k_frontal: f32,
+    /// #165 — Hadley SUBTROPICAL SUBSIDENCE dryness. The descending branch of the
+    /// Hadley cell (~20-30°) suppresses frontal precipitation → the world's great
+    /// deserts (Sahara, Arabia, Atacama, Kalahari, Australia). Multiplies the
+    /// frontal base by `1 − subtropical_subsidence · gaussian(|lat|−28°)` (see
+    /// [`subtropical_suppression`]) — a LOCAL dip on the subtropical high that
+    /// deepens the zonal minimum `belt_factor` alone left too shallow (the
+    /// diagnostic measured 30° interior ~279 mm = steppe, above the 250 mm desert
+    /// line). Anchored on the observed subtropical/mid-latitude precip ratio
+    /// (subsidence removes ~half the frontal base), not eyeballed to a target.
+    /// `0.0` → off (byte-identical to pre-fix). Leaves the ITCZ, savanna, and
+    /// temperate belts intact (the gaussian is narrow, centred on ~28°).
+    #[serde(default)]
+    pub subtropical_subsidence: f32,
+}
+
+/// #165 — frontal-base multiplier from Hadley subtropical subsidence. Returns a
+/// value in `(0, 1]`: ~`1 − amplitude` at the subtropical high (~28°, the Hadley
+/// descending branch), rising back to `1` away from it. LOCAL by construction (a
+/// narrow gaussian) — the equatorial ITCZ, the ~15° savanna, and the ~45-60°
+/// temperate/westerly belts are essentially untouched. `amplitude = 0` → `1.0`
+/// everywhere (no-op). Anchored: the centre 28° and width 8° are the subtropical
+/// subsidence belt; the amplitude scales the observed subtropical dryness.
+pub fn subtropical_suppression(lat_deg: f32, amplitude: f32) -> f32 {
+    const CENTER: f32 = 28.0; // subtropical high — Hadley descending branch
+    const WIDTH: f32 = 8.0;
+    let g = (-((lat_deg.abs() - CENTER) / WIDTH).powi(2)).exp();
+    1.0 - amplitude * g
 }
 
 impl Default for PrecipParams {
@@ -123,7 +150,16 @@ impl Default for PrecipParams {
         // (desert line) at 45° → temperate steppe, NOT desert; at ~30° belt_factor
         // drops it to ~150 → desert, correct (the Sahara belt). The mm scale
         // (PRECIP_MM_PER_UNIT) is unchanged; only the frontal strength changes.
-        Self { k_evap: 0.20, k_oro: 0.5, k_frontal: 0.0035 }
+        // #165 subtropical desert — the latitude-slider diagnostic measured the
+        // ~30° interior at ~279 mm (steppe), above the 250 mm desert line: the
+        // `belt_factor` zonal minimum alone was too shallow to render the
+        // subtropical desert belt. `subtropical_subsidence = 0.45` deepens it via
+        // the Hadley descending-branch suppression (see `subtropical_suppression`)
+        // so the 30° interior drops below 250 mm (desert) WHILE leaving 0°/15°/45°+
+        // intact (narrow gaussian on the subtropical high). 0.45 ≈ the observed
+        // subtropical/mid-latitude precip ratio (subsidence removes ~half the
+        // frontal base); 0.0 = off (byte-identical pre-fix).
+        Self { k_evap: 0.20, k_oro: 0.5, k_frontal: 0.0035, subtropical_subsidence: 0.45 }
     }
 }
 
@@ -165,8 +201,12 @@ pub fn compute_precipitation_with_budget(
     let mut exit_out = 0.0f64;
     let mut oro_precip_sum = 0.0f64;
     // FRONTAL / synoptic base (per the domain's belt; ~9° span → one value).
-    let frontal_base =
-        params.k_frontal * belt_factor(lat_deg) * e_sat(super::temperature::sea_level_temperature(lat_deg));
+    // #165 — Hadley subtropical subsidence deepens the zonal minimum so the ~30°
+    // belt reads as desert (the diagnostic gap); 0.0 amplitude → unchanged.
+    let frontal_base = params.k_frontal
+        * belt_factor(lat_deg)
+        * e_sat(super::temperature::sea_level_temperature(lat_deg))
+        * subtropical_suppression(lat_deg, params.subtropical_subsidence);
 
     for j in 0..h {
         // Scan along the wind, upwind → downwind.
@@ -269,5 +309,28 @@ mod tests {
             "moisture not conserved: evap_in={evap_in:.4} oro_precip={oro_sum:.4} exit={exit_out:.4} residual={residual:.2e}"
         );
         assert!(oro_sum > 0.0, "some orographic precipitation expected");
+    }
+
+    /// #165 — the Hadley subtropical subsidence dip is LOCAL: it suppresses the
+    /// frontal base hard at the subtropical high (~28°) but leaves the ITCZ,
+    /// savanna, and temperate/westerly belts essentially untouched. Locks the
+    /// "don't dry the temperate belt" invariant (the 45° production default must
+    /// not move) and the byte-identical off-switch.
+    #[test]
+    fn subtropical_subsidence_is_local() {
+        let a = 0.45;
+        // Strong suppression on the subtropical high (~28°): ~1 − amplitude.
+        assert!((subtropical_suppression(28.0, a) - (1.0 - a)).abs() < 1e-6);
+        assert!(subtropical_suppression(30.0, a) < 0.6, "30° must be strongly dried (desert belt)");
+        // Neighbours essentially untouched (local narrow gaussian).
+        assert!(subtropical_suppression(0.0, a) > 0.999, "ITCZ intact");
+        assert!(subtropical_suppression(15.0, a) > 0.95, "savanna ~intact");
+        assert!(subtropical_suppression(45.0, a) > 0.99, "temperate belt intact");
+        assert!(subtropical_suppression(60.0, a) > 0.999, "polar front intact");
+        // Symmetric in hemisphere and off at amplitude 0 (byte-identical).
+        assert_eq!(subtropical_suppression(-28.0, a), subtropical_suppression(28.0, a));
+        for lat in [0.0, 15.0, 28.0, 45.0, 75.0] {
+            assert_eq!(subtropical_suppression(lat, 0.0), 1.0, "amplitude 0 = no-op");
+        }
     }
 }

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -6400,3 +6400,102 @@ fn probe_craton_bimodal() {
          dissolved). That fraction is the c1 production value."
     );
 }
+
+/// #165 LATITUDE SLIDER — is the latitude_deg slider EXPRESSIVE? Each belt should
+/// read as its signature climate: 0° ITCZ (jungle), ~30° subsidence (desert),
+/// ~45° westerlies (temperate, the shipped default), ~60° polar front (humid),
+/// ~75-90° (cold dry). Measures what's WIRED vs MISSING so only the gap is coded.
+///
+/// Generates the climate (T, P, biomes) on ONE seed at 0/15/30/45/60/75°. The
+/// cache shares the eroded terrain across latitudes (latitude changes only the
+/// DERIVED climate, not the relief), so this is fast. Per latitude reports:
+/// (1) wind direction `wind_zonal_dir` (trade easterly / westerly / polar); (2)
+/// the zonal base `belt_factor` + the actual land precip distribution (mm/yr) —
+/// does it follow the real zonal profile (wet ITCZ / dry subtropics / etc.) or
+/// is it flat; (3) the land biome histogram — distinct signatures or uniform.
+///
+/// DIAGNOSTIC ONLY. Invocation:
+/// `cargo test --release -p ymir-core --test c1_closure_morphology probe_latitude_slider -- --ignored --nocapture`
+#[test]
+#[ignore]
+fn probe_latitude_slider() {
+    use ymir_core::climate::biomes::Biome;
+    use ymir_core::climate::precipitation::{
+        belt_factor, precip_mm_per_year, wind_zonal_dir, PrecipParams,
+    };
+    use ymir_core::climate::temperature::sea_level_temperature;
+    use ymir_core::climate::{c1_biomes, c1_climate};
+    use ymir_core::climate::precipitation::SEA_LEVEL_NORM;
+
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let pp = PrecipParams::default();
+    let seed = 42u64;
+    // Shared eroded terrain (cache HIT if a prior #165 probe built this seed).
+    let heightmap = c165_eroded(seed, &iso);
+    let h = &heightmap;
+    let land: Vec<usize> = (0..h.data.len()).filter(|&k| h.data[k] > SEA_LEVEL_NORM).collect();
+
+    let pct = |v: &mut Vec<f32>, q: f32| -> f32 {
+        if v.is_empty() {
+            return 0.0;
+        }
+        v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        v[((q * (v.len() - 1) as f32).round() as usize).min(v.len() - 1)]
+    };
+
+    let order = [
+        Biome::TropicalRainforest, Biome::TropicalSeasonalForest, Biome::Savanna, Biome::Desert,
+        Biome::TemperateGrassland, Biome::TemperateForest, Biome::TemperateRainforest,
+        Biome::BorealForest, Biome::Tundra,
+    ];
+
+    eprintln!(
+        "#165 latitude slider — seed {seed}, shared terrain across latitudes. wind: trade=E→W \
+         (<30°), westerly=W→E (30-60°), polar=E→W (≥60°). Real zonal precip anchor: ITCZ ~0° \
+         very wet, subtropics ~30° desert (<250), westerlies ~45-60° moderate, poles dry."
+    );
+    eprintln!("  lat | wind | belt | T_sea | land T med | precip mm/yr (p10/med/p90) | dominant biomes");
+
+    for &lat in &[0.0f32, 15.0, 30.0, 45.0, 60.0, 75.0] {
+        let clim = c1_climate(h, &ss, lat, &pp);
+        let biomes = c1_biomes(h, &clim);
+        let mut temps: Vec<f32> = land.iter().map(|&k| clim.temperature.data[k]).collect();
+        let mut precip: Vec<f32> =
+            land.iter().map(|&k| precip_mm_per_year(clim.precipitation.data[k])).collect();
+        let n = land.len().max(1);
+        let mut cnt = std::collections::HashMap::new();
+        for &k in &land {
+            *cnt.entry(biomes[k]).or_insert(0u64) += 1;
+        }
+        let wind = match wind_zonal_dir(lat) {
+            d if d > 0 => "W→E west",
+            _ => "E→W east",
+        };
+        let t_med = pct(&mut temps, 0.5);
+        let (p10, pmed, p90) = (pct(&mut precip, 0.1), pct(&mut precip, 0.5), pct(&mut precip, 0.9));
+        let hist: Vec<String> = order
+            .iter()
+            .filter_map(|b| {
+                let c = *cnt.get(b).unwrap_or(&0);
+                let f = 100.0 * c as f64 / n as f64;
+                if f >= 8.0 {
+                    Some(format!("{} {:.0}%", b.name(), f))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        eprintln!(
+            "  {lat:>3.0}° | {wind} | {:.2} | {:>5.1}°C | {t_med:>6.1}°C | {p10:>5.0}/{pmed:>5.0}/{p90:>5.0} | {}",
+            belt_factor(lat),
+            sea_level_temperature(lat),
+            hist.join("  "),
+        );
+    }
+    eprintln!(
+        "\n  → (1) wind flips by belt? (2) precip MEDIAN follows the zonal profile (ITCZ high, \
+         ~30° desert <250, midlat moderate, poles dry) or flat? (3) biomes distinct per latitude \
+         (jungle / desert / temperate / boreal-tundra) or uniform? Verdict = what's wired vs the gap."
+    );
+}

--- a/docs/reports/c1_continental_buoyancy/closure_morphology/latitude_slider/VERDICT.md
+++ b/docs/reports/c1_continental_buoyancy/closure_morphology/latitude_slider/VERDICT.md
@@ -1,0 +1,60 @@
+# Verdict — le slider de latitude est-il expressif ? (#165 jonctions latitudinales)
+
+**Probe :** `c1_closure_morphology::probe_latitude_slider` (`#[ignore]`).
+**Run :** seed 42, terrain érodé PARTAGÉ entre latitudes (la latitude ne change que le climat
+dérivé, pas le relief — cache HIT). Latitudes 0/15/30/45/60/75°.
+
+## Mesure (seed 42)
+
+| lat | vent | belt | T_sea | T méd terre | précip mm/yr p10/méd/p90 | biomes dominants |
+|---|---|---|---|---|---|---|
+| 0° | **E→W alizés** | 1.00 | 27.0° | 24.4° | **2054**/2054/4073 | trop. rainforest 85 %, temp. rainforest 15 % |
+| 15° | E→W alizés | 0.33 | 24.9° | 22.5° | 599/599/2392 | **savane 60 %**, temp. forest 21 % |
+| 30° | **W→E westerlies** | 0.21 | 19.8° | 17.4° | 279/279/2376 | **steppe 67 %**, temp. forest 11 %, temp. rainforest 13 % |
+| 45° | W→E westerlies | 0.55 | 12.1° | 9.7° | 448/448/1753 | **steppe 56 %**, temp. forest 19 %, boréal 12 % |
+| 60° | **E→W polaires** | 0.53 | 1.9° | −0.4° | 213/213/617 | **desert 62 %**, boréal 24 %, toundra 14 % |
+| 75° | E→W polaires | 0.20 | −10.5° | −12.8° | **32**/32/191 | **toundra 100 %** |
+
+## Ce qui MARCHE déjà (largement câblé — ne pas réinventer)
+
+1. **Direction du vent — CÂBLÉE & fonctionne.** `wind_zonal_dir(lat)` bascule par bande et le
+   transport scanne dans le bon sens : E→W alizés (<30°), W→E westerlies (30-60°), E→W
+   polaires (≥60°). L'orographie est calculée au bon vent par bande.
+2. **Température zonale — CÂBLÉE.** `sea_level_temperature(lat)` = 27 °C équateur → −25 °C
+   pôle (`(lat/90)^1.8`). T médiane terre 24.4 → −12.8 °C.
+3. **Profil de précip de base zonal — CÂBLÉ.** `belt_factor(lat)` × `e_sat(T_sea(lat))` donne
+   le vrai profil méridien : ITCZ très humide (2054 mm @0°), déclin vers les subtropiques,
+   pôle sec (32 mm @75°).
+4. **Biomes DISTINCTS par latitude — le slider EST expressif :** jungle (0°) → savane (15°)
+   → steppe (30°) → tempéré (45°) → froid-sec (60°) → toundra (75°). Signatures lisibles.
+
+## Le GAP (2 raffinements de PROFIL, PAS de câblage de direction)
+
+1. **Le désert subtropical ~30° est TROP FAIBLE.** Médiane 279 mm → **steppe**, pas désert
+   (ligne 250). Le minimum subtropical de `belt_factor(30°)=0.21` ne descend pas l'intérieur
+   sous 250. Réel : la ceinture saharienne (~25-30°, subsidence) est désertique. → creuser le
+   minimum subtropical (belt_factor un peu plus bas vers 25-30°, ou un terme de sécheresse de
+   subsidence), pour que l'intérieur 30° passe < 250 = désert.
+2. **Le front polaire ~60° n'est PAS humide.** Médiane 213 mm → lu comme **desert froid**,
+   pas « front polaire humide ». Cause : T_sea(60°)=1.9 °C → `e_sat` faible (l'air froid
+   tient peu d'humidité) écrase le `frontal_base` malgré `belt_factor(60°)=0.53` correct. Le
+   60° continental EST sec (légitime), mais l'enrichissement frontal des rails de tempête
+   (storm-track maritime) n'est pas modélisé → pas de signature « humide ». À trancher selon
+   la cible produit (un boost de front polaire si « 60° humide » est voulu).
+
+## Observation transversale
+
+L'intérieur est **PLAT au frontal_base** à chaque latitude (p10 = médiane partout) : le profil
+zonal pose un PLANCHER uniforme par bande, la variété orographique n'apparaît qu'au p90.
+Donc la variété vient (a) de la latitude (le profil zonal) + (b) de l'orographie (p90) — PAS
+de variété intra-bande au niveau médian. C'est le motif de saturation frontale déjà connu
+(cf les commentaires `k_frontal`).
+
+## Verdict
+
+Le slider est **LARGEMENT CÂBLÉ et EXPRESSIF** — direction du vent, température, profil de
+précip zonal et biomes changent tous avec la latitude, produisant des signatures distinctes.
+**Le câblage de direction ne manque RIEN.** Le seul GAP est 2 raffinements de PROFIL de
+précip : (1) creuser le désert subtropical ~30° (279 → < 250 mm), (2) optionnellement
+enrichir le front polaire ~60° (sinon il reste froid-sec, pas humide). Diagnostic seulement —
+le fix (ajuster `belt_factor` / un terme subsidence / un boost front polaire) suit ce verdict.

--- a/docs/reports/c1_continental_buoyancy/closure_morphology/latitude_slider/VERDICT.md
+++ b/docs/reports/c1_continental_buoyancy/closure_morphology/latitude_slider/VERDICT.md
@@ -58,3 +58,16 @@ précip zonal et biomes changent tous avec la latitude, produisant des signature
 précip : (1) creuser le désert subtropical ~30° (279 → < 250 mm), (2) optionnellement
 enrichir le front polaire ~60° (sinon il reste froid-sec, pas humide). Diagnostic seulement —
 le fix (ajuster `belt_factor` / un terme subsidence / un boost front polaire) suit ce verdict.
+
+## FIX appliqué — gap (1) résolu (subsidence subtropicale de Hadley)
+
+`PrecipParams::subtropical_subsidence = 0.45` (gated, `0.0` = byte-identique) multiplie le
+`frontal_base` par `1 − 0.45·gaussian(|lat|−28°)` (`subtropical_suppression`) — la branche
+descendante de la cellule de Hadley qui assèche les subtropiques (Sahara/Arabie/Atacama).
+**Mesuré (slider, seed 42)** : 30° médiane **279 → 161 mm → désert 67 %** (la signature
+manquante), tandis que les voisines sont **intactes** (0° 2054 mm jungle ; 15° 599→579 mm
+savane ; 45° 448→**446** mm tempéré, −2 mm négligeable ; 60°/75° inchangés). Le slider couvre
+désormais TOUTE la gamme : jungle → savane → **désert** → tempéré → froid-sec → toundra.
+Test unitaire `subtropical_subsidence_is_local` + lib verte (471). **Gap (2) — front polaire
+60° : NON touché** (limite déclarée : le 60° continental est sec légitimement ; un « 60°
+humide » exigerait une closure de storm tracks maritimes, différée/hors-scope).


### PR DESCRIPTION
# Verdict — le slider de latitude est-il expressif ? (#165 jonctions latitudinales)

**Probe :** `c1_closure_morphology::probe_latitude_slider` (`#[ignore]`).
**Run :** seed 42, terrain érodé PARTAGÉ entre latitudes (la latitude ne change que le climat
dérivé, pas le relief — cache HIT). Latitudes 0/15/30/45/60/75°.

## Mesure (seed 42)

| lat | vent | belt | T_sea | T méd terre | précip mm/yr p10/méd/p90 | biomes dominants |
|---|---|---|---|---|---|---|
| 0° | **E→W alizés** | 1.00 | 27.0° | 24.4° | **2054**/2054/4073 | trop. rainforest 85 %, temp. rainforest 15 % |
| 15° | E→W alizés | 0.33 | 24.9° | 22.5° | 599/599/2392 | **savane 60 %**, temp. forest 21 % |
| 30° | **W→E westerlies** | 0.21 | 19.8° | 17.4° | 279/279/2376 | **steppe 67 %**, temp. forest 11 %, temp. rainforest 13 % |
| 45° | W→E westerlies | 0.55 | 12.1° | 9.7° | 448/448/1753 | **steppe 56 %**, temp. forest 19 %, boréal 12 % |
| 60° | **E→W polaires** | 0.53 | 1.9° | −0.4° | 213/213/617 | **desert 62 %**, boréal 24 %, toundra 14 % |
| 75° | E→W polaires | 0.20 | −10.5° | −12.8° | **32**/32/191 | **toundra 100 %** |

## Ce qui MARCHE déjà (largement câblé — ne pas réinventer)

1. **Direction du vent — CÂBLÉE & fonctionne.** `wind_zonal_dir(lat)` bascule par bande et le
   transport scanne dans le bon sens : E→W alizés (<30°), W→E westerlies (30-60°), E→W
   polaires (≥60°). L'orographie est calculée au bon vent par bande.
2. **Température zonale — CÂBLÉE.** `sea_level_temperature(lat)` = 27 °C équateur → −25 °C
   pôle (`(lat/90)^1.8`). T médiane terre 24.4 → −12.8 °C.
3. **Profil de précip de base zonal — CÂBLÉ.** `belt_factor(lat)` × `e_sat(T_sea(lat))` donne
   le vrai profil méridien : ITCZ très humide (2054 mm @0°), déclin vers les subtropiques,
   pôle sec (32 mm @75°).
4. **Biomes DISTINCTS par latitude — le slider EST expressif :** jungle (0°) → savane (15°)
   → steppe (30°) → tempéré (45°) → froid-sec (60°) → toundra (75°). Signatures lisibles.

## Le GAP (2 raffinements de PROFIL, PAS de câblage de direction)

1. **Le désert subtropical ~30° est TROP FAIBLE.** Médiane 279 mm → **steppe**, pas désert
   (ligne 250). Le minimum subtropical de `belt_factor(30°)=0.21` ne descend pas l'intérieur
   sous 250. Réel : la ceinture saharienne (~25-30°, subsidence) est désertique. → creuser le
   minimum subtropical (belt_factor un peu plus bas vers 25-30°, ou un terme de sécheresse de
   subsidence), pour que l'intérieur 30° passe < 250 = désert.
2. **Le front polaire ~60° n'est PAS humide.** Médiane 213 mm → lu comme **desert froid**,
   pas « front polaire humide ». Cause : T_sea(60°)=1.9 °C → `e_sat` faible (l'air froid
   tient peu d'humidité) écrase le `frontal_base` malgré `belt_factor(60°)=0.53` correct. Le
   60° continental EST sec (légitime), mais l'enrichissement frontal des rails de tempête
   (storm-track maritime) n'est pas modélisé → pas de signature « humide ». À trancher selon
   la cible produit (un boost de front polaire si « 60° humide » est voulu).

## Observation transversale

L'intérieur est **PLAT au frontal_base** à chaque latitude (p10 = médiane partout) : le profil
zonal pose un PLANCHER uniforme par bande, la variété orographique n'apparaît qu'au p90.
Donc la variété vient (a) de la latitude (le profil zonal) + (b) de l'orographie (p90) — PAS
de variété intra-bande au niveau médian. C'est le motif de saturation frontale déjà connu
(cf les commentaires `k_frontal`).

## Verdict

Le slider est **LARGEMENT CÂBLÉ et EXPRESSIF** — direction du vent, température, profil de
précip zonal et biomes changent tous avec la latitude, produisant des signatures distinctes.
**Le câblage de direction ne manque RIEN.** Le seul GAP est 2 raffinements de PROFIL de
précip : (1) creuser le désert subtropical ~30° (279 → < 250 mm), (2) optionnellement
enrichir le front polaire ~60° (sinon il reste froid-sec, pas humide). Diagnostic seulement —
le fix (ajuster `belt_factor` / un terme subsidence / un boost front polaire) suit ce verdict.

## FIX appliqué — gap (1) résolu (subsidence subtropicale de Hadley)

`PrecipParams::subtropical_subsidence = 0.45` (gated, `0.0` = byte-identique) multiplie le
`frontal_base` par `1 − 0.45·gaussian(|lat|−28°)` (`subtropical_suppression`) — la branche
descendante de la cellule de Hadley qui assèche les subtropiques (Sahara/Arabie/Atacama).
**Mesuré (slider, seed 42)** : 30° médiane **279 → 161 mm → désert 67 %** (la signature
manquante), tandis que les voisines sont **intactes** (0° 2054 mm jungle ; 15° 599→579 mm
savane ; 45° 448→**446** mm tempéré, −2 mm négligeable ; 60°/75° inchangés). Le slider couvre
désormais TOUTE la gamme : jungle → savane → **désert** → tempéré → froid-sec → toundra.
Test unitaire `subtropical_subsidence_is_local` + lib verte (471). **Gap (2) — front polaire
60° : NON touché** (limite déclarée : le 60° continental est sec légitimement ; un « 60°
humide » exigerait une closure de storm tracks maritimes, différée/hors-scope).
