### PR TITLE
Extend the C1 worker to the full HD pipeline — cache + progress (UI rewrite — step b/5)

### DIFF
--- a/crates/ymir-viz/src/bridge/c1/commands.rs
+++ b/crates/ymir-viz/src/bridge/c1/commands.rs
@@ -23,6 +23,7 @@
 
 use ymir_core::tectonics_v2::workflow::PhaseAParams;
 
+use super::hd::HdParams;
 use super::spec::C1RunSpec;
 
 #[derive(Clone, Debug)]
@@ -46,6 +47,12 @@ pub enum C1Command {
         spec: C1RunSpec,
         phase_a: PhaseAParams,
     },
+    /// Launch the HD production chain (UI rewrite step b/5): tectonics →
+    /// upscale → erosion → bathymetry → drainage → climate → biomes, via
+    /// the cached `ymir-core` production functions, on the worker thread.
+    /// Emits `HdStarted → (HdPhaseStarted → HdPhaseDone) × 4 → HdCompleted`
+    /// (or `HdFailed`). Cancellable between phases.
+    RunHd { spec: C1RunSpec, params: HdParams },
     /// Set the shared cancel flag. Does NOT interrupt the
     /// current run — see module docstring.
     Cancel,

--- a/crates/ymir-viz/src/bridge/c1/events.rs
+++ b/crates/ymir-viz/src/bridge/c1/events.rs
@@ -25,10 +25,12 @@
 //! pausing the simulation. This is the intended "tight backpressure
 //! = pause semantics" behaviour (W1 of Stage E2).
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use ymir_core::tectonics_v2::workflow::PhaseAParams;
 
+use super::hd::{CacheRegime, HdParams, HdPhase, HdResult};
 use super::snapshot::C1Snapshot;
 use super::spec::C1RunSpec;
 
@@ -81,4 +83,21 @@ pub enum C1Event {
     /// Unreachable at MVP (Q-E1.2). Reserved for future panic
     /// catch or NaN detection paths.
     Failed { error: String },
+
+    // ── HD pipeline (UI rewrite step b/5) ──────────────────────────
+    /// The HD production chain (eroded → climate → drainage → biomes)
+    /// is about to start on the worker.
+    HdStarted { spec: C1RunSpec, params: HdParams },
+    /// An HD phase has begun (UI shows an indeterminate waiter — every
+    /// HD phase is an opaque block, no N/total).
+    HdPhaseStarted { phase: HdPhase },
+    /// An HD phase finished; `regime` says HIT (from cache) / MISS
+    /// (computed) / Computed (uncached cheap phase), `elapsed` its wall
+    /// time.
+    HdPhaseDone { phase: HdPhase, regime: CacheRegime, elapsed: Duration },
+    /// The HD chain completed; `result` carries the full product (Arc so
+    /// the event stays `Clone` without `C1DrainageResult: Clone`).
+    HdCompleted { result: Arc<HdResult>, elapsed: Duration },
+    /// The HD chain failed (core error) or was cancelled between phases.
+    HdFailed { error: String },
 }

--- a/crates/ymir-viz/src/bridge/c1/hd.rs
+++ b/crates/ymir-viz/src/bridge/c1/hd.rs
@@ -1,0 +1,302 @@
+//! HD production pipeline driven on the C1 worker thread (UI rewrite
+//! step b/5 — the foundation).
+//!
+//! The coarse tectonic loop (`RunBaseline` / `RunWorkflow`) renders the
+//! live 64² S̃/age/plate/craton fields. This module drives the FULL HD
+//! production chain — the same `ymir-core` functions the production /
+//! test pipelines use — on the background worker:
+//!
+//! ```text
+//!   eroded  (tectonics → upscale → erosion → bathymetry, CACHED)
+//!   climate (temperature + precipitation, computed)
+//!   drainage (rivers + lakes + water balance, CACHED)
+//!   biomes  (Whittaker classification, computed)
+//! ```
+//!
+//! Each phase emits `HdPhaseStarted` → `HdPhaseDone { regime, elapsed }`
+//! events (see [`super::events`]). Per ÉTAPE 0 every phase is an OPAQUE
+//! block (no progress callback survives `cached_c1_eroded` / `c1_drainage`),
+//! so the UI shows an INDETERMINATE waiter per phase — not an N/total bar.
+//! The cache regime (HIT vs MISS) is detected by probing the sidecar file
+//! BEFORE the call (exact, not time-inferred): a HIT reloads in ~ms, a MISS
+//! computes (erosion at 2048² is the slow one). Re-running the same continent
+//! → every cached phase HITs → near-instant.
+//!
+//! `ymir-core` is CALLED, never re-implemented (the legacy-viz mistake the
+//! v2 removal undid).
+
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crossbeam_channel::Sender;
+
+use ymir_core::cache::default_cache_dir;
+use ymir_core::climate::biomes::Biome;
+use ymir_core::climate::precipitation::PrecipParams;
+use ymir_core::climate::{c1_biomes, c1_climate};
+use ymir_core::grid::GridF32;
+use ymir_core::tectonics::isostasy::IsostasyConfig;
+use ymir_core::tectonics_c1::cached_product::{
+    cached_c1_drainage, cached_c1_eroded, drainage_key, eroded_key, tectonic_key,
+};
+use ymir_core::tectonics_c1::closures::oceanic_bathymetry::params::SteinSteinParams;
+use ymir_core::tectonics_c1::drainage::{C1DrainageConfig, C1DrainageResult};
+use ymir_core::tectonics_c1::time_loop::C1TimeLoopConfig;
+use ymir_core::terrain::upscale::FbmUpscaleConfig;
+
+use super::events::C1Event;
+use super::spec::C1RunSpec;
+
+/// HD-specific run parameters (the coarse tectonic params live in
+/// [`C1RunSpec`]). `target_size` is the HD grid edge (2048 = production);
+/// `latitude_deg` drives the climate band (45° = the production anchor the
+/// drainage/climate tiles use).
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HdParams {
+    pub target_size: usize,
+    pub latitude_deg: f32,
+}
+
+impl Default for HdParams {
+    fn default() -> Self {
+        Self { target_size: 2048, latitude_deg: 45.0 }
+    }
+}
+
+/// The HD pipeline phases, in execution order.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HdPhase {
+    /// Tectonics → upscale → erosion → bathymetry (cached as "eroded").
+    Eroded,
+    /// Temperature + precipitation.
+    Climate,
+    /// Rivers + lakes + water balance (cached as "drainage").
+    Drainage,
+    /// Whittaker biome classification.
+    Biomes,
+}
+
+impl HdPhase {
+    pub fn label(self) -> &'static str {
+        match self {
+            HdPhase::Eroded => "relief + bathymétrie",
+            HdPhase::Climate => "climat",
+            HdPhase::Drainage => "drainage",
+            HdPhase::Biomes => "biomes",
+        }
+    }
+}
+
+/// Outcome of a phase w.r.t. the content-addressed cache.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CacheRegime {
+    /// Reloaded from `.ymir_cache/` (the sidecar existed) — near-instant.
+    Hit,
+    /// Computed and written (no sidecar) — the slow path.
+    Miss,
+    /// Not a cached phase (climate / biomes are cheap, always computed).
+    Computed,
+}
+
+impl CacheRegime {
+    pub fn label(self) -> &'static str {
+        match self {
+            CacheRegime::Hit => "depuis le cache",
+            CacheRegime::Miss => "calculé",
+            CacheRegime::Computed => "calculé",
+        }
+    }
+}
+
+/// The full HD product — every layer the UI inspects. Carried to the UI
+/// inside an [`Arc`] (so [`C1Event`] stays `Clone`/`Debug` without
+/// requiring `C1DrainageResult: Clone`, which it is not).
+pub struct HdResult {
+    pub width: usize,
+    pub height: usize,
+    /// Final relief + bathymetry (post-erosion, normalised altitude).
+    pub eroded: GridF32,
+    /// Temperature grid (°C).
+    pub temperature: GridF32,
+    /// Precipitation grid (internal units → `precip_mm_per_year`).
+    pub precipitation: GridF32,
+    /// Rivers + lakes + per-segment navigability + water balance.
+    pub drainage: C1DrainageResult,
+    /// Per-cell Whittaker biome (row-major `width × height`).
+    pub biomes: Vec<Biome>,
+}
+
+impl fmt::Debug for HdResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Manual Debug: the heavy fields (and `C1DrainageResult`) are not
+        // `Debug`. Print a compact summary so `C1Event` can derive `Debug`.
+        f.debug_struct("HdResult")
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field("rivers", &self.drainage.rivers.segments.len())
+            .field("lakes", &self.drainage.lakes.len())
+            .finish()
+    }
+}
+
+/// A finished phase record (for the UI's per-phase HIT/MISS log).
+#[derive(Clone, Copy, Debug)]
+pub struct HdPhaseRecord {
+    pub phase: HdPhase,
+    pub regime: CacheRegime,
+    pub elapsed: Duration,
+}
+
+/// UI-side state of the HD pipeline, updated by `poll_c1_events` from the
+/// HD event stream. Independent of the coarse tectonic `C1RunState` so the
+/// live gallery view and the HD generation coexist.
+#[derive(Clone, Default)]
+pub enum HdState {
+    #[default]
+    Idle,
+    Running {
+        params: HdParams,
+        /// Phase currently in flight (an indeterminate waiter), if any.
+        current: Option<HdPhase>,
+        /// Phases finished so far, with their HIT/MISS regime + timing.
+        done: Vec<HdPhaseRecord>,
+    },
+    Completed {
+        result: Arc<HdResult>,
+        total: Duration,
+        done: Vec<HdPhaseRecord>,
+    },
+    Failed {
+        error: String,
+    },
+}
+
+/// Build the production tectonic time-loop config for `spec` (matches the
+/// gallery worker + the production/test pipelines so cache keys align).
+fn hd_run_config(spec: &C1RunSpec) -> C1TimeLoopConfig {
+    C1TimeLoopConfig {
+        rigid_continental_crust: true,
+        n_steps: spec.n_steps,
+        dx: 1.0 / spec.grid_size as f64,
+        dy: 1.0 / spec.grid_size as f64,
+        iso_config: IsostasyConfig::c1_default(),
+        drainage_max_distance: spec.drainage_max_distance,
+    }
+}
+
+/// Drive the HD chain on the worker thread, emitting per-phase events.
+/// Cancellable BETWEEN phases (the cached/opaque calls have no interior
+/// cancel hook — adding one would reopen `ymir-core`). On any core error,
+/// emits `HdFailed` and returns.
+pub fn run_hd(spec: &C1RunSpec, params: &HdParams, tx: &Sender<C1Event>, cancel: &Arc<AtomicBool>) {
+    cancel.store(false, Ordering::Relaxed);
+    let _ = tx.send(C1Event::HdStarted { spec: spec.clone(), params: *params });
+    let t_all = Instant::now();
+
+    let run = hd_run_config(spec);
+    let ss = SteinSteinParams::default();
+    let upscale = FbmUpscaleConfig::c1_hd_production(params.target_size);
+    let pp = PrecipParams::default();
+    let dcfg = C1DrainageConfig::default();
+    let cache_dir = default_cache_dir();
+    let lat = params.latitude_deg;
+
+    // Cache keys (for HIT/MISS detection via sidecar existence).
+    let tkey = tectonic_key(spec.seed, spec.grid_size, &spec.init_params, &run, &spec.closures);
+    let ekey = eroded_key(&tkey, &ss, &upscale);
+    let sidecar_exists = |step: &str, digest: String| -> bool {
+        cache_dir.join(format!("{step}_{digest}.json")).exists()
+    };
+
+    macro_rules! bail_if_cancelled {
+        () => {
+            if cancel.load(Ordering::Relaxed) {
+                let _ = tx.send(C1Event::HdFailed { error: "annulé".to_string() });
+                return;
+            }
+        };
+    }
+
+    // ── Phase 1: eroded (tectonics → upscale → erosion → bathymetry). ──
+    bail_if_cancelled!();
+    let eroded_hit = sidecar_exists("eroded", ekey.digest());
+    let _ = tx.send(C1Event::HdPhaseStarted { phase: HdPhase::Eroded });
+    let t = Instant::now();
+    let eroded = match cached_c1_eroded(
+        &cache_dir,
+        spec.seed,
+        spec.grid_size,
+        &spec.init_params,
+        &run,
+        &spec.closures,
+        &ss,
+        &upscale,
+    ) {
+        Ok(g) => g,
+        Err(e) => {
+            let _ = tx.send(C1Event::HdFailed { error: format!("eroded: {e}") });
+            return;
+        }
+    };
+    let _ = tx.send(C1Event::HdPhaseDone {
+        phase: HdPhase::Eroded,
+        regime: if eroded_hit { CacheRegime::Hit } else { CacheRegime::Miss },
+        elapsed: t.elapsed(),
+    });
+
+    // ── Phase 2: climate (temperature + precipitation). ──
+    bail_if_cancelled!();
+    let _ = tx.send(C1Event::HdPhaseStarted { phase: HdPhase::Climate });
+    let t = Instant::now();
+    let climate = c1_climate(&eroded, &ss, lat, &pp);
+    let _ = tx.send(C1Event::HdPhaseDone {
+        phase: HdPhase::Climate,
+        regime: CacheRegime::Computed,
+        elapsed: t.elapsed(),
+    });
+
+    // ── Phase 3: drainage (rivers + lakes + water balance). ──
+    bail_if_cancelled!();
+    let dkey = drainage_key(&ekey, &dcfg, &ss, Some((lat, &pp)));
+    let drainage_hit = sidecar_exists("drainage", dkey.digest());
+    let _ = tx.send(C1Event::HdPhaseStarted { phase: HdPhase::Drainage });
+    let t = Instant::now();
+    let drainage = match cached_c1_drainage(&cache_dir, &ekey, &eroded, Some((lat, &pp)), &dcfg, &ss)
+    {
+        Ok(d) => d,
+        Err(e) => {
+            let _ = tx.send(C1Event::HdFailed { error: format!("drainage: {e}") });
+            return;
+        }
+    };
+    let _ = tx.send(C1Event::HdPhaseDone {
+        phase: HdPhase::Drainage,
+        regime: if drainage_hit { CacheRegime::Hit } else { CacheRegime::Miss },
+        elapsed: t.elapsed(),
+    });
+
+    // ── Phase 4: biomes (Whittaker classification). ──
+    bail_if_cancelled!();
+    let _ = tx.send(C1Event::HdPhaseStarted { phase: HdPhase::Biomes });
+    let t = Instant::now();
+    let biomes = c1_biomes(&eroded, &climate);
+    let _ = tx.send(C1Event::HdPhaseDone {
+        phase: HdPhase::Biomes,
+        regime: CacheRegime::Computed,
+        elapsed: t.elapsed(),
+    });
+
+    // ── Done — ship the full product. ──
+    let result = Arc::new(HdResult {
+        width: eroded.width,
+        height: eroded.height,
+        eroded,
+        temperature: climate.temperature,
+        precipitation: climate.precipitation,
+        drainage,
+        biomes,
+    });
+    let _ = tx.send(C1Event::HdCompleted { result, elapsed: t_all.elapsed() });
+}

--- a/crates/ymir-viz/src/bridge/c1/mod.rs
+++ b/crates/ymir-viz/src/bridge/c1/mod.rs
@@ -12,11 +12,13 @@
 
 pub mod commands;
 pub mod events;
+pub mod hd;
 pub mod plugin;
 pub mod snapshot;
 pub mod spec;
 pub mod thread;
 
 pub use events::C1RunKind;
+pub use hd::{CacheRegime, HdParams, HdPhase, HdResult, HdState};
 pub use plugin::{C1BridgePlugin, C1CumulativeStats, C1RunState, C1SolverBridge};
 pub use spec::C1RunSpec;

--- a/crates/ymir-viz/src/bridge/c1/plugin.rs
+++ b/crates/ymir-viz/src/bridge/c1/plugin.rs
@@ -28,6 +28,7 @@ use ymir_core::tectonics_v2::workflow::PhaseAParams;
 
 use super::commands::C1Command;
 use super::events::{C1Event, C1RunKind};
+use super::hd::{HdParams, HdPhaseRecord, HdState};
 use super::snapshot::C1Snapshot;
 use super::spec::C1RunSpec;
 use super::thread::spawn_c1_thread;
@@ -113,6 +114,9 @@ pub struct C1SolverBridge {
     pub events_rx: Receiver<C1Event>,
     pub cancel_flag: Arc<AtomicBool>,
     pub state: C1RunState,
+    /// HD pipeline state (step b/5) — independent of the coarse tectonic
+    /// `state` so the live gallery view and HD generation coexist.
+    pub hd: HdState,
 }
 
 impl C1SolverBridge {
@@ -134,6 +138,14 @@ impl C1SolverBridge {
     ) -> Result<(), &'static str> {
         self.commands_tx
             .send(C1Command::RunWorkflow { spec, phase_a })
+            .map_err(|_| "c1 bridge channel send failed")
+    }
+
+    /// Queue an HD production run (step b/5): the full cached chain
+    /// (eroded → climate → drainage → biomes) on the worker thread.
+    pub fn submit_hd(&self, spec: C1RunSpec, params: HdParams) -> Result<(), &'static str> {
+        self.commands_tx
+            .send(C1Command::RunHd { spec, params })
             .map_err(|_| "c1 bridge channel send failed")
     }
 
@@ -164,6 +176,7 @@ impl Plugin for C1BridgePlugin {
             events_rx: evt_rx,
             cancel_flag: cancel,
             state: C1RunState::Idle,
+            hd: HdState::Idle,
         });
 
         app.add_systems(Update, poll_c1_events);
@@ -251,6 +264,32 @@ fn poll_c1_events(mut bridge: ResMut<C1SolverBridge>) {
             }
             C1Event::Failed { error } => {
                 bridge.state = C1RunState::Failed { error };
+            }
+
+            // ── HD pipeline (step b/5) — drives `bridge.hd`. ──
+            C1Event::HdStarted { params, .. } => {
+                bridge.hd = HdState::Running { params, current: None, done: Vec::new() };
+            }
+            C1Event::HdPhaseStarted { phase } => {
+                if let HdState::Running { current, .. } = &mut bridge.hd {
+                    *current = Some(phase);
+                }
+            }
+            C1Event::HdPhaseDone { phase, regime, elapsed } => {
+                if let HdState::Running { current, done, .. } = &mut bridge.hd {
+                    *current = None;
+                    done.push(HdPhaseRecord { phase, regime, elapsed });
+                }
+            }
+            C1Event::HdCompleted { result, elapsed } => {
+                let done = match std::mem::take(&mut bridge.hd) {
+                    HdState::Running { done, .. } => done,
+                    _ => Vec::new(),
+                };
+                bridge.hd = HdState::Completed { result, total: elapsed, done };
+            }
+            C1Event::HdFailed { error } => {
+                bridge.hd = HdState::Failed { error };
             }
         }
     }

--- a/crates/ymir-viz/src/bridge/c1/thread.rs
+++ b/crates/ymir-viz/src/bridge/c1/thread.rs
@@ -192,6 +192,86 @@ mod tests {
         handle.join().expect("c1 worker join");
     }
 
+    /// Step b/5 — the worker drives the full HD chain and SHIPS the
+    /// product. Tiny grid + small HD target so erosion is fast even in a
+    /// debug test build. Validates the event sequence (Started → 4×(phase
+    /// start+done) → Completed) and that the result carries every layer at
+    /// the HD resolution. Cache regime is NOT asserted (HIT/MISS depends on
+    /// whether a prior test populated `.ymir_cache/`).
+    #[test]
+    fn c1_worker_runs_hd_chain_and_ships_product() {
+        use super::super::hd::{HdParams, HdPhase};
+
+        let (cmd_tx, cmd_rx) = bounded(4);
+        let (evt_tx, evt_rx) = bounded(2);
+        let cancel = Arc::new(AtomicBool::new(false));
+        let handle = spawn_c1_thread(cmd_rx, evt_tx, cancel);
+
+        let target = 64usize;
+        cmd_tx
+            .send(C1Command::RunHd {
+                spec: small_spec(10, 42),
+                params: HdParams { target_size: target, latitude_deg: 45.0 },
+            })
+            .expect("send RunHd");
+
+        // Drain until HdCompleted / HdFailed (drain_run stops on the
+        // tectonic Completed, which the HD path never emits).
+        let mut events = Vec::new();
+        loop {
+            match evt_rx.recv_timeout(Duration::from_secs(120)) {
+                Ok(e) => {
+                    let terminal =
+                        matches!(e, C1Event::HdCompleted { .. } | C1Event::HdFailed { .. });
+                    events.push(e);
+                    if terminal {
+                        break;
+                    }
+                }
+                Err(_) => panic!("HD worker timed out"),
+            }
+        }
+
+        let started = events.iter().filter(|e| matches!(e, C1Event::HdStarted { .. })).count();
+        let phase_started =
+            events.iter().filter(|e| matches!(e, C1Event::HdPhaseStarted { .. })).count();
+        let phase_done =
+            events.iter().filter(|e| matches!(e, C1Event::HdPhaseDone { .. })).count();
+        assert_eq!(started, 1, "one HdStarted");
+        assert_eq!(phase_started, 4, "4 HdPhaseStarted (eroded/climate/drainage/biomes)");
+        assert_eq!(phase_done, 4, "4 HdPhaseDone");
+
+        // Phases arrive in execution order.
+        let order: Vec<HdPhase> = events
+            .iter()
+            .filter_map(|e| match e {
+                C1Event::HdPhaseStarted { phase } => Some(*phase),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            order,
+            vec![HdPhase::Eroded, HdPhase::Climate, HdPhase::Drainage, HdPhase::Biomes],
+        );
+
+        // Final product carries every layer at the HD resolution.
+        match events.last() {
+            Some(C1Event::HdCompleted { result, .. }) => {
+                assert_eq!(result.width, target);
+                assert_eq!(result.height, target);
+                assert_eq!(result.eroded.width, target);
+                assert_eq!(result.temperature.data.len(), target * target);
+                assert_eq!(result.precipitation.data.len(), target * target);
+                assert_eq!(result.biomes.len(), target * target);
+                assert_eq!(result.drainage.width, target);
+            }
+            other => panic!("last event must be HdCompleted, got {other:?}"),
+        }
+
+        drop(cmd_tx);
+        handle.join().expect("c1 worker join");
+    }
+
     #[test]
     fn c1_worker_event_ordering_no_loss_under_backpressure() {
         // Q-E5.1 Option C: bounded(2) events + immediate drain.
@@ -1442,6 +1522,13 @@ pub fn spawn_c1_thread(
                     C1Command::RunWorkflow { spec, phase_a } => {
                         retained =
                             Some(run_workflow(&spec, &phase_a, &events_tx));
+                    }
+                    C1Command::RunHd { spec, params } => {
+                        // HD production chain (step b/5) — cached ymir-core
+                        // functions on the worker, per-phase events. Does not
+                        // touch `retained` (re-derives deterministically /
+                        // from cache).
+                        super::hd::run_hd(&spec, &params, &events_tx, &cancel);
                     }
                     C1Command::Cancel => {
                         // MVP Option C — set the flag; takes

--- a/crates/ymir-viz/src/visualization/c1_plugin.rs
+++ b/crates/ymir-viz/src/visualization/c1_plugin.rs
@@ -33,7 +33,9 @@ use bevy_egui::{egui, EguiContexts, EguiPrimaryContextPass};
 use ymir_core::grid::GridF32;
 use ymir_core::tectonics_v2::workflow::PhaseAParams;
 
-use crate::bridge::c1::{C1CumulativeStats, C1RunKind, C1RunSpec, C1RunState, C1SolverBridge};
+use crate::bridge::c1::{
+    C1CumulativeStats, C1RunKind, C1RunSpec, C1RunState, C1SolverBridge, HdParams, HdState,
+};
 use crate::camera::CursorWorldPos;
 use crate::visualization::c1_viz::{derive_altitude_field, field_to_rgba, C1Field};
 use crate::visualization::overlay::{draw_velocity_vectors, draw_voronoi_boundaries};
@@ -628,6 +630,68 @@ fn c1_control_panel(
                     bridge.request_cancel();
                 }
             });
+
+            // HD production (step b/5). Coarse validation surface: a button
+            // that drives the full cached chain on the worker + a per-phase
+            // status with the HIT/MISS regime. (The polished layer rendering
+            // is the UI rewrite step d.)
+            ui.separator();
+            let hd_running = matches!(bridge.hd, HdState::Running { .. });
+            ui.horizontal(|ui| {
+                if ui
+                    .add_enabled(!hd_running, egui::Button::new("⛰ Generate HD"))
+                    .on_hover_text(
+                        "Run the full HD chain (eroded → climate → drainage → biomes) \
+                         on the worker. First build is slow (erosion at 2048²); cached after.",
+                    )
+                    .clicked()
+                {
+                    let _ = bridge.submit_hd(viz.pending_spec.clone(), HdParams::default());
+                }
+                if hd_running {
+                    ui.spinner();
+                }
+            });
+            match &bridge.hd {
+                HdState::Idle => {}
+                HdState::Running { current, done, .. } => {
+                    for r in done {
+                        ui.weak(format!(
+                            "✓ {} — {} ({:.1}s)",
+                            r.phase.label(),
+                            r.regime.label(),
+                            r.elapsed.as_secs_f32()
+                        ));
+                    }
+                    if let Some(p) = current {
+                        ui.label(format!("⏳ {} …", p.label()));
+                    }
+                }
+                HdState::Completed { result, total, done } => {
+                    for r in done {
+                        ui.weak(format!(
+                            "✓ {} — {} ({:.1}s)",
+                            r.phase.label(),
+                            r.regime.label(),
+                            r.elapsed.as_secs_f32()
+                        ));
+                    }
+                    ui.colored_label(
+                        egui::Color32::from_rgb(0x6E, 0xBE, 0x6E),
+                        format!(
+                            "✓ HD prêt : {}×{} · {} rivières · {} lacs · biomes ✓ ({:.1}s)",
+                            result.width,
+                            result.height,
+                            result.drainage.rivers.segments.len(),
+                            result.drainage.lakes.len(),
+                            total.as_secs_f32(),
+                        ),
+                    );
+                }
+                HdState::Failed { error } => {
+                    ui.colored_label(egui::Color32::from_rgb(0xE1, 0x78, 0x46), format!("HD : {error}"));
+                }
+            }
 
             // Field switcher.
             ui.separator();


### PR DESCRIPTION
# Extend the C1 worker to the full HD pipeline — cache + progress (UI rewrite — step b/5)

**Branch**: `viz-hd-worker` → `viz-remove-v2-legacy` (stacked on step a/5; retarget to
`milestone/c1-lightweight-dynamic-tectonics` once a/5 merges).

The **foundation** of the ymir-viz UI rewrite. The C1 worker only ran the coarse 64²
tectonics (S̃/age/plate/craton). This wires it to the **whole ymir-core production
chain** — CALLED, not re-implemented (the legacy mistake step a/5 removed) — on the
background thread, with per-phase progress and caching. This is engine plumbing; it is
validated by the EMITTED EVENTS + the EXPOSED RESULT, not by UI polish (that's step d).

## ÉTAPE 0 — progress profile of each HD phase (measured first)

Every HD phase is an **OPAQUE block**: `run_erosion`'s batch callback is the only
determinate hook, but it's buried inside `upscale_from_c1` / `cached_c1_eroded`, out of
reach without reopening core. So progress is **INDETERMINATE per phase** (a waiter), not
an N/total bar. The cache **HIT/MISS is not observable** from the return value → detected
by probing the **sidecar file before the call** (exact, not time-inferred).

## The extension (`bridge/c1/hd.rs`)

- `run_hd` chains, on the worker: **eroded** (tectonics → upscale → erosion →
  bathymetry, CACHED via `cached_c1_eroded`) → **climate** (`c1_climate`) → **drainage**
  (CACHED via `cached_c1_drainage`) → **biomes** (`c1_biomes`). Bathymetry is INSIDE
  upscale → the eroded layer = relief + bathymetry (one phase).
- per-phase events: `HdStarted → (HdPhaseStarted → HdPhaseDone { regime, elapsed }) ×4 →
  HdCompleted { result }` (or `HdFailed`). `regime` = `Hit` (sidecar present) / `Miss` /
  `Computed` (uncached cheap phase).
- **cancellable between phases** (the cached/opaque calls have no interior cancel hook;
  adding one would reopen core).
- the HD product travels as `Arc<HdResult>` (eroded + temperature + precipitation +
  drainage + biomes) → `C1Event` stays `Clone`/`Debug` without requiring
  `C1DrainageResult: Clone` (it isn't); `HdResult` has a manual compact `Debug`.
- `RunHd` command; plugin gains `hd: HdState` (`Idle`/`Running{current,done}`/`Completed`/
  `Failed`) driven by `poll_c1_events`, **independent of the coarse `C1RunState`** (live
  gallery + HD coexist); `submit_hd`.

## Coarse validation surface (boundary with step d — NOT the real UI)

A **"⛰ Generate HD"** button in the C1 control panel + a per-phase status (HIT/MISS
regime + timing) + a final summary (`W×H · N rivers · M lakes · biomes`). Enough to
confirm the worker produces and ships the HD; the per-layer rendering + pipeline frieze
are step d.

## Cache

Shared `.ymir_cache/`: re-running the same continent → every cached phase HITs →
near-instant. (First build is slow — erosion at 2048² — then cached.)

## Validation

- `cargo build -p ymir-viz` green.
- Unit test `c1_worker_runs_hd_chain_and_ships_product` (grid 32, HD target 64): asserts
  the ordered event sequence (eroded → climate → drainage → biomes) and that the result
  carries every layer at the HD resolution.
- Full viz suite green (29 tests). **ymir-core untouched.**

## Next (the remaining steps)

- **(c)** per-cell inspection accessors (2 getters + a cell→segment map).
- **(d)** the egui UI (3 docked zones + pipeline frieze + Standard/Expert density +
  inspection) — renders the HD layers this step produces.
- **(e)** surface the HD per-phase progress in the frieze.
