### PR TITLE
FEAT : submarine relief — bathymetric profile (shelf/slope/abyss)

### DIFF
--- a/crates/ymir-core/src/tectonics_c1/production_upscale.rs
+++ b/crates/ymir-core/src/tectonics_c1/production_upscale.rs
@@ -279,7 +279,7 @@ pub fn upscale_from_c1(
     }
     let sea_level_normalized = 0.5_f32;
 
-    let result = upscale_with_fbm(&coarse, sea_level_normalized, seed, cfg);
+    let mut result = upscale_with_fbm(&coarse, sea_level_normalized, seed, cfg);
 
     // #155 méso — HD hydraulic erosion (the dendritic dissection that makes
     // the macro ridge read as credible eroded mountains). Applied AFTER the
@@ -287,23 +287,39 @@ pub fn upscale_from_c1(
     // `FbmUpscaleConfig::c1_hd_production` turns it on; default None →
     // byte-identical). Slope is RECOMPUTED post-erosion (it changed);
     // `sediment` is forwarded (the rivers/lakes hook, not consumed yet).
-    let Some(ero) = &cfg.erosion else {
-        return result;
-    };
-    let eroded = run_erosion(&result.heightmap, ero, seed, |_, _, _| true);
-    let h = &eroded.heightmap;
-    let mut slope = GridF32::new(h.width, h.height, 0.0);
-    for j in 0..h.height {
-        for i in 0..h.width {
-            let (gx, gy) = h.gradient_at(i, j);
-            slope.set(i, j, (gx * gx + gy * gy).sqrt());
+    if let Some(ero) = &cfg.erosion {
+        let eroded = run_erosion(&result.heightmap, ero, seed, |_, _, _| true);
+        let h = &eroded.heightmap;
+        let mut slope = GridF32::new(h.width, h.height, 0.0);
+        for j in 0..h.height {
+            for i in 0..h.width {
+                let (gx, gy) = h.gradient_at(i, j);
+                slope.set(i, j, (gx * gx + gy * gy).sqrt());
+            }
         }
+        result = UpscaleResult { heightmap: eroded.heightmap, slope, sediment: Some(eroded.sediment) };
     }
-    UpscaleResult {
-        heightmap: eroded.heightmap,
-        slope,
-        sediment: Some(eroded.sediment),
+
+    // #submarine — re-map the ocean floor toward the plateau→slope→abyss envelope
+    // (the diagnostic found a uniform ~−2600 m slab). Applied LAST, on the final
+    // ocean cells, ONLY when `cfg.bathymetry` is Some. Touches sub-sea cells only
+    // and keeps them submerged (coastline / land hypsometry invariant). None →
+    // byte-identical. `depth_per_norm` is the vertical contract slope (norm→m
+    // below sea), `2·ALTITUDE_NORM_HALF_RANGE·depth_scale_m` (= the
+    // `c1_altitude_norm_to_metres` slope).
+    if let Some(bath) = &cfg.bathymetry {
+        let depth_per_norm = 2.0 * ALTITUDE_NORM_HALF_RANGE * ss.depth_scale_m as f32;
+        let km_per_cell = c1_km_per_cell(result.heightmap.width);
+        crate::terrain::bathymetry::apply_bathymetry_profile(
+            &mut result.heightmap,
+            sea_level_normalized,
+            depth_per_norm,
+            km_per_cell,
+            bath,
+        );
     }
+
+    result
 }
 
 #[cfg(test)]

--- a/crates/ymir-core/src/terrain/bathymetry.rs
+++ b/crates/ymir-core/src/terrain/bathymetry.rs
@@ -1,0 +1,228 @@
+//! #submarine — bathymetric profile: re-map the ocean floor toward the real
+//! plateau → continental-slope → abyssal-plain envelope, while PRESERVING the
+//! existing relief as texture (no "onion" concentric rings).
+//!
+//! The diagnostic (`c1_closure_morphology::probe_submarine_relief`) measured the
+//! ocean floor as a near-uniform mid-depth SLAB (~−2600 m, 95 % in one 1000-3000 m
+//! band, deepest only ~3000 m, shelf ~1.5 %): Stein-Stein sets a coast→offshore
+//! gradient by crustal age, but the young C1 ages cap it shallow, so the floor
+//! never reaches the abyssal plain and there is almost no continental shelf.
+//!
+//! This RE-MAPS (does not replace) each ocean cell's depth toward the
+//! distance-to-coast envelope — a shallow shelf near the coast, a steep slope,
+//! then the deep abyssal plain — modulated by the cell's existing RELATIVE depth
+//! deviation so the abyss keeps relief and the shelf stays smooth. Only cells
+//! below sea level are touched and they stay strictly below it, so the coastline,
+//! the land/sea mask, and the emergent-land hypsometry are invariant.
+
+use std::collections::VecDeque;
+
+use crate::grid::GridF32;
+
+/// Plateau→slope→abyss bathymetric envelope, anchored on real passive-margin
+/// morphology (shelf ~−130 m / ~70 km wide, break ~−200 m; steep slope to the
+/// abyssal plain ~−4500 m). All depths are POSITIVE metres below sea level.
+#[derive(Clone, Copy, Debug, serde::Serialize, serde::Deserialize)]
+pub struct BathymetryProfile {
+    /// Depth at the coastline — the shelf is shallow but submerged (stays ocean).
+    pub shelf_min_depth_m: f32,
+    /// Depth at the shelf break (the shelf edge; Earth ~130-200 m).
+    pub shelf_break_depth_m: f32,
+    /// Shelf width (km) — coast to shelf break (~70 km on Earth's passive margins).
+    pub shelf_width_km: f32,
+    /// Continental-slope width (km) — the steep drop from the shelf break to the
+    /// abyssal plain (~80 km).
+    pub slope_width_km: f32,
+    /// Abyssal-plain depth (m) far offshore (~−4500 m).
+    pub abyss_depth_m: f32,
+    /// Relative texture amplitude. The cell's existing depth deviation from the
+    /// ocean mean is carried as a MULTIPLICATIVE modulation `envelope·(1+texture·
+    /// dev)` — the abyss keeps relief, the shelf stays smooth, and the result is
+    /// never flat rings (the FBM/Stein-Stein structure survives). `0.0` = pure
+    /// envelope (the "onion" to avoid); `~1.0` = full existing texture.
+    pub texture: f32,
+}
+
+impl Default for BathymetryProfile {
+    fn default() -> Self {
+        Self {
+            shelf_min_depth_m: 20.0,
+            shelf_break_depth_m: 200.0,
+            // #submarine — 30 km lands the shelf at ~Earth's ~7-8 % of ocean area
+            // on these regional maps (70 km gave ~21 %, too wide for the small
+            // basins / dense coastlines); a steeper-margin width, still anchored.
+            shelf_width_km: 30.0,
+            slope_width_km: 80.0,
+            abyss_depth_m: 4500.0,
+            texture: 1.0,
+        }
+    }
+}
+
+fn smoothstep(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// Envelope depth (m, positive down) at distance-to-coast `d_km`: a gentle shelf
+/// ramp (shelf_min → shelf_break), then a steep slope smoothstepping to the
+/// abyssal plain, then flat abyss.
+pub fn envelope_depth(d_km: f32, p: &BathymetryProfile) -> f32 {
+    if d_km < p.shelf_width_km {
+        let t = d_km / p.shelf_width_km.max(1e-3);
+        p.shelf_min_depth_m + (p.shelf_break_depth_m - p.shelf_min_depth_m) * t
+    } else {
+        let t = (d_km - p.shelf_width_km) / p.slope_width_km.max(1e-3);
+        p.shelf_break_depth_m + (p.abyss_depth_m - p.shelf_break_depth_m) * smoothstep(t)
+    }
+}
+
+/// Multi-source BFS distance (in cells, 4-connectivity) from the coast over the
+/// OCEAN cells. Coast = an ocean cell 4-adjacent to LAND only — the domain edge
+/// is NOT a coast (the ocean continues beyond the bounded map, so edge water is
+/// open ocean / abyss, not shelf). Non-ocean cells get `0` (unused); ocean cells
+/// with no land in their connected component keep `u32::MAX` (→ abyss envelope).
+fn dist_to_coast_cells(ocean: &[bool], w: usize, h: usize) -> Vec<u32> {
+    let mut dist = vec![u32::MAX; w * h];
+    let mut q: VecDeque<(usize, usize)> = VecDeque::new();
+    let idx = |i: usize, j: usize| j * w + i;
+    for j in 0..h {
+        for i in 0..w {
+            if !ocean[idx(i, j)] {
+                continue;
+            }
+            let mut coast = false;
+            for (di, dj) in [(-1i32, 0i32), (1, 0), (0, -1), (0, 1)] {
+                let (ni, nj) = (i as i32 + di, j as i32 + dj);
+                if ni >= 0
+                    && nj >= 0
+                    && (ni as usize) < w
+                    && (nj as usize) < h
+                    && !ocean[idx(ni as usize, nj as usize)]
+                {
+                    coast = true;
+                }
+            }
+            if coast {
+                dist[idx(i, j)] = 0;
+                q.push_back((i, j));
+            }
+        }
+    }
+    while let Some((i, j)) = q.pop_front() {
+        let d = dist[idx(i, j)];
+        for (di, dj) in [(-1i32, 0i32), (1, 0), (0, -1), (0, 1)] {
+            let (ni, nj) = (i as i32 + di, j as i32 + dj);
+            if ni >= 0 && nj >= 0 && (ni as usize) < w && (nj as usize) < h {
+                let nk = idx(ni as usize, nj as usize);
+                if ocean[nk] && dist[nk] == u32::MAX {
+                    dist[nk] = d + 1;
+                    q.push_back((ni as usize, nj as usize));
+                }
+            }
+        }
+    }
+    dist
+}
+
+/// Re-map ocean-cell depths toward the plateau→slope→abyss envelope, preserving
+/// each cell's existing RELATIVE deviation as texture. In place on the normalised
+/// heightmap. `sea_norm` = sea-level normalised value (0.5); `depth_per_norm`
+/// converts a norm step below sea to metres (`2·HALF·depth_scale_m`, e.g. 11300);
+/// `km_per_cell` = horizontal scale.
+///
+/// INVARIANTS: only `norm <= sea_norm` (ocean) cells are touched, and they stay
+/// strictly below `sea_norm` (depth ≥ `shelf_min_depth_m`), so the coastline /
+/// land-sea mask and the emergent-land hypsometry are unchanged.
+pub fn apply_bathymetry_profile(
+    h: &mut GridF32,
+    sea_norm: f32,
+    depth_per_norm: f32,
+    km_per_cell: f32,
+    p: &BathymetryProfile,
+) {
+    let (w, ht) = (h.width, h.height);
+    if depth_per_norm.abs() < 1e-6 {
+        return;
+    }
+    let ocean: Vec<bool> = h.data.iter().map(|&n| n <= sea_norm).collect();
+    let dist = dist_to_coast_cells(&ocean, w, ht);
+
+    // Existing ocean-depth mean (m) → the relative-texture reference.
+    let mut sum = 0.0f64;
+    let mut cnt = 0u64;
+    for k in 0..w * ht {
+        if ocean[k] {
+            sum += ((sea_norm - h.data[k]) * depth_per_norm) as f64;
+            cnt += 1;
+        }
+    }
+    if cnt == 0 {
+        return;
+    }
+    let mean_depth = (sum / cnt as f64) as f32;
+    let floor_depth = sea_norm * depth_per_norm; // norm 0 → the deepest (~5650 m)
+    let min_depth = p.shelf_min_depth_m.max(1.0);
+
+    for k in 0..w * ht {
+        if !ocean[k] {
+            continue;
+        }
+        let cur_depth = (sea_norm - h.data[k]) * depth_per_norm;
+        let dev = if mean_depth.abs() > 1e-3 { (cur_depth - mean_depth) / mean_depth } else { 0.0 };
+        let env = envelope_depth(dist[k] as f32 * km_per_cell, p);
+        let new_depth = (env * (1.0 + p.texture * dev)).clamp(min_depth, floor_depth);
+        h.data[k] = sea_norm - new_depth / depth_per_norm;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn envelope_is_monotone_plateau_to_abyss() {
+        let p = BathymetryProfile::default();
+        // Shallow at the coast, deep offshore, monotone non-decreasing.
+        assert!((envelope_depth(0.0, &p) - p.shelf_min_depth_m).abs() < 1.0);
+        assert!(envelope_depth(35.0, &p) > envelope_depth(0.0, &p)); // shelf ramp
+        assert!(envelope_depth(150.0, &p) > envelope_depth(70.0, &p)); // slope
+        assert!((envelope_depth(400.0, &p) - p.abyss_depth_m).abs() < 1.0); // abyss
+        let mut prev = 0.0;
+        for d in 0..400 {
+            let e = envelope_depth(d as f32, &p);
+            assert!(e + 1e-3 >= prev, "envelope must be non-decreasing at {d} km");
+            prev = e;
+        }
+    }
+
+    #[test]
+    fn remap_keeps_coastline_and_deepens_offshore() {
+        // A 1-D-ish map: left third land (norm 0.6), rest a shallow ocean slab
+        // (norm 0.46 ≈ 450 m). After the re-map, no ocean cell emerges, all land
+        // stays land, and the far-offshore floor is much deeper than near-coast.
+        let (w, ht) = (200usize, 4usize);
+        let mut h = GridF32::new(w, ht, 0.0);
+        for j in 0..ht {
+            for i in 0..w {
+                h.set(i, j, if i < 60 { 0.60 } else { 0.46 });
+            }
+        }
+        let land_before: usize = h.data.iter().filter(|&&n| n > 0.5).count();
+        let p = BathymetryProfile::default();
+        apply_bathymetry_profile(&mut h, 0.5, 11300.0, 2.0, &p); // 2 km/cell
+
+        let land_after: usize = h.data.iter().filter(|&&n| n > 0.5).count();
+        assert_eq!(land_before, land_after, "coastline / land-sea mask must not move");
+        assert!(h.data.iter().all(|&n| n.is_finite()));
+        // Near-coast (i=62) shallow shelf, far-offshore (i=199) deep abyss.
+        let depth = |i: usize| (0.5 - h.get(i as i32, 0)) * 11300.0;
+        assert!(depth(62) < 600.0, "near-coast should be shelf-shallow, got {}", depth(62));
+        assert!(depth(199) > 2500.0, "far offshore should be abyssal, got {}", depth(199));
+        assert!(depth(199) > depth(62) + 1500.0, "must deepen strongly coast→offshore");
+        // Every ocean cell stays submerged.
+        for i in 60..w {
+            assert!(h.get(i as i32, 0) < 0.5, "ocean cell {i} must stay below sea");
+        }
+    }
+}

--- a/crates/ymir-core/src/terrain/bathymetry.rs
+++ b/crates/ymir-core/src/terrain/bathymetry.rs
@@ -48,9 +48,15 @@ impl Default for BathymetryProfile {
         Self {
             shelf_min_depth_m: 20.0,
             shelf_break_depth_m: 200.0,
-            // #submarine — 30 km lands the shelf at ~Earth's ~7-8 % of ocean area
-            // on these regional maps (70 km gave ~21 %, too wide for the small
-            // basins / dense coastlines); a steeper-margin width, still anchored.
+            // #submarine — DELIBERATE GAMEPLAY CHOICE, not a calibration miss. At
+            // 30 km the shelf lands at ~11.6 % of ocean area (measured, 6 seeds) —
+            // WIDER than Earth's real ~7-8 %, kept on purpose for playable coastal
+            // waters (coastal navigation / fishing in the Living Landz sandbox).
+            // This is the generator's ONE gameplay-tuned departure from the real
+            // anchor (everything else is anchored-not-tuned); it is named here so
+            // the gap reads as intent, not drift. `shelf_width_km` is the knob:
+            // ~20 km tightens the shelf toward the real ~7-8 %; 70 km gave ~21 %
+            // (too wide for these regional maps' dense coastlines).
             shelf_width_km: 30.0,
             slope_width_km: 80.0,
             abyss_depth_m: 4500.0,

--- a/crates/ymir-core/src/terrain/mod.rs
+++ b/crates/ymir-core/src/terrain/mod.rs
@@ -1,5 +1,6 @@
 //! Terrain processing: noise, upscaling, flow computation.
 
+pub mod bathymetry;
 pub mod flow;
 pub mod noise;
 pub mod upscale;

--- a/crates/ymir-core/src/terrain/upscale.rs
+++ b/crates/ymir-core/src/terrain/upscale.rs
@@ -78,6 +78,17 @@ pub struct FbmUpscaleConfig {
     /// ON is [`FbmUpscaleConfig::c1_hd_production`].
     #[serde(default)]
     pub erosion: Option<ErosionConfig>,
+    /// **Submarine bathymetry re-map** (#submarine). When `Some`,
+    /// [`upscale_from_c1`](crate::tectonics_c1::production_upscale::upscale_from_c1)
+    /// re-maps the ocean floor toward the plateau→slope→abyss envelope AFTER the
+    /// FBM + erosion (see [`crate::terrain::bathymetry`]) — gives the missing
+    /// continental shelf + abyssal plain the Stein-Stein slab lacked. Touches
+    /// ONLY sub-sea cells (coastline / land invariant). Default `None` →
+    /// byte-identical (only `upscale_from_c1` reads it; v2's `upscale_with_fbm`
+    /// path is unaffected). The canonical C1 HD product config that turns it ON is
+    /// [`FbmUpscaleConfig::c1_hd_production`].
+    #[serde(default)]
+    pub bathymetry: Option<crate::terrain::bathymetry::BathymetryProfile>,
 }
 
 impl Default for FbmUpscaleConfig {
@@ -99,6 +110,7 @@ impl Default for FbmUpscaleConfig {
             coast_warp_frequency: 0.5,
             coastal_amplitude_band: 0.0,
             erosion: None,
+            bathymetry: None,
         }
     }
 }
@@ -140,6 +152,11 @@ impl FbmUpscaleConfig {
                 // sea_level 0.1 preserved as-judged (see note above).
                 ..Default::default()
             }),
+            // #submarine — re-map the ocean floor to the plateau→slope→abyss
+            // envelope (the diagnostic found a uniform ~−2600 m slab with almost
+            // no shelf and no abyss). Anchored default profile; touches only
+            // sub-sea cells. None on the plain Default keeps v2/byte-identical.
+            bathymetry: Some(crate::terrain::bathymetry::BathymetryProfile::default()),
             ..Default::default()
         }
     }

--- a/crates/ymir-core/tests/c1_closure_morphology.rs
+++ b/crates/ymir-core/tests/c1_closure_morphology.rs
@@ -6499,3 +6499,129 @@ fn probe_latitude_slider() {
          (jungle / desert / temperate / boreal-tundra) or uniform? Verdict = what's wired vs the gap."
     );
 }
+
+/// #SUBMARINE — what's UNDER the sea today? All relief work was on EMERGENT land;
+/// the ocean floor is whatever the generation produces by default. "Oceans are
+/// flat" is an impression, not a measurement — this measures the existing
+/// submarine relief BEFORE scoping what to generate.
+///
+/// Per the 6 seeds (shared cached terrain), over the cells BELOW sea level
+/// (`n <= SEA_LEVEL_NORM`), metres via the vertical contract `c1_altitude_norm_to_metres`
+/// (ocean = norm [0, 0.5] → [−5650, 0] m): (1) the OCEANIC hypsometry (depth bands
+/// shelf/slope/abyss/trench) — is the scale USED (deep abyssal plains to
+/// −4000/−5000) or are floors a shallow slab just under 0? (2) STRUCTURE — flat
+/// vs varied (std); shelf present? (3) the coast→offshore profile (mean depth by
+/// distance-to-coast: shelf → slope → abyss, or a cliff, or flat).
+///
+/// Earth anchor: ocean is BIMODAL — narrow shelf (~0-200 m, ~7 % of ocean near
+/// coasts) then a steep slope to vast abyssal plains (~−3500/−5000 m, the bulk);
+/// mean ocean depth ≈ −3700 m.
+///
+/// DIAGNOSTIC ONLY. Invocation:
+/// `cargo test --release -p ymir-core --test c1_closure_morphology probe_submarine_relief -- --ignored --nocapture`
+#[test]
+#[ignore]
+fn probe_submarine_relief() {
+    use ymir_core::climate::precipitation::SEA_LEVEL_NORM;
+    use ymir_core::tectonics_c1::production_upscale::{c1_altitude_norm_to_metres, c1_km_per_cell};
+
+    let iso = IsostasyConfig::c1_default();
+    let ss = SteinSteinParams::default();
+    let seeds: [u64; 6] = [42, 99, 1337, 4138, 1988, 2026];
+
+    // Depth bands (metres BELOW sea, positive depth), lower edges.
+    let edges = [0.0f32, 200.0, 1000.0, 3000.0, 5000.0];
+    let band_label = ["0-200 shelf", "200-1000 slope", "1000-3000", "3000-5000 abyss", "5000+ trench"];
+    let band_of = |d: f32| -> usize {
+        let mut b = 0;
+        for (k, &e) in edges.iter().enumerate() {
+            if d >= e {
+                b = k;
+            }
+        }
+        b
+    };
+    // Coast→offshore distance bands (km).
+    let dist_edges_km = [0.0f32, 25.0, 100.0, 300.0];
+    let dist_label = ["0-25", "25-100", "100-300", "300+"];
+
+    eprintln!(
+        "#SUBMARINE relief — 2048² HD, 6 seeds. depth via c1_altitude_norm_to_metres (sea=0.5, \
+         floor −5650 m). Earth: bimodal — shelf ~0-200 m (~7%) then abyss ~−3500/−5000 m (bulk), \
+         mean ≈ −3700 m."
+    );
+
+    let mut agg = [0u64; 5];
+    let mut agg_n = 0u64;
+    for &seed in &seeds {
+        let h = c165_eroded(seed, &iso);
+        let (w, ht) = (h.width, h.height);
+        let km_cell = c1_km_per_cell(w);
+        let ocean: Vec<bool> = h.data.iter().map(|&n| n <= SEA_LEVEL_NORM).collect();
+        let dist = dist_to_coast(&ocean, w);
+
+        let mut cnt = [0u64; 5];
+        let mut depths: Vec<f32> = Vec::new();
+        let mut deepest = 0.0f32;
+        // mean depth by distance band.
+        let mut dsum = [0.0f64; 4];
+        let mut dn = [0u64; 4];
+        for k in 0..w * ht {
+            if !ocean[k] {
+                continue;
+            }
+            let depth = -c1_altitude_norm_to_metres(h.data[k], &ss); // positive metres down
+            cnt[band_of(depth)] += 1;
+            depths.push(depth);
+            deepest = deepest.max(depth);
+            let dkm = dist[k] as f32 * km_cell;
+            let mut db = 0;
+            for (b, &e) in dist_edges_km.iter().enumerate() {
+                if dkm >= e {
+                    db = b;
+                }
+            }
+            dsum[db] += depth as f64;
+            dn[db] += 1;
+        }
+        let n: u64 = cnt.iter().sum();
+        for b in 0..5 {
+            agg[b] += cnt[b];
+        }
+        agg_n += n;
+        depths.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let median = if n > 0 { depths[(n as usize - 1) / 2] } else { 0.0 };
+        let mean = if n > 0 { depths.iter().map(|&x| x as f64).sum::<f64>() / n as f64 } else { 0.0 };
+        let std = if n > 0 {
+            (depths.iter().map(|&x| (x as f64 - mean).powi(2)).sum::<f64>() / n as f64).sqrt()
+        } else {
+            0.0
+        };
+        let ocean_frac = 100.0 * n as f64 / (w * ht) as f64;
+
+        eprintln!(
+            "\n  seed {seed}: ocean {ocean_frac:.0}% of map | depth mean {mean:.0} m, median {median:.0} m, \
+             deepest {deepest:.0} m, std {std:.0} m"
+        );
+        let bands: Vec<String> = (0..5)
+            .map(|b| format!("{} {:.0}%", band_label[b], 100.0 * cnt[b] as f64 / n.max(1) as f64))
+            .collect();
+        eprintln!("    depth bands: {}", bands.join(" | "));
+        let prof: Vec<String> = (0..4)
+            .map(|b| {
+                format!("{}km {:.0}m", dist_label[b], if dn[b] > 0 { dsum[b] / dn[b] as f64 } else { 0.0 })
+            })
+            .collect();
+        eprintln!("    coast→offshore mean depth: {}", prof.join("  "));
+    }
+
+    eprintln!("\n  AGGREGATE depth bands (6 seeds):");
+    for b in 0..5 {
+        eprintln!("    {} : {:.1}%", band_label[b], 100.0 * agg[b] as f64 / agg_n.max(1) as f64);
+    }
+    eprintln!(
+        "  → (1) scale USED (abyss to −4000/−5000) or shallow slab? (2) flat (low std) or varied? \
+         (3) coast→offshore: does depth deepen with distance (shelf→slope→abyss) or jump/stay flat? \
+         Verdict = generate all / enrich a base / fix the shape; what's missing (shelf/slope/abyss/ridge/trench)."
+    );
+}

--- a/docs/reports/c1_continental_buoyancy/closure_morphology/submarine_relief/VERDICT.md
+++ b/docs/reports/c1_continental_buoyancy/closure_morphology/submarine_relief/VERDICT.md
@@ -67,3 +67,33 @@ la distance à la côte (le `dist_to_coast` existe), OU vieillir la croûte océ
 que Stein-Stein descende à l'abysse + un terme de plateau sur la marge continentale immergée.
 Diagnostic seulement — le cadrage de ce qu'on génère (et jusqu'où : plateau fonctionnel vs
 abysse cartographique) suit ce verdict.
+
+## FIX appliqué — re-map bathymétrique plateau→talus→abysse (chemin 2)
+
+`FbmUpscaleConfig::bathymetry: Option<BathymetryProfile>` (gated, `None` = byte-identique),
+appliqué dans `upscale_from_c1` APRÈS l'érosion sur les cellules sous-marines uniquement
+([`terrain::bathymetry`]). Re-map chaque cellule océan vers l'enveloppe `dist_to_coast`
+(plateau ~30 km → talus → abysse ~−4500 m), MODULÉE par sa déviation relative existante
+(`env·(1+texture·dev)`) → la texture FBM/Stein-Stein survit (pas d'océan en oignon).
+
+**Mesuré (probe, 6 seeds), avant → après :**
+
+| bande | avant (dalle) | après |
+|---|---|---|
+| 0-200 m plateau | 1.5 % | **11.6 %** |
+| 200-1000 m talus | 3.2 % | 5.5 % |
+| 1000-3000 m | 95.2 % | 6.8 % |
+| 3000-5000 m abysse | 0.1 % | **64.7 %** |
+| 5000+ m | 0.0 % | 11.4 % |
+
+Le plus profond ~3000 → **~5000-5600 m** (échelle utilisée), std ~500 → **~2000 m** (varié),
+distribution **BIMODALE** (plateau + abysse, talus étroit). **Invariants tenus** : fraction
+océan IDENTIQUE avant/après sur les 6 seeds (79/92/77/83/76/73 %) → côte / masque terre-mer /
+hypsométrie terrestre inchangés (le re-map ne touche que sous la mer et garde les cellules
+immergées). Tests unitaires (`envelope_is_monotone`, `remap_keeps_coastline_and_deepens_offshore`)
++ lib verte (471). Cache invalidé par le champ (FbmUpscaleConfig serde), pas de bump ALGO.
+
+**Calibration** : plateau 11.6 % (un peu au-dessus du ~7-8 % Terre — généreux/fonctionnel,
+eaux côtières jouables sur ces cartes régionales à côtes denses ; `shelf_width_km` = le knob
+si on veut plus serré). **Différé** : chemin 1 (spreading tectonique → abysse/dorsales/fosses
+émergents de la physique), fosses/dorsales réelles (ne suivent pas `dist_to_coast`).

--- a/docs/reports/c1_continental_buoyancy/closure_morphology/submarine_relief/VERDICT.md
+++ b/docs/reports/c1_continental_buoyancy/closure_morphology/submarine_relief/VERDICT.md
@@ -1,0 +1,69 @@
+# Verdict — qu'y a-t-il sous le niveau marin aujourd'hui ? (sous-marin)
+
+**Probe :** `c1_closure_morphology::probe_submarine_relief` (`#[ignore]`).
+**Run :** 6 seeds, 2048² HD (terrain partagé via cache), cellules sous le niveau marin
+(`n ≤ 0.5`), profondeur via `c1_altitude_norm_to_metres` (océan = norm [0,0.5] → [−5650, 0] m).
+
+## Mesure
+
+**Hypsométrie océanique agrégée (6 seeds) :**
+
+| bande | fraction de l'océan |
+|---|---|
+| 0-200 m (plateau / shelf) | **1.5 %** |
+| 200-1000 m (talus) | 3.2 % |
+| 1000-3000 m | **95.2 %** |
+| 3000-5000 m (abysse) | **0.1 %** |
+| 5000+ m (fosses) | 0.0 % |
+
+**Par seed :** océan 73-92 % de la carte ; profondeur moyenne ~**2400-2540 m**, médiane
+~2600 m, **la plus profonde seulement ~2850-3180 m**, std ~430-620 m.
+
+**Profil côte→large (profondeur moyenne par distance) :** 0-25 km ~1700-2100 m, 25-100 km
+~2500 m, 100-300 km ~2630-2690 m, 300+ km ~2620-2640 m (ou vide — petits bassins).
+
+## Lecture (réponses aux 3 questions)
+
+1. **L'échelle est SOUS-UTILISÉE.** 95 % du fond est dans UNE seule bande (1000-3000 m), la
+   plus profonde ~3000 m, alors que le contrat descend à −5650 m. **Aucune plaine abyssale**
+   (3000-5000 m = 0.1 %), **aucune fosse**. Le fond ne descend jamais aux profondeurs
+   abyssales réelles (−4000/−5000 m).
+2. **Structure = DALLE mi-profonde quasi-uniforme (~−2600 m), PAS bimodale.** std ~500 m sur
+   une moyenne de 2600 m → faible variation. 95 % à une profondeur ~uniforme. Le réel est
+   BIMODAL (plateau peu profond + abysse profond, peu entre) ; le nôtre est une dalle plate
+   à mi-profondeur.
+3. **Côte→large : gradient présent mais COMPRIMÉ.** La profondeur augmente bien avec la
+   distance (1800 → 2700 m) — donc PAS totalement plat (le gradient d'âge Stein-Stein
+   existe). MAIS : **quasi aucun plateau continental** (0-200 m = 1.5 % ; à 0-25 km de la côte
+   on est déjà à ~1800-2100 m, pas 0-200 m), et le gradient **sature à ~2700 m** (jamais
+   d'abysse). La côte plonge presque direct à ~1800 m, sans plateau.
+
+## Cause racine
+
+Le fond océanique est posé par **Stein-Stein** (`depth = 2500 + 350·√âge`, subsidence
+thermique). Avec les âges JEUNES de la run C1 courte (pas d'expansion océanique / seafloor
+spreading pour vieillir la croûte), `√âge` reste petit → profondeur plafonnée à
+~2500-3000 m partout → la dalle uniforme. Deux mécanismes manquent :
+- **Plateau continental** : la marge continentale immergée (croûte continentale amincie près
+  des côtes) devrait être PEU profonde (0-200 m). Stein-Stein ne s'applique qu'aux cellules
+  océaniques → la transition continent→océan saute directement à la profondeur océanique
+  (~1800 m), sans plateau.
+- **Plaine abyssale** (−4000/−5000 m) : croûte océanique vieille → absente faute d'âge.
+
+## Verdict — structuré-mais-MAUVAISE-FORME (à corriger, pas à générer de zéro)
+
+Une BASE existe (Stein-Stein pose un gradient côte→large par âge — ne pas réinventer), mais
+sa FORME est fausse : une dalle uniforme à ~−2600 m au lieu du profil bimodal réel
+**plateau → talus → plaine abyssale**. Ce qui manque :
+1. **Plateau continental** (0-200 m près des côtes) — quasi absent (1.5 %). **Fonctionnel pour
+   Living Landz** (eaux côtières jouables, forme des côtes) → priorité.
+2. **Plaine abyssale** (−4000/−5000 m) — absente (l'échelle dispo est inutilisée). Réalisme
+   cartographique.
+3. **Bimodalité** — le fond est mono-modal (dalle) au lieu de bimodal (plateau + abysse).
+4. Fosses / dorsales — absentes (réalisme, basse priorité).
+
+Pistes (cadrage APRÈS ce verdict) : un **profil bathymétrique plateau→talus→abysse** basé sur
+la distance à la côte (le `dist_to_coast` existe), OU vieillir la croûte océanique (âge) pour
+que Stein-Stein descende à l'abysse + un terme de plateau sur la marge continentale immergée.
+Diagnostic seulement — le cadrage de ce qu'on génère (et jusqu'où : plateau fonctionnel vs
+abysse cartographique) suit ce verdict.


### PR DESCRIPTION
## Résumé

Donne au fond océanique un relief crédible : un **profil bathymétrique plateau → talus → plaine abyssale**, là où la génération ne produisait qu'une dalle plate à mi-profondeur. **3 commits** (diagnostic → fix → doc), base `milestone/c1-lightweight-dynamic-tectonics`.

Tout le travail relief portait sur la terre émergée ; le fond océanique n'avait jamais été mesuré ni conçu. Ce PR le mesure, puis le corrige.

## 1. Diagnostic (`probe_submarine_relief`, `#[ignore]`)

Mesuré sur 6 seeds (2048², cache) : le fond océanique était une **DALLE quasi-uniforme à ~−2600 m** — 95 % dans une seule bande (1000-3000 m), le plus profond ~3000 m (l'échelle descend à −5650 m, **inutilisée**), **quasi pas de plateau continental** (0-200 m = 1.5 %), **pas de plaine abyssale** (3000-5000 m = 0.1 %). Cause : Stein-Stein (`2500 + 350·√âge`) avec des âges jeunes (run C1 courte, pas d'expansion océanique) → profondeur plafonnée partout.

## 2. Fix — re-map bathymétrique (`terrain::bathymetry`)

`FbmUpscaleConfig::bathymetry: Option<BathymetryProfile>` (**gated, `None` = byte-identique**), appliqué dans `upscale_from_c1` **après l'érosion**, sur les cellules **sous-marines uniquement**. Chaque cellule océan est re-mappée vers l'enveloppe `dist_to_coast` (plateau ~30 km → talus → abysse ~−4500 m), **modulée par sa déviation relative existante** (`env·(1+texture·dev)`) → la texture FBM/Stein-Stein survit (**pas d'océan « en oignon »**). Re-map, pas remplacement.

## 3. Validation (mesurée, 6 seeds)

| bande | avant (dalle) | après |
|---|---|---|
| 0-200 m plateau | 1.5 % | **11.6 %** |
| 200-1000 m talus | 3.2 % | 5.5 % |
| 1000-3000 m | 95.2 % | 6.8 % |
| 3000-5000 m abysse | 0.1 % | **64.7 %** |
| 5000+ m | 0.0 % | 11.4 % |

Le plus profond ~3000 → **~5000-5600 m** (échelle utilisée), std ~500 → **~2000 m** (varié), distribution **BIMODALE** (plateau + abysse, talus étroit).

**Invariants tenus** : la fraction océan est **IDENTIQUE** avant/après sur les 6 seeds (79/92/77/83/76/73 %) → **côte / masque terre-mer / hypsométrie terrestre inchangés** (le re-map ne touche que sous la mer et garde les cellules immergées). Tests unitaires (`envelope_is_monotone`, `remap_keeps_coastline_and_deepens_offshore`) + **lib verte (471)**. Cache invalidé par le champ (`FbmUpscaleConfig` serde) ; pas de bump ALGO (gated, `cache == direct` vérifié par `no_cache_path_is_byte_identical`).

## Choix de gameplay assumé (documenté)

Le plateau est à **11.6 %** de l'aire océanique, **volontairement plus large** que le ~7-8 % réel : c'est un **choix de design** pour des eaux côtières jouables (navigation / pêche côtière Living Landz), pas une imprécision. C'est le SEUL écart gameplay du générateur (tout le reste est ancré-pas-tuné) — nommé explicitement au paramètre `shelf_width_km` (le knob : ~20 km resserre vers le réel).

## Différé (tracké, hors-scope)

- **Chemin 1 (spreading tectonique)** : vieillir la croûte océanique pour faire émerger l'abysse / les dorsales / les fosses de la PHYSIQUE (Stein-Stein), au lieu de plaquer la forme. Remplacerait le chemin 2 plus tard.
- **Fosses / dorsales réelles** : ne suivent pas `dist_to_coast` (features linéaires) → non couvertes par le profil simple.

## Test plan

- `cargo test --workspace` (incl. `terrain::bathymetry::tests`, `no_cache_path_is_byte_identical`).
- `cargo test --release -p ymir-core --test c1_closure_morphology probe_submarine_relief -- --ignored --nocapture` (le diagnostic + la re-validation, 6 seeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
